### PR TITLE
SYSENG-1305: Deprecate use of aws_subnet_ids resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 This module is used as a metadata _service_ that given VPC marker (name) exposes attributes of that VPC as output resources which can be consumed by other Terraform resources, without having to duplicate the `data_source` logic.
 
+Requirements
+------------
+
+Minimum v3.55 of the AWS Provider
+
 Input variables
 ---------------
 

--- a/datasources.tf
+++ b/datasources.tf
@@ -4,38 +4,34 @@ data "aws_vpc" "this" {
   }
 }
 
-data "aws_subnet_ids" "public" {
-  vpc_id = data.aws_vpc.this.id
+data "aws_route_table" "public" {
+  count     = length(local.public_subnet_ids)
+  subnet_id = element(sort(tolist(local.public_subnet_ids)), count.index)
+}
+
+data "aws_route_table" "private" {
+  count     = length(local.private_subnet_ids)
+  subnet_id = element(sort(tolist(local.private_subnet_ids)), count.index)
+}
+
+data "aws_subnets" "public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
 
   tags = {
     type = "public"
   }
 }
 
-data "aws_subnet_ids" "private" {
-  vpc_id = data.aws_vpc.this.id
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
 
   tags = {
     type = "private"
   }
-}
-
-data "aws_route_table" "public" {
-  count     = length(data.aws_subnet_ids.public.ids)
-  subnet_id = element(sort(tolist(data.aws_subnet_ids.public.ids)), count.index)
-}
-
-data "aws_route_table" "private" {
-  count     = length(data.aws_subnet_ids.private.ids)
-  subnet_id = element(sort(tolist(data.aws_subnet_ids.private.ids)), count.index)
-}
-
-data "aws_subnet" "public" {
-  count = length(data.aws_subnet_ids.public.ids)
-  id    = element(sort(tolist(data.aws_subnet_ids.public.ids)), count.index)
-}
-
-data "aws_subnet" "private" {
-  count = length(data.aws_subnet_ids.private.ids)
-  id    = element(sort(tolist(data.aws_subnet_ids.private.ids)), count.index)
 }

--- a/datasources.tf
+++ b/datasources.tf
@@ -6,12 +6,12 @@ data "aws_vpc" "this" {
 
 data "aws_route_table" "public" {
   count     = length(local.public_subnet_ids)
-  subnet_id = element(sort(tolist(local.public_subnet_ids)), count.index)
+  subnet_id = element(local.public_subnet_ids, count.index)
 }
 
 data "aws_route_table" "private" {
   count     = length(local.private_subnet_ids)
-  subnet_id = element(sort(tolist(local.private_subnet_ids)), count.index)
+  subnet_id = element(local.private_subnet_ids, count.index)
 }
 
 data "aws_subnets" "public" {

--- a/local.tf
+++ b/local.tf
@@ -1,6 +1,6 @@
 locals {
 
-  private_subnet_ids = toset(data.aws_subnets.private.ids)
-  public_subnet_ids  = toset(data.aws_subnets.public.ids)
+  private_subnet_ids = sort(data.aws_subnets.private.ids)
+  public_subnet_ids  = sort(data.aws_subnets.public.ids)
 
 }

--- a/local.tf
+++ b/local.tf
@@ -1,0 +1,6 @@
+locals {
+
+  private_subnet_ids = toset(data.aws_subnets.private.ids)
+  public_subnet_ids  = toset(data.aws_subnets.public.ids)
+
+}

--- a/output.tf
+++ b/output.tf
@@ -7,11 +7,11 @@ output "vpc_cidr" {
 }
 
 output "vpc_public_subnets_ids" {
-  value = sort(data.aws_subnet_ids.public.ids)
+  value = local.public_subnet_ids
 }
 
 output "vpc_private_subnets_ids" {
-  value = sort(data.aws_subnet_ids.private.ids)
+  value = local.private_subnet_ids
 }
 
 output "vpc_public_route_table_ids" {
@@ -26,12 +26,12 @@ output "vpc_private_route_table_ids" {
 
 output "vpc_public_subnets" {
   description = "List of public subnets"
-  value       = sort(distinct(data.aws_subnet.public.*.id))
+  value       = local.public_subnet_ids
 }
 
 output "vpc_private_subnets" {
   description = "List of private subnets"
-  value       = sort(distinct(data.aws_subnet.private.*.id))
+  value       = local.private_subnet_ids
 }
 
 output "vpn_cidr" {


### PR DESCRIPTION
New versions of the AWS provider (>4 I think) are throwing deprecation warnings about the `aws_subnet_ids` data source.

This kind of thing:
```
│ Warning: Deprecated Resource
│ 
│   with module.aws_metadata.data.aws_subnet_ids.public,
│   on .terraform/modules/aws_metadata/datasources.tf line 7, in data "aws_subnet_ids" "public":
│    7: data "aws_subnet_ids" "public" {
│ 
│ The aws_subnet_ids data source has been deprecated and will be removed in a future version. Use the aws_subnets data source instead.
```

Primarily this PR is to drop the use of the `aws_subnet_ids` resource in favour of `aws_subnets`. This does require a minimum of provider 3.55.0 however. I've only found one repo where we lower than this and I've opened a PR to fix that.

Secondarily, while putting this together I realised that the outputs `vpc_[public|private]_subnets_ids` and `vpc_[public|private]_subnets` whilst having different logic, produce identical outputs. This is a little weird but is clearly not causing any problems, so I've modified both of these to use the new data source and the same logic.



