### PR TITLE
Add shared Claude code review workflow (SYSENG-3024)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,11 @@
+name: Claude Code Review
+on:
+  pull_request:
+    types: [opened, ready_for_review, labeled]
+jobs:
+  review:
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'claude-review')
+    uses: Zegocover/shared-gha-workflows/.github/workflows/claude-code-review.yml@v1
+    secrets: inherit


### PR DESCRIPTION
## Background

Wires this repository up to the shared
`Zegocover/shared-gha-workflows/.github/workflows/claude-code-review.yml@v1`
reusable workflow so pull requests receive an automated Claude review.

Part of the SysEng-wide rollout tracked in SYSENG-3024.

## Changes

* Add `.github/workflows/claude-code-review.yml` calling the shared workflow.


## Jira Ticket/s

* https://zegons.atlassian.net/browse/SYSENG-3024
