### PR TITLE
SYSENG-3093: roll out Zego AI Standards v1.1.0 + terraform-safety hook

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -1,0 +1,17 @@
+# Commands
+
+Simple, single-concern prompts. Plain markdown, no YAML frontmatter.
+
+Commands are fanned out to every consumer repo and installed into `.claude/commands/`. They are invoked with `/command-name` in Claude Code.
+
+## When to use a command vs a skill
+
+If the entire workflow fits in one paragraph and doesn't branch, orchestrate, or require model/tool control — it's a command. If it needs YAML frontmatter, runs sub-agents, or accepts structured arguments — it's a skill. See `docs/framework/02-mechanism-hierarchy.md`.
+
+## Contributing
+
+Add a new `.md` file to this directory. No frontmatter. The filename becomes the command name (e.g. `add-migration.md` → `/add-migration`).
+
+## Commands in this library
+
+No commands have been authored yet.

--- a/.claude/hooks/database-safety.sh
+++ b/.claude/hooks/database-safety.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# PreToolUse hook — database safety
+# Blocks dangerous database patterns before Bash tool execution.
+# stdin: {"tool_name":"Bash","tool_input":{"command":"<cmd>"}}
+# Exit 2 + stderr  → command blocked
+# Exit 0           → command allowed (also on parse failure — fail open)
+
+set -euo pipefail
+
+# Read all stdin upfront; subshell $(cat) would compete with python3 for stdin
+INPUT=$(cat)
+
+CMD=$(python3 -c "
+import json, sys
+try:
+    payload = json.loads(sys.argv[1])
+    print(payload['tool_input']['command'])
+except Exception:
+    sys.exit(0)
+" "$INPUT") || exit 0
+
+# Exit 0 if CMD is empty (parse failure produced no output)
+[ -z "${CMD:-}" ] && exit 0
+
+block() {
+    printf "BLOCKED: '%s' is forbidden by the Zego AI safety hook.\n" "$CMD" >&2
+    printf "Stop and surface this block to the user. Do not attempt to rephrase or work around it.\n" >&2
+    exit 2
+}
+
+python3 -c "
+import re, sys
+
+cmd = sys.argv[1]
+
+# DROP TABLE / DROP DATABASE / TRUNCATE TABLE (case-insensitive)
+if re.search(r'(?i)drop\s+table', cmd):
+    sys.exit(1)
+if re.search(r'(?i)drop\s+database', cmd):
+    sys.exit(1)
+if re.search(r'(?i)\btruncate\s+(?:table\s+|only\s+)?[A-Za-z_]\w*', cmd):
+    sys.exit(1)
+
+sys.exit(0)
+" "$CMD" 2>/dev/null || block
+
+exit 0

--- a/.claude/hooks/filesystem-safety.sh
+++ b/.claude/hooks/filesystem-safety.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# PreToolUse hook — filesystem safety
+# Blocks dangerous filesystem patterns before Bash tool execution.
+# stdin: {"tool_name":"Bash","tool_input":{"command":"<cmd>"}}
+# Exit 2 + stderr  → command blocked
+# Exit 0           → command allowed (also on parse failure — fail open)
+
+set -euo pipefail
+
+# Read all stdin upfront; subshell $(cat) would compete with python3 for stdin
+INPUT=$(cat)
+
+CMD=$(python3 -c "
+import json, sys
+try:
+    payload = json.loads(sys.argv[1])
+    print(payload['tool_input']['command'])
+except Exception:
+    sys.exit(0)
+" "$INPUT") || exit 0
+
+# Exit 0 if CMD is empty (parse failure produced no output)
+[ -z "${CMD:-}" ] && exit 0
+
+block() {
+    printf "BLOCKED: '%s' is forbidden by the Zego AI safety hook.\n" "$CMD" >&2
+    printf "Stop and surface this block to the user. Do not attempt to rephrase or work around it.\n" >&2
+    exit 2
+}
+
+# Recursive delete: rm with both recursive and force flags (combined or separate)
+python3 -c "
+import re, sys
+
+cmd = sys.argv[1]
+
+if re.search(r'\brm\b', cmd):
+    has_recursive = bool(re.search(r'\s-[a-zA-Z]*[rR][a-zA-Z]*|--recursive', cmd))
+    has_force = bool(re.search(r'\s-[a-zA-Z]*[fF][a-zA-Z]*|--force', cmd))
+    if has_recursive and has_force:
+        sys.exit(1)
+
+sys.exit(0)
+" "$CMD" 2>/dev/null || block
+
+exit 0

--- a/.claude/hooks/git-safety.sh
+++ b/.claude/hooks/git-safety.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# PreToolUse hook — git safety
+# Blocks dangerous git patterns before Bash tool execution.
+# stdin: {"tool_name":"Bash","tool_input":{"command":"<cmd>"}}
+# Exit 2 + stderr  → command blocked
+# Exit 0           → command allowed (also on parse failure — fail open)
+
+set -euo pipefail
+
+# Read all stdin upfront; subshell $(cat) would compete with python3 for stdin
+INPUT=$(cat)
+
+CMD=$(python3 -c "
+import json, sys
+try:
+    payload = json.loads(sys.argv[1])
+    print(payload['tool_input']['command'])
+except Exception:
+    sys.exit(0)
+" "$INPUT") || exit 0
+
+# Exit 0 if CMD is empty (parse failure produced no output)
+[ -z "${CMD:-}" ] && exit 0
+
+block() {
+    printf "BLOCKED: '%s' is forbidden by the Zego AI safety hook.\n" "$CMD" >&2
+    printf "Stop and surface this block to the user. Do not attempt to rephrase or work around it.\n" >&2
+    exit 2
+}
+
+python3 -c "
+import re, sys
+
+cmd = sys.argv[1]
+
+# Force push variants (bare --force and -f are always blocked;
+# --force-with-lease is only blocked on protected branches)
+force_patterns = [
+    r'git\s+push\b.*\s--force(?!-with-lease|-if-includes)\b',
+    r'git\s+push\b.*\s-[a-zA-Z]*f',
+]
+for p in force_patterns:
+    if re.search(p, cmd):
+        sys.exit(1)
+
+# Push to protected branch (any remote) — match branch name after space, + or :
+# Covers: push origin main, push origin +main, push origin HEAD:main, push origin main:main
+protected = r'git\s+push\b.*[\s+:](?:main|master|production|staging|release/\S+?)(?=\s|$|:)'
+if re.search(protected, cmd):
+    sys.exit(1)
+
+# Hard reset
+if re.search(r'git\s+reset\b.*--hard', cmd):
+    sys.exit(1)
+
+# git clean with -f flag
+if re.search(r'git\s+clean\b.*-[a-zA-Z]*f[a-zA-Z]*', cmd):
+    sys.exit(1)
+
+# Discard all changes
+if re.search(r'git\s+checkout\s+--\s+\.', cmd):
+    sys.exit(1)
+if re.search(r'git\s+restore\s+\.', cmd):
+    sys.exit(1)
+
+# Force branch delete
+if re.search(r'git\s+branch\b.*\s-[a-zA-Z]*D', cmd):
+    sys.exit(1)
+
+# Stash discard
+if re.search(r'git\s+stash\s+drop', cmd):
+    sys.exit(1)
+if re.search(r'git\s+stash\s+clear', cmd):
+    sys.exit(1)
+
+# gh pr merge
+if re.search(r'gh\s+pr\s+merge', cmd):
+    sys.exit(1)
+
+sys.exit(0)
+" "$CMD" 2>/dev/null || block
+
+exit 0

--- a/.claude/hooks/terraform-safety.sh
+++ b/.claude/hooks/terraform-safety.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# PreToolUse hook — Terraform / IaC infra-mutation safety
+# Blocks any AI agent attempt to mutate live infrastructure or trigger remote
+# pipelines from inside an infrastructure-as-code repo. The agent workflow is:
+# edit code, run a read-only plan, open a PR — humans merge and CI applies with
+# the privileged role. Direct mutation by the agent is never the workflow.
+# stdin: {"tool_name":"Bash","tool_input":{"command":"<cmd>"}}
+# Exit 2 + stderr  → command blocked
+# Exit 0           → command allowed (also on parse failure — fail open)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+CMD=$(python3 -c "
+import json, sys
+try:
+    payload = json.loads(sys.argv[1])
+    print(payload['tool_input']['command'])
+except Exception:
+    sys.exit(0)
+" "$INPUT") || exit 0
+
+[ -z "${CMD:-}" ] && exit 0
+
+block() {
+    printf "BLOCKED: '%s' is forbidden by the terraform-safety hook.\n" "$CMD" >&2
+    printf "Live infrastructure must not be mutated by an AI agent. Edit code, run a read-only plan, and open a PR; humans merge and CI applies.\n" >&2
+    printf "Stop and surface this block to the user. Do not rephrase or work around it.\n" >&2
+    exit 2
+}
+
+python3 -c "
+import re, sys
+
+cmd = sys.argv[1]
+
+# Terraform / OpenTofu / Terragrunt mutating subcommands. Allow global flags
+# (e.g. '-chdir=DIR') between the binary and the verb — 'terraform -chdir=env
+# apply' is the usual invocation in these repos.
+tf = r'(terraform|terragrunt|tofu)'
+if re.search(rf'\b{tf}\s+(-\S+\s+)*(apply|destroy|import|taint|untaint|force-unlock)\b', cmd):
+    sys.exit(1)
+if re.search(rf'\b{tf}\s+(-\S+\s+)*state\s+(rm|push|replace-provider|mv)\b', cmd):
+    sys.exit(1)
+
+# Makefile shortcuts that wrap the above. Match the target anywhere after
+# 'make' (so 'make WORKSPACE=staging apply' is caught) but stop at a command
+# separator so 'make plan && echo apply' is not.
+if re.search(r'\bmake\b[^|;&\n]*\b(apply|destroy)\b', cmd):
+    sys.exit(1)
+
+# Raw AWS CLI — IaC repos manage AWS via Terraform; raw calls are not the
+# workflow. Also matches an absolute/relative path prefix (e.g. /usr/bin/aws).
+if re.search(r'(^|[\s;|&(/])aws\s+', cmd):
+    sys.exit(1)
+
+# Buildkite agent triggering — only the pipeline itself should call this.
+if re.search(r'\bbuildkite-agent\s+(pipeline|annotate|artifact\s+upload|meta-data\s+set)\b', cmd):
+    sys.exit(1)
+
+# GitHub Actions: starting workflows, or mutating via the API (an explicit
+# method, or field flags — which make 'gh api' a POST).
+if re.search(r'\bgh\s+workflow\s+run\b', cmd):
+    sys.exit(1)
+if re.search(r'\bgh\s+api\b', cmd):
+    if re.search(r'(-X|--method)\s+(POST|PATCH|PUT|DELETE)\b', cmd):
+        sys.exit(1)
+    if re.search(r'(^|\s)(-f|-F|--field|--raw-field|--input)(\s|=)', cmd):
+        sys.exit(1)
+
+sys.exit(0)
+" "$CMD" 2>/dev/null || block
+
+exit 0

--- a/.claude/scripts/README.md
+++ b/.claude/scripts/README.md
@@ -1,0 +1,50 @@
+# Scripts
+
+Narrowly-scoped shell helper scripts that fan out to consumer repos alongside skills. Each script handles one intent, validates its inputs, and avoids broad permissions.
+
+Scripts are installed into `.claude/scripts/` in consumer repos. Skills reference them by relative path (`.claude/scripts/<name>.sh`).
+
+## Scripts in this library
+
+| Script | Usage | Description |
+| --- | --- | --- |
+| `pr-comments.sh` | `.claude/scripts/pr-comments.sh <pr-number>` | Fetches all PR feedback as a JSON array with three entry types: `review_thread` (`{type, thread_id, comment_id, path, line, body}`), `top_level_comment` (`{type, comment_id, body, author}`), and `review_body` (`{type, comment_id, body, author}`). Review threads are unresolved only; review bodies exclude empty/whitespace-only entries. |
+| `pr-issue-reply.sh` | `.claude/scripts/pr-issue-reply.sh <pr-number> <body-file>` | Posts a top-level issue comment to a PR. Body comes from a file to avoid shell-metachar issues. Body-file path must be `/tmp/*`, `/private/tmp/*`, `<repo>/.git/*`, or `<repo>/.claude/scripts/_replies/*`. Exit 3 on PR/branch mismatch. |
+| `pr-reply.sh` | `.claude/scripts/pr-reply.sh <pr-number> <comment-id> <body-file>` | Posts a reply to a PR review comment. Body comes from a file to avoid shell-metachar issues. Body-file path must be `/tmp/*`, `/private/tmp/*`, `<repo>/.git/*`, or `<repo>/.claude/scripts/_replies/*`. Exit 3 on PR/branch mismatch. |
+| `pr-resolve.sh` | `.claude/scripts/pr-resolve.sh <thread-id> <pr-number>` | Marks a PR review thread resolved via GraphQL mutation. Takes the `thread_id` node ID returned by `pr-comments.sh`. Cross-checks the PR number against the current branch's open PR; exits 3 on mismatch. |
+| `req-branch.sh` | `.claude/scripts/req-branch.sh <ticket> <feature-slug>` | Creates or switches to the requirements branch for a ticket. Constructs branch name `{ticket}_{feature-slug}`. If the branch exists locally, switches to it; if on remote, tracks and switches; otherwise creates from origin's default branch. Refuses to switch with uncommitted changes. |
+| `req-pr.sh` | `.claude/scripts/req-pr.sh <ticket> <requirements-file> <body-file> <commit-msg-file>` | Commits the requirements package, pushes the current branch, and opens a PR (or reports the existing PR if one is already open). Requirements file must be under `docs/requirements/`. Exit 2 on validation failure. |
+
+## `_replies/`
+
+Scratch directory for reply body files written by `fix-pr-comments` before calling `pr-reply.sh`. Files here are transient — the skill cleans them up after posting. This path is in `pr-reply.sh`'s allowed list.
+
+## PreToolUse Scripts
+
+Hook scripts registered in `.claude/settings.json` under `hooks.PreToolUse`. Each script receives a JSON object on stdin from the Claude Code harness, parses the `tool_input.command` field using `python3`, and exits 2 with a human-readable message if the command matches a blocked pattern. On parse failure the script exits 0 (fail open).
+
+Block message format:
+```
+BLOCKED: '<matched command>' is forbidden by the Zego AI safety hook.
+Stop and surface this block to the user. Do not attempt to rephrase or work around it.
+```
+
+| Script | Pattern scope |
+| --- | --- |
+| `git-safety.sh` | Unconditional: force push (`--force`, `-f`); push to protected branches (`main`, `master`, `production`, `staging`, `release/*`); `git reset --hard`; `git clean -f*`; `git checkout -- .`; `git restore .`; `git branch -D`; `git stash drop`; `git stash clear`; `gh pr merge`. Protected-branch only: `--force-with-lease`, `--force-if-includes`. |
+| `filesystem-safety.sh` | `rm -rf` and `rm -fr` (flags in any order or combination) |
+| `database-safety.sh` | `DROP TABLE`; `DROP DATABASE`; `TRUNCATE TABLE`; `TRUNCATE <identifier>` (all case-insensitive) |
+
+Manual test:
+```bash
+echo '{"tool_name":"Bash","tool_input":{"command":"<cmd>"}}' | bash .claude/hooks/<name>.sh
+echo $?
+```
+
+## Safety model
+
+Each script:
+- Validates all inputs before use (digits-only for integers, alphanumeric for node IDs)
+- Derives the repo from `gh repo view` rather than accepting it as an argument
+- Uses a hardcoded API path or mutation shape so agents cannot pivot to a different endpoint via argument injection
+- Rejects symlinks on body files (`pr-reply.sh`) to prevent the `pwd -P` basename bypass

--- a/.claude/scripts/pr-comments.sh
+++ b/.claude/scripts/pr-comments.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# pr-comments.sh — fetch all PR feedback: unresolved review threads,
+# top-level PR conversation comments, and PR review body text.
+#
+# Usage:
+#   .claude/scripts/pr-comments.sh <pr-number>
+#
+# Output: JSON array with three entry shapes, each tagged by `type`:
+#
+#   [
+#     {
+#       "type":       "review_thread",
+#       "thread_id":  "PRRT_kwDOSFazsM5-gFO8",
+#       "comment_id": 3162616672,
+#       "path":       "src/onboarding_demo/mcp_tools/quote.py",
+#       "line":       425,
+#       "body":       "**Medium — silent fallback ...\n\n---\n\nActually, do Y instead."
+#     },
+#     {
+#       "type":       "top_level_comment",
+#       "comment_id": 12345678,
+#       "body":       "Can we also add a retry here?",
+#       "author":     "reviewer-login"
+#     },
+#     {
+#       "type":       "review_body",
+#       "comment_id": 87654321,
+#       "body":       "Overall looks good but a few architectural concerns...",
+#       "author":     "reviewer-login"
+#     }
+#   ]
+#
+# `body` for review_thread entries contains every comment in the thread
+# joined by `\n\n---\n\n` (oldest first). If a reviewer amended or
+# retracted their instruction in a follow-up, the fixer agent sees the
+# full conversation rather than only the original message.
+#
+# Filtering:
+#   - review_thread: only unresolved threads (existing behaviour)
+#   - top_level_comment: deleted-account comments excluded (null author)
+#   - review_body: empty or whitespace-only bodies excluded
+#
+# Why this script vs `gh api` directly:
+#   - One allowlist entry covers the whole "show me the PR comments"
+#     intent, instead of a wildcard on `gh api *` (which can POST/PUT/
+#     DELETE).
+#   - Pulls the GraphQL thread IDs and the REST comment IDs together
+#     so the agent doesn't have to correlate them itself.
+#   - Filters out resolved threads — agents shouldn't be re-replying
+#     to threads someone already closed.
+#
+# Safety:
+#   - PR number is validated as digits-only.
+#   - Repo is derived from `gh repo view`, not passed in.
+#   - No `eval`, no unquoted vars.
+
+set -euo pipefail
+
+PR_NUM="${1:?usage: pr-comments.sh <pr-number>}"
+
+# Validation — the only legal character class for a PR number is
+# digits. Anything else is the agent confused or a malicious prompt.
+if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+  echo "pr-comments: invalid pr-number '$PR_NUM' (digits only)" >&2
+  exit 2
+fi
+
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+
+# Pull all three comment collections via a single GraphQL call:
+#   1. reviewThreads — inline code review threads (existing)
+#   2. comments      — top-level PR conversation comments
+#   3. reviews       — PR review submissions (have optional body text)
+#
+# `first: 100` is GitHub's max page size without cursor pagination.
+# We pull `pageInfo.hasNextPage` for every collection and fail loudly
+# if any would be truncated. Pagination is a follow-up.
+#
+# jq filter quirks worth knowing:
+#   - No trailing comma in the object constructor — jq 1.6 (still
+#     the default on Ubuntu 22.04 / common CI images) treats
+#     trailing commas as a syntax error. jq 1.7+ is permissive.
+#   - `error("...")` raises a non-zero exit so the script fails
+#     loudly on the truncation guard.
+gh api graphql \
+  -f query='
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100) {
+            pageInfo { hasNextPage }
+            nodes {
+              id
+              isResolved
+              comments(first: 100) {
+                nodes {
+                  databaseId
+                  path
+                  body
+                  line
+                  originalLine
+                }
+              }
+            }
+          }
+          comments(first: 100) {
+            pageInfo { hasNextPage }
+            nodes {
+              databaseId
+              body
+              author {
+                login
+              }
+            }
+          }
+          reviews(first: 100) {
+            pageInfo { hasNextPage }
+            nodes {
+              databaseId
+              body
+              author {
+                login
+              }
+            }
+          }
+        }
+      }
+    }
+  ' \
+  -F owner="${REPO%/*}" \
+  -F repo="${REPO#*/}" \
+  -F number="$PR_NUM" \
+  --jq '
+    .data.repository.pullRequest as $pr
+
+    # ── Truncation guards ────────────────────────────────────────
+    | if $pr.reviewThreads.pageInfo.hasNextPage
+      then error("pr-comments: PR has more than 100 review threads; pagination not implemented")
+      else true end
+
+    | if $pr.comments.pageInfo.hasNextPage
+      then error("pr-comments: PR has more than 100 top-level comments; pagination not implemented")
+      else true end
+
+    | if $pr.reviews.pageInfo.hasNextPage
+      then error("pr-comments: PR has more than 100 reviews; pagination not implemented")
+      else true end
+
+    # ── Review threads (existing, now tagged with type) ──────────
+    | [
+        $pr.reviewThreads.nodes[]
+        | select(.isResolved | not)
+        | {
+            type:       "review_thread",
+            thread_id:  .id,
+            comment_id: .comments.nodes[0].databaseId,
+            path:       .comments.nodes[0].path,
+            line:       (.comments.nodes[0].line // .comments.nodes[0].originalLine),
+            body:       ([.comments.nodes[].body] | join("\n\n---\n\n"))
+          }
+      ]
+
+    # ── Top-level PR conversation comments ───────────────────────
+    # No bot filtering — the fix-pr-comments skill triages all
+    # comments and can classify irrelevant ones as acknowledged.
+    + [
+        $pr.comments.nodes[]
+        | select(.author != null)
+        | {
+            type:       "top_level_comment",
+            comment_id: .databaseId,
+            body:       .body,
+            author:     (.author.login // "unknown")
+          }
+      ]
+
+    # ── Review bodies ────────────────────────────────────────────
+    # Exclude reviews with empty or whitespace-only bodies.
+    + [
+        $pr.reviews.nodes[]
+        | select(.author != null)
+        | select((.body // "") | gsub("\\s"; "") | length > 0)
+        | {
+            type:       "review_body",
+            comment_id: .databaseId,
+            body:       .body,
+            author:     (.author.login // "unknown")
+          }
+      ]
+  '

--- a/.claude/scripts/pr-issue-reply.sh
+++ b/.claude/scripts/pr-issue-reply.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# pr-issue-reply.sh — post a top-level issue comment to a PR.
+#
+# Usage:
+#   .claude/scripts/pr-issue-reply.sh <pr-number> <body-file>
+#
+# Body comes from a file rather than stdin or a literal arg so the
+# agent can use `Write` to compose the response (preserving newlines,
+# markdown, code fences) and the script doesn't need to escape
+# shell-metachar payloads at all.
+#
+# Why this script vs `gh api`:
+#   - One allowlist entry per intent.
+#   - Body via file → never touches the shell parser.
+#   - Hardcoded API path shape — agent can't pivot to a different
+#     endpoint by injecting into args.
+#
+# Why a separate script from pr-reply.sh:
+#   - pr-reply.sh posts to `pulls/{pr}/comments` with `in_reply_to`
+#     (review comment replies, threaded).
+#   - This script posts to `issues/{pr}/comments` (top-level PR
+#     conversation comments, flat — no threading or `in_reply_to`).
+#   - One-script-one-API-path keeps the allowlist semantics clean.
+#
+# Safety:
+#   - PR number validated as digits-only.
+#   - Body-file existence checked, capped at 64KiB.
+#   - Body-file symlink rejection — refuses symlinks regardless of
+#     target, preventing the `pwd -P` basename bypass where a
+#     symlink at `/tmp/evil -> /etc/passwd` would pass the path-
+#     prefix check and leak the target's contents.
+#   - Body-file path restricted to safe locations (`/tmp/`, repo's
+#     `.git/`, repo's `.claude/scripts/_replies/`) so the agent
+#     can't read e.g. `~/.ssh/id_rsa` and post it as a comment.
+#   - PR number cross-checked against the current branch's open PR;
+#     mismatch exits 3 (a distinct, agent-recoverable code) so the
+#     caller can confirm with the user instead of silently posting
+#     to the wrong PR.
+#   - `set -u` turns missing args into errors.
+#
+# Exit codes:
+#   0  posted successfully
+#   2  validation failed (input is malformed; do not retry)
+#   3  PR-number / branch mismatch (caller should confirm with user)
+#   *  any other failure propagates `gh`'s exit code unchanged
+
+set -euo pipefail
+
+PR_NUM="${1:?usage: pr-issue-reply.sh <pr-number> <body-file>}"
+BODY_FILE="${2:?usage: pr-issue-reply.sh <pr-number> <body-file>}"
+
+if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+  echo "pr-issue-reply: invalid pr-number '$PR_NUM' (digits only)" >&2
+  exit 2
+fi
+
+if [[ ! -f "$BODY_FILE" ]]; then
+  echo "pr-issue-reply: body file '$BODY_FILE' not found" >&2
+  exit 2
+fi
+
+# Reject symlinks outright. `pwd -P` only canonicalises the
+# *directory* part of the path, so a symlink at the basename
+# (e.g. `/tmp/evil -> /etc/passwd`) would otherwise pass the
+# /tmp/* prefix check and then leak the symlink target's contents
+# through `< "$BODY_FILE"`. The reply scratch flow never legitimately
+# needs symlinks, so refusing them is the simplest portable fix.
+if [[ -L "$BODY_FILE" ]]; then
+  echo "pr-issue-reply: body file '$BODY_FILE' is a symlink; refusing to resolve" >&2
+  exit 2
+fi
+
+# Resolve to an absolute path so the prefix check below isn't fooled
+# by `..` traversal.
+BODY_REAL="$(cd "$(dirname "$BODY_FILE")" && pwd -P)/$(basename "$BODY_FILE")"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+if [[ -d "$REPO_ROOT/.claude/scripts/_replies" ]]; then
+  REPLIES_REAL="$(cd "$REPO_ROOT/.claude/scripts/_replies" && pwd -P)"
+else
+  REPLIES_REAL="$REPO_ROOT/.claude/scripts/_replies"
+fi
+
+# Allowed body-file locations:
+#   - /tmp/                        — scratch space the agent can write
+#   - /private/tmp/                — same path on macOS (symlink target)
+#   - <repo>/.git/                 — git's own scratch dir, always
+#                                    inside the repo
+#   - <repo>/.claude/scripts/_replies/     — durable per-repo scratch dir
+#                                    the skill writes into
+# REPLIES_REAL is the symlink-resolved form of .claude/scripts/_replies/
+# and is also accepted so the check works in repos where .claude/scripts
+# is a symlink (e.g. this standards library repo).
+# Anything outside these is refused. Catches the "agent reads
+# ~/.ssh/id_rsa as a body" failure mode without blocking the
+# legitimate workflows. macOS resolves /tmp -> /private/tmp via
+# symlink, so pwd -P returns the /private/tmp form; allow both.
+if [[ "$BODY_REAL" != /tmp/* \
+   && "$BODY_REAL" != /private/tmp/* \
+   && "$BODY_REAL" != "$REPO_ROOT/.git/"* \
+   && "$BODY_REAL" != "$REPO_ROOT/.claude/scripts/_replies/"* \
+   && "$BODY_REAL" != "$REPLIES_REAL/"* ]]; then
+  echo "pr-issue-reply: body file '$BODY_REAL' is outside the allowed set" >&2
+  echo "  allowed: /tmp/*, /private/tmp/*, $REPO_ROOT/.git/*, $REPO_ROOT/.claude/scripts/_replies/*" >&2
+  exit 2
+fi
+
+# Sanity: refuse a body file > 64KiB. GitHub's comment limit
+# is 65535 bytes; if the agent has produced more than that, something
+# is wrong (a leaked transcript, a paste of the whole PR diff, etc.)
+# and we'd rather error than truncate or post nonsense.
+BODY_SIZE="$(wc -c < "$BODY_FILE")"
+if (( BODY_SIZE > 65000 )); then
+  echo "pr-issue-reply: body file '$BODY_FILE' is ${BODY_SIZE} bytes, refusing to post (limit ~65 000 bytes)" >&2
+  exit 2
+fi
+
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+
+# Cross-check that the PR number matches the current branch's open
+# PR. Mismatch is exit 3 — distinct from validation (2) so the
+# caller can decide to confirm with the user rather than abort. We
+# don't refuse outright because the agent might legitimately want
+# to comment on a different PR (e.g. cross-referencing a fix in a
+# stacked PR), but it should be a deliberate, confirmed action.
+#
+# "No open PR for current branch" is also exit 3, not 0: scripted
+# replies don't make sense from a branch without a PR (the typical
+# wrong case is the agent on `main` with a stale PR number it
+# half-remembers). The caller can still proceed if the user
+# explicitly confirms.
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+EXPECTED_PR="$(gh pr list --head "$CURRENT_BRANCH" --state open --json number -q '.[0].number' 2>/dev/null || true)"
+if [[ -z "$EXPECTED_PR" ]]; then
+  echo "pr-issue-reply: current branch '$CURRENT_BRANCH' has no open PR" >&2
+  echo "  refusing to post to PR #$PR_NUM without an explicit branch context;" >&2
+  echo "  switch to the branch whose PR you want to comment on, or confirm with the user" >&2
+  exit 3
+fi
+if [[ "$EXPECTED_PR" != "$PR_NUM" ]]; then
+  echo "pr-issue-reply: pr-number '$PR_NUM' does not match current branch '$CURRENT_BRANCH' (expected PR #$EXPECTED_PR)" >&2
+  echo "  re-run with the correct PR number, or confirm with the user that you intend to comment on a different PR" >&2
+  exit 3
+fi
+
+# Post via stdin (--field body=@-) so the body content never gets
+# parsed by the shell. Issue comments are flat — no in_reply_to.
+gh api \
+  "repos/${REPO}/issues/${PR_NUM}/comments" \
+  -X POST \
+  --field body=@- \
+  < "$BODY_FILE"

--- a/.claude/scripts/pr-reply.sh
+++ b/.claude/scripts/pr-reply.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# pr-reply.sh — post a reply to a PR review comment.
+#
+# Usage:
+#   .claude/scripts/pr-reply.sh <pr-number> <comment-id> <body-file>
+#
+# Body comes from a file rather than stdin or a literal arg so the
+# agent can use `Write` to compose the response (preserving newlines,
+# markdown, code fences) and the script doesn't need to escape
+# shell-metachar payloads at all.
+#
+# Why this script vs `gh api`:
+#   - One allowlist entry per intent.
+#   - Body via file → never touches the shell parser.
+#   - Hardcoded API path shape — agent can't pivot to a different
+#     endpoint by injecting into args.
+#
+# Safety:
+#   - PR number and comment-id validated as digits-only.
+#   - Body-file existence checked, capped at 64KiB.
+#   - Body-file symlink rejection — refuses symlinks regardless of
+#     target, preventing the `pwd -P` basename bypass where a
+#     symlink at `/tmp/evil -> /etc/passwd` would pass the path-
+#     prefix check and leak the target's contents.
+#   - Body-file path restricted to safe locations (`/tmp/`, repo's
+#     `.git/`, repo's `.claude/scripts/_replies/`) so the agent
+#     can't read e.g. `~/.ssh/id_rsa` and post it as a comment.
+#   - PR number cross-checked against the current branch's open PR;
+#     mismatch exits 3 (a distinct, agent-recoverable code) so the
+#     caller can confirm with the user instead of silently posting
+#     to the wrong PR.
+#   - `set -u` turns missing args into errors.
+#
+# Exit codes:
+#   0  posted successfully
+#   2  validation failed (input is malformed; do not retry)
+#   3  PR-number / branch mismatch (caller should confirm with user)
+#   *  any other failure propagates `gh`'s exit code unchanged
+
+set -euo pipefail
+
+PR_NUM="${1:?usage: pr-reply.sh <pr-number> <comment-id> <body-file>}"
+COMMENT_ID="${2:?usage: pr-reply.sh <pr-number> <comment-id> <body-file>}"
+BODY_FILE="${3:?usage: pr-reply.sh <pr-number> <comment-id> <body-file>}"
+
+if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+  echo "pr-reply: invalid pr-number '$PR_NUM' (digits only)" >&2
+  exit 2
+fi
+
+if ! [[ "$COMMENT_ID" =~ ^[0-9]+$ ]]; then
+  echo "pr-reply: invalid comment-id '$COMMENT_ID' (digits only)" >&2
+  exit 2
+fi
+
+if [[ ! -f "$BODY_FILE" ]]; then
+  echo "pr-reply: body file '$BODY_FILE' not found" >&2
+  exit 2
+fi
+
+# Reject symlinks outright. `pwd -P` only canonicalises the
+# *directory* part of the path, so a symlink at the basename
+# (e.g. `/tmp/evil -> /etc/passwd`) would otherwise pass the
+# /tmp/* prefix check and then leak the symlink target's contents
+# through `< "$BODY_FILE"`. The reply scratch flow never legitimately
+# needs symlinks, so refusing them is the simplest portable fix.
+if [[ -L "$BODY_FILE" ]]; then
+  echo "pr-reply: body file '$BODY_FILE' is a symlink; refusing to resolve" >&2
+  exit 2
+fi
+
+# Resolve to an absolute path so the prefix check below isn't fooled
+# by `..` traversal.
+BODY_REAL="$(cd "$(dirname "$BODY_FILE")" && pwd -P)/$(basename "$BODY_FILE")"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+if [[ -d "$REPO_ROOT/.claude/scripts/_replies" ]]; then
+  REPLIES_REAL="$(cd "$REPO_ROOT/.claude/scripts/_replies" && pwd -P)"
+else
+  REPLIES_REAL="$REPO_ROOT/.claude/scripts/_replies"
+fi
+
+# Allowed body-file locations:
+#   - /tmp/                        — scratch space the agent can write
+#   - /private/tmp/                — same path on macOS (symlink target)
+#   - <repo>/.git/                 — git's own scratch dir, always
+#                                    inside the repo
+#   - <repo>/.claude/scripts/_replies/     — durable per-repo scratch dir
+#                                    the skill writes into
+# Anything outside these is refused. Catches the "agent reads
+# ~/.ssh/id_rsa as a body" failure mode without blocking the
+# legitimate workflows. macOS resolves /tmp -> /private/tmp via
+# symlink, so pwd -P returns the /private/tmp form; allow both.
+if [[ "$BODY_REAL" != /tmp/* \
+   && "$BODY_REAL" != /private/tmp/* \
+   && "$BODY_REAL" != "$REPO_ROOT/.git/"* \
+   && "$BODY_REAL" != "$REPO_ROOT/.claude/scripts/_replies/"* \
+   && "$BODY_REAL" != "$REPLIES_REAL/"* ]]; then
+  echo "pr-reply: body file '$BODY_REAL' is outside the allowed set" >&2
+  echo "  allowed: /tmp/*, /private/tmp/*, $REPO_ROOT/.git/*, $REPO_ROOT/.claude/scripts/_replies/*" >&2
+  exit 2
+fi
+
+# Sanity: refuse a body file > 64KiB. GitHub's review-comment limit
+# is 65535 bytes; if the agent has produced more than that, something
+# is wrong (a leaked transcript, a paste of the whole PR diff, etc.)
+# and we'd rather error than truncate or post nonsense.
+BODY_SIZE="$(wc -c < "$BODY_FILE")"
+if (( BODY_SIZE > 65000 )); then
+  echo "pr-reply: body file '$BODY_FILE' is ${BODY_SIZE} bytes, refusing to post (limit ~65 000 bytes)" >&2
+  exit 2
+fi
+
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+
+# Cross-check that the PR number matches the current branch's open
+# PR. Mismatch is exit 3 — distinct from validation (2) so the
+# caller can decide to confirm with the user rather than abort. We
+# don't refuse outright because the agent might legitimately want
+# to comment on a different PR (e.g. cross-referencing a fix in a
+# stacked PR), but it should be a deliberate, confirmed action.
+#
+# "No open PR for current branch" is also exit 3, not 0: scripted
+# replies don't make sense from a branch without a PR (the typical
+# wrong case is the agent on `main` with a stale PR number it
+# half-remembers). The caller can still proceed if the user
+# explicitly confirms.
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+EXPECTED_PR="$(gh pr list --head "$CURRENT_BRANCH" --state open --json number -q '.[0].number' 2>/dev/null || true)"
+if [[ -z "$EXPECTED_PR" ]]; then
+  echo "pr-reply: current branch '$CURRENT_BRANCH' has no open PR" >&2
+  echo "  refusing to post to PR #$PR_NUM without an explicit branch context;" >&2
+  echo "  switch to the branch whose PR you want to comment on, or confirm with the user" >&2
+  exit 3
+fi
+if [[ "$EXPECTED_PR" != "$PR_NUM" ]]; then
+  echo "pr-reply: pr-number '$PR_NUM' does not match current branch '$CURRENT_BRANCH' (expected PR #$EXPECTED_PR)" >&2
+  echo "  re-run with the correct PR number, or confirm with the user that you intend to comment on a different PR" >&2
+  exit 3
+fi
+
+# Post via stdin (--field body=@-) so the body content never gets
+# parsed by the shell. The PR number is in the path; the comment-id
+# is the `in_reply_to` target.
+gh api \
+  "repos/${REPO}/pulls/${PR_NUM}/comments" \
+  -X POST \
+  --field body=@- \
+  -F in_reply_to="$COMMENT_ID" \
+  < "$BODY_FILE"

--- a/.claude/scripts/pr-resolve.sh
+++ b/.claude/scripts/pr-resolve.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# pr-resolve.sh — mark a PR review thread as resolved.
+#
+# Usage:
+#   .claude/scripts/pr-resolve.sh <thread-id> <pr-number>
+#
+# `<thread-id>` is the GraphQL node id (e.g. `PRRT_kwDOSFazsM5-gFO8`),
+# *not* the REST comment id. `pr-comments.sh` returns it as
+# `thread_id` on each entry; pass that value through verbatim.
+#
+# `<pr-number>` is the PR number the thread belongs to. It is
+# cross-checked against the open PR for the current branch — if they
+# don't match, the script exits 3 (same semantics as `pr-reply.sh`)
+# so a confused agent can't silently resolve a thread on the wrong PR.
+#
+# Why this script vs `gh api graphql`:
+#   - One allowlist entry per intent.
+#   - The mutation shape is hardcoded — agent can't substitute a
+#     different mutation (e.g. `unresolveReviewThread`,
+#     `addPullRequestReview`) via arg injection.
+#
+# Safety:
+#   - Thread id validated as `^[A-Za-z0-9_-]+$` (the character class
+#     GitHub's base64-ish node ids actually use).
+#   - PR number validated as digits-only.
+#   - PR number cross-checked against the current branch's open PR
+#     (exit 3 on mismatch, matching `pr-reply.sh` behaviour).
+
+set -euo pipefail
+
+THREAD_ID="${1:?usage: pr-resolve.sh <thread-id> <pr-number>}"
+PR_NUM="${2:?usage: pr-resolve.sh <thread-id> <pr-number>}"
+
+# GitHub node ids are base64-shaped — letters, digits, underscore,
+# dash. Anything else means the agent passed in junk (or shell-
+# metachar payload) and we should bail.
+if ! [[ "$THREAD_ID" =~ ^[A-Za-z0-9_-]+$ ]]; then
+  echo "pr-resolve: invalid thread-id '$THREAD_ID' (alphanumeric / _ / - only)" >&2
+  exit 2
+fi
+
+if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+  echo "pr-resolve: invalid pr-number '$PR_NUM' (digits only)" >&2
+  exit 2
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+EXPECTED_PR="$(gh pr list --head "$CURRENT_BRANCH" --state open --json number -q '.[0].number' 2>/dev/null || true)"
+if [[ -z "$EXPECTED_PR" ]]; then
+  echo "pr-resolve: current branch '$CURRENT_BRANCH' has no open PR" >&2
+  echo "  refusing to resolve thread without an explicit branch context;" >&2
+  echo "  switch to the branch whose PR you want to resolve a thread on, or confirm with the user" >&2
+  exit 3
+fi
+if [[ "$EXPECTED_PR" != "$PR_NUM" ]]; then
+  echo "pr-resolve: pr-number '$PR_NUM' does not match current branch '$CURRENT_BRANCH' (expected PR #$EXPECTED_PR)" >&2
+  echo "  re-run with the correct PR number, or confirm with the user that you intend to resolve a thread on a different PR" >&2
+  exit 3
+fi
+
+gh api graphql \
+  -f query='
+    mutation($threadId: ID!) {
+      resolveReviewThread(input: { threadId: $threadId }) {
+        thread { isResolved }
+      }
+    }
+  ' \
+  -F threadId="$THREAD_ID" \
+  --jq '
+    if ((.errors // []) | length) > 0
+    then error("pr-resolve: GraphQL error: \(.errors[0].message)")
+    elif .data.resolveReviewThread.thread.isResolved
+    then true
+    else error("pr-resolve: thread was not marked resolved (locked, already-unresolvable, or transient API failure)")
+    end
+  '

--- a/.claude/scripts/req-branch.sh
+++ b/.claude/scripts/req-branch.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# req-branch.sh — create or switch to the requirements branch for a ticket.
+#
+# Usage:
+#   .claude/scripts/req-branch.sh <ticket> <feature-slug>
+#
+# Constructs branch name: {ticket}_{feature-slug}
+#
+# Behaviour:
+#   - Already on the target branch → report and exit 0.
+#   - Branch exists locally → switch to it.
+#   - Branch exists on remote → track and switch.
+#   - Branch does not exist → create from origin's default branch.
+#
+# Why this script vs raw `git switch` / `git checkout`:
+#   - One allowlist entry for the "set up the requirements branch" intent.
+#   - Input validation (ticket format, slug format) is centralised.
+#   - Anchors new branches to origin's default branch — a PM running the
+#     skill from an arbitrary local branch doesn't accidentally fork from
+#     stale state.
+#   - Refuses to switch with uncommitted changes, giving a clear message
+#     rather than a cryptic git error.
+#
+# Safety:
+#   - Ticket validated as PROJ-123 format (uppercase letters, dash, digits).
+#   - Slug validated as kebab-case (lowercase letters, digits, hyphens).
+#   - Refuses to switch if there are uncommitted changes.
+#   - No `eval`, no unquoted vars, no force-checkout.
+
+set -euo pipefail
+
+TICKET="${1:?usage: req-branch.sh <ticket> <feature-slug>}"
+SLUG="${2:?usage: req-branch.sh <ticket> <feature-slug>}"
+
+# Validate ticket: PROJ-123 format (one or more uppercase letters, dash,
+# one or more digits).
+if ! [[ "$TICKET" =~ ^[A-Z]+-[0-9]+$ ]]; then
+  echo "req-branch: invalid ticket '$TICKET' (expected PROJ-123 format)" >&2
+  exit 2
+fi
+
+# Validate slug: kebab-case (lowercase letters, digits, hyphens; must
+# start and end with a letter or digit).
+if ! [[ "$SLUG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+  echo "req-branch: invalid feature-slug '$SLUG' (kebab-case only)" >&2
+  exit 2
+fi
+
+BRANCH="${TICKET}_${SLUG}"
+
+# Already on the target branch — nothing to do.
+CURRENT="$(git branch --show-current)"
+if [[ -z "$CURRENT" ]]; then
+  echo "req-branch: detached HEAD state — switch to a branch first" >&2
+  exit 2
+fi
+if [[ "$CURRENT" == "$BRANCH" ]]; then
+  echo "Already on branch '$BRANCH'"
+  exit 0
+fi
+
+# Refuse to switch if there are uncommitted changes — a PM may not know
+# how to recover from a dirty-state error, so we catch it early with a
+# clear message rather than letting git switch fail cryptically.
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "req-branch: uncommitted changes on '$CURRENT' — commit or stash before switching" >&2
+  exit 2
+fi
+
+# Branch exists locally → switch to it.
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git switch "$BRANCH"
+  echo "Switched to existing local branch '$BRANCH'"
+  exit 0
+fi
+
+# Fetch to pick up any remote branch that was created elsewhere.
+git fetch origin --prune
+
+# Branch exists on remote → track and switch.
+if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+  git switch --track "origin/$BRANCH"
+  echo "Switched to remote-tracking branch '$BRANCH'"
+  exit 0
+fi
+
+# Create new branch from origin's default branch so the PM doesn't
+# accidentally fork from stale local state.
+DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
+git switch -c "$BRANCH" "origin/$DEFAULT_BRANCH"
+echo "Created branch '$BRANCH' from 'origin/$DEFAULT_BRANCH'"

--- a/.claude/scripts/req-pr.sh
+++ b/.claude/scripts/req-pr.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# req-pr.sh — commit the requirements package, push, and open a PR.
+#
+# Usage:
+#   .claude/scripts/req-pr.sh <ticket> <requirements-file> <body-file> <commit-msg-file>
+#
+# The script:
+#   1. Validates inputs.
+#   2. Stages the requirements file.
+#   3. Commits with the message from <commit-msg-file>.
+#   4. Pushes the current branch to origin.
+#   5. Opens a PR via gh pr create (or reports the existing PR if one
+#      is already open for the branch).
+#
+# The PR body comes from <body-file>, which the skill writes to a temp
+# file before calling this script — same pattern as pr-reply.sh.
+#
+# Why this script vs raw `gh pr create`:
+#   - One allowlist entry covers the "publish requirements and open PR"
+#     intent, instead of a wildcard on `gh` or `git push`.
+#   - Body via file — no shell metachar escaping issues.
+#   - gh pr create flags are hardcoded — the agent can't inject --force
+#     or --draft.
+#   - Requirements file path is restricted to docs/requirements/ so the
+#     agent can't commit arbitrary files.
+#
+# Safety:
+#   - Ticket validated as PROJ-123 format.
+#   - Requirements file must exist and live under docs/requirements/.
+#   - Requirements file symlink rejection (same reasoning as pr-reply.sh
+#     body-file check).
+#   - Body-file symlink rejection, path restriction, size cap (same
+#     checks as pr-reply.sh).
+#   - Commit-message-file symlink rejection and path restriction.
+#   - Refuses to commit or push on main/master or detached HEAD.
+#   - No force-push, no --force, no --draft.
+#   - If an open PR already exists for the branch, pushes the commit
+#     and reports the existing PR URL rather than failing.
+#
+# Exit codes:
+#   0  committed, pushed, and PR created (or existing PR updated)
+#   2  validation failed (input is malformed; do not retry)
+#   *  any other failure propagates git/gh exit code unchanged
+
+set -euo pipefail
+
+TICKET="${1:?usage: req-pr.sh <ticket> <requirements-file> <body-file> <commit-msg-file>}"
+REQ_FILE="${2:?usage: req-pr.sh <ticket> <requirements-file> <body-file> <commit-msg-file>}"
+BODY_FILE="${3:?usage: req-pr.sh <ticket> <requirements-file> <body-file> <commit-msg-file>}"
+COMMIT_MSG_FILE="${4:?usage: req-pr.sh <ticket> <requirements-file> <body-file> <commit-msg-file>}"
+
+# --- Input validation ---
+
+if ! [[ "$TICKET" =~ ^[A-Z]+-[0-9]+$ ]]; then
+  echo "req-pr: invalid ticket '$TICKET' (expected PROJ-123 format)" >&2
+  exit 2
+fi
+
+if [[ ! -f "$REQ_FILE" ]]; then
+  echo "req-pr: requirements file '$REQ_FILE' not found" >&2
+  exit 2
+fi
+
+# Reject symlinks — same reasoning as pr-reply.sh's body-file check.
+# A symlink at docs/requirements/PROJ-123-foo.md -> /etc/passwd would
+# pass the prefix check (pwd -P only canonicalises the directory) and
+# git add would follow it, committing the target's contents.
+if [[ -L "$REQ_FILE" ]]; then
+  echo "req-pr: requirements file '$REQ_FILE' is a symlink; refusing to commit" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Requirements file must be under docs/requirements/ to prevent the
+# agent from committing arbitrary files via this script.
+REQ_REAL="$(cd "$(dirname "$REQ_FILE")" && pwd -P)/$(basename "$REQ_FILE")"
+if [[ "$REQ_REAL" != "$REPO_ROOT/docs/requirements/"* ]]; then
+  echo "req-pr: requirements file '$REQ_REAL' is not under docs/requirements/" >&2
+  exit 2
+fi
+
+# --- Body-file validation (mirrors pr-reply.sh) ---
+
+if [[ ! -f "$BODY_FILE" ]]; then
+  echo "req-pr: body file '$BODY_FILE' not found" >&2
+  exit 2
+fi
+
+if [[ -L "$BODY_FILE" ]]; then
+  echo "req-pr: body file '$BODY_FILE' is a symlink; refusing to resolve" >&2
+  exit 2
+fi
+
+BODY_REAL="$(cd "$(dirname "$BODY_FILE")" && pwd -P)/$(basename "$BODY_FILE")"
+if [[ -d "$REPO_ROOT/.claude/scripts/_replies" ]]; then
+  REPLIES_REAL="$(cd "$REPO_ROOT/.claude/scripts/_replies" && pwd -P)"
+else
+  REPLIES_REAL="$REPO_ROOT/.claude/scripts/_replies"
+fi
+
+# Allowed body-file locations (same set as pr-reply.sh):
+#   - /tmp/                        — scratch space the agent can write
+#   - /private/tmp/                — same path on macOS (symlink target)
+#   - <repo>/.git/                 — git's own scratch dir
+#   - <repo>/.claude/scripts/_replies/     — durable per-repo scratch dir
+# REPLIES_REAL is the symlink-resolved form; accepted for repos where
+# .claude/scripts is a symlink (e.g. this standards library repo).
+if [[ "$BODY_REAL" != /tmp/* \
+   && "$BODY_REAL" != /private/tmp/* \
+   && "$BODY_REAL" != "$REPO_ROOT/.git/"* \
+   && "$BODY_REAL" != "$REPO_ROOT/.claude/scripts/_replies/"* \
+   && "$BODY_REAL" != "$REPLIES_REAL/"* ]]; then
+  echo "req-pr: body file '$BODY_REAL' is outside the allowed set" >&2
+  echo "  allowed: /tmp/*, /private/tmp/*, $REPO_ROOT/.git/*, $REPO_ROOT/.claude/scripts/_replies/*" >&2
+  exit 2
+fi
+
+BODY_SIZE="$(wc -c < "$BODY_FILE")"
+if (( BODY_SIZE > 65000 )); then
+  echo "req-pr: body file '$BODY_FILE' is ${BODY_SIZE} bytes, refusing (limit ~65 000 bytes)" >&2
+  exit 2
+fi
+
+# --- Commit-message-file validation ---
+
+if [[ ! -f "$COMMIT_MSG_FILE" ]]; then
+  echo "req-pr: commit message file '$COMMIT_MSG_FILE' not found" >&2
+  exit 2
+fi
+
+if [[ -L "$COMMIT_MSG_FILE" ]]; then
+  echo "req-pr: commit message file '$COMMIT_MSG_FILE' is a symlink; refusing to resolve" >&2
+  exit 2
+fi
+
+COMMIT_MSG_REAL="$(cd "$(dirname "$COMMIT_MSG_FILE")" && pwd -P)/$(basename "$COMMIT_MSG_FILE")"
+
+if [[ "$COMMIT_MSG_REAL" != /tmp/* \
+   && "$COMMIT_MSG_REAL" != /private/tmp/* \
+   && "$COMMIT_MSG_REAL" != "$REPO_ROOT/.git/"* \
+   && "$COMMIT_MSG_REAL" != "$REPO_ROOT/.claude/scripts/_replies/"* \
+   && "$COMMIT_MSG_REAL" != "$REPLIES_REAL/"* ]]; then
+  echo "req-pr: commit message file '$COMMIT_MSG_REAL' is outside the allowed set" >&2
+  exit 2
+fi
+
+COMMIT_MSG_SIZE="$(wc -c < "$COMMIT_MSG_FILE")"
+if (( COMMIT_MSG_SIZE > 8000 )); then
+  echo "req-pr: commit message file '$COMMIT_MSG_FILE' is ${COMMIT_MSG_SIZE} bytes, refusing (limit ~8 000 bytes)" >&2
+  exit 2
+fi
+
+# --- Pre-flight checks ---
+
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ -z "$CURRENT_BRANCH" ]]; then
+  echo "req-pr: detached HEAD state — switch to a branch first" >&2
+  exit 2
+fi
+if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
+  echo "req-pr: refusing to commit and push on '$CURRENT_BRANCH'" >&2
+  exit 2
+fi
+
+# --- Commit ---
+
+git add "$REQ_FILE"
+
+# If nothing to commit (file already committed on a prior run that
+# failed at push or PR creation), skip the commit and proceed to push.
+# This makes the script idempotent for the push+PR step.
+if git diff --cached --quiet; then
+  echo "req-pr: no new changes to commit — proceeding to push"
+else
+  git commit -F "$COMMIT_MSG_FILE"
+fi
+
+# --- Push ---
+
+git push -u origin "$CURRENT_BRANCH"
+
+# --- Create PR (or report existing) ---
+
+EXISTING_PR="$(gh pr list --head "$CURRENT_BRANCH" --state open --json url -q '.[0].url' 2>/dev/null || true)"
+
+if [[ -n "$EXISTING_PR" ]]; then
+  echo "Pushed to existing PR: $EXISTING_PR"
+else
+  DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
+
+  PR_URL="$(gh pr create \
+    --title "${TICKET}: Add requirements package" \
+    --base "$DEFAULT_BRANCH" \
+    --body-file "$BODY_FILE")"
+
+  echo "$PR_URL"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,62 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/git-safety.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/filesystem-safety.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/database-safety.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/terraform-safety.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git rev-parse:*)",
+      "Bash(git symbolic-ref:*)",
+      "Bash(git fetch:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git status:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git checkout:*)",
+      "Bash(git pull origin main)",
+      "Bash(git pull origin HEAD)",
+      "Bash(git push -u origin:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(rg:*)",
+      "Bash(fd:*)",
+      "Read(docs/**)",
+      "Read(.claude/**)",
+      "Write(.claude/scripts/_replies/**)",
+      "Bash(.claude/scripts/pr-comments.sh:*)",
+      "Bash(.claude/scripts/pr-reply.sh:*)",
+      "Bash(.claude/scripts/pr-issue-reply.sh:*)",
+      "Bash(.claude/scripts/pr-resolve.sh:*)",
+      "Bash(.claude/scripts/req-branch.sh:*)",
+      "Bash(.claude/scripts/req-pr.sh:*)"
+    ],
+    "deny": [
+      "Bash(find:*)",
+      "Bash(grep:*)"
+    ]
+  }
+}

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,39 @@
+# Skills
+
+Complex, named, developer-invoked workflows with YAML frontmatter specifying model, allowed tools, and argument hints.
+
+Skills are fanned out to every consumer repo and installed into `.claude/skills/`. They are invoked with `/skill-name` in Claude Code.
+
+## When to use a skill vs a command
+
+Skills require YAML frontmatter, run sub-agents, need model selection, or accept structured arguments. If it fits in one paragraph with no branching — use a command. See `docs/framework/02-mechanism-hierarchy.md`.
+
+## Frontmatter format
+
+```yaml
+---
+description: One-line description shown in /help output
+model: claude-opus-4-8        # Use Opus for expensive cognitive work, Haiku for cheap/repetitive
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash
+argument_hint: "Optional — describe expected argument if the skill accepts one"
+---
+```
+
+## Skills in this library
+
+| Skill | Purpose | Model | Status |
+|---|---|---|---|
+| `init-claude.md` | Bootstrap a repo — absorbs existing AI configs, generates CLAUDE.md and local rules ([AIDEV-1](https://zegons.atlassian.net/browse/AIDEV-1)) | Opus | P0 |
+| `review-code.md` | Parallel multi-agent code review against standards + steering doc | Opus | P1 |
+| `create-pr/SKILL.md` | Open a PR after implement PASS — derives title from steering doc, builds Background + Changes + Jira Ticket/s from the diff ([AIDEV-25](https://zegons.atlassian.net/browse/AIDEV-25)) | Sonnet | P1 |
+| `write-requirements.md` | PM-facing interview to certainty — produces structured Given/When/Then requirements document | Opus | P1 |
+| `write-steering-doc.md` | Developer-facing interview to certainty — produces steering document with impact assessment | Opus | P1 |
+| `fix-pr-comments.md` | Feed PR review comments back through the code → review loop | Sonnet | P1 |
+| `fix-buildkite/SKILL.md` | Diagnose and remediate Buildkite CI failures via MCP — triage, retry flaky tests, fix code errors, commit and push | Opus | P1 |
+| `write-skill/SKILL.md` | Staged orchestrator: interview, TDD cycle (RED/GREEN/REFACTOR with sub-agents), validation — produces tested skill files | Opus | P1 |
+| `extend-claude-standards/SKILL.md` | Gap analysis and engineer interview for `## Repository context` in `CLAUDE.local.md` — classifies 10 topics, interviews for thin/absent, merges answers ([AIDEV-78](https://zegons.atlassian.net/browse/AIDEV-78)) | Opus | P1 |
+| `write-standard/SKILL.md` | Interview-driven: creates a new standards file or extends an existing one. Analyses sources, detects conflicts, validates structure, commits | Opus | P1 |

--- a/.claude/skills/ci-validation/SKILL.md
+++ b/.claude/skills/ci-validation/SKILL.md
@@ -1,0 +1,432 @@
+---
+name: ci-validation
+description: You MUST use this when the user asks to run CI validation locally or verify that code passes CI checks before committing.
+model: claude-sonnet-4-6
+allowed-tools:
+  - Bash
+  - Read
+---
+
+You are executing the `ci-validation` skill. Discover the repo's CI
+commands and execute them locally, gating on success before the caller
+proceeds. You do not fix failures — you discover, execute, and report.
+
+---
+
+## Objective
+
+Before committing, run CI-equivalent validation locally so that known failures
+never reach the pipeline. This skill discovers the repo's CI commands and
+executes them, gating on success before proceeding.
+
+---
+
+## Stage 1 — Discover CI commands
+
+Follow this priority chain. Check each source in order. If a source file
+exists but yields no extractable commands, fall through to the next source.
+Stop at the first source that yields at least one command.
+
+1. **CLAUDE.md frontmatter `ci-test-command`.**
+   Read the consumer repo's `CLAUDE.md`. If the managed frontmatter block
+   contains a `ci-test-command` key whose value is non-empty, use it. The value
+   may be a single command string or a newline-separated list of commands. Split
+   on newlines and trim whitespace to produce the command list.
+
+2. **`.buildkite/pipeline.yml`.**
+   If no commands were found in step 1, check whether `.buildkite/pipeline.yml`
+   exists. If it does, read it and extract every `command:` value that starts
+   with `make` or that contains a test, lint, or format invocation (e.g.
+   `pytest`, `npm test`, `ruff`, `sbt test`, `eslint`). For multi-line
+   `command:` values (YAML `|` or `>` blocks), split on newlines and treat each
+   non-empty line as a separate command, applying the same filter. If the
+   pipeline exists but yields no extractable commands, fall through to step 3.
+
+3. **`.github/workflows/*.yml`.**
+   If no commands were found in steps 1–2, check for `.github/workflows/*.yml`.
+   If any workflow files exist, read them and extract every `run:` value that
+   contains a test, lint, or format invocation. If the workflows exist but
+   yield no extractable commands, fall through to step 4.
+
+4. **No CI configuration found.**
+   If none of the above sources yielded commands, log:
+
+   > No CI configuration found — skipping CI validation.
+
+   Return verdict: **passed** (nothing to validate).
+
+**For repos with complex pipelines** (multi-line command blocks, Docker
+invocations, plugin-heavy steps), automatic extraction may produce
+inconsistent results across runs. Declare `ci-test-command` explicitly in
+CLAUDE.md frontmatter rather than relying on extraction. See
+[ADR 003](docs/decisions/003-claudemd-frontmatter.md) for format details.
+
+---
+
+## Stage 2 — Prepare the command list
+
+Once commands are discovered, prepare them for execution:
+
+- **Check for a Makefile.** Run `test -f Makefile` to determine whether one
+  exists.
+- **`make` commands without a Makefile:** halt and report:
+
+  > CI validation cannot proceed: `{command}` references a `make` target but
+  > no Makefile exists in the working tree. Either add a Makefile or declare
+  > the underlying commands via `ci-test-command` in CLAUDE.md frontmatter.
+
+  Do not attempt to guess the underlying tool command. Do not skip the command.
+  Return verdict: **failed**.
+
+- **`make` commands whose target is not defined:** run `make -n {target}` (dry
+  run) to check whether the target exists. This is the authoritative check — it
+  handles pattern rules, included Makefiles, `.PHONY` declarations, conditional
+  blocks, and dynamically generated targets. Do not grep the Makefile directly.
+  If `make -n {target}` exits non-zero, halt and report:
+
+  > CI validation cannot proceed: `{command}` references make target
+  > `{target}` but it is not defined in the Makefile. Either add the target
+  > or declare the underlying commands via `ci-test-command` in CLAUDE.md
+  > frontmatter.
+
+  Do not attempt to guess the underlying tool command. Do not skip the command.
+  Return verdict: **failed**.
+
+- **`make` commands where `make -n {target}` exits zero:** run as-is.
+
+- **Non-`make` commands** (e.g. `npm test`, `pytest`, `sbt test`): run
+  directly as-is regardless of whether a Makefile exists.
+
+**Auto-format before lint.** The implement agent writes code but does not run
+formatters. If the discovered command list contains a lint command but no
+format command, find and prepend a format step so that lint does not fail on
+style violations the formatter would fix automatically.
+
+Search for a format command in this order:
+1. **Makefile** (if present): scan for a target whose name exactly matches one
+   of the allowlist entries — `format`, `fmt`, `format-all`, `fmt-all` — or
+   that starts with `format-` or `fmt-` but is not a check target (reject
+   names ending in `-check`, `-verify`, `-lint`, or `-deps`). Use the matched
+   target as `make {target}`.
+2. **Pipeline file**: look for a `command:` or `run:` value that invokes a
+   known formatter tool (`ruff format`, `black`, `prettier --write`,
+   `gofmt -w`, `gofumpt -w`, `sbt scalafmtAll`, `sbt scalafmt`) but was not
+   included in the discovered list (e.g. it lives in a separate pipeline step
+   that was filtered out). Do not match a value merely because it contains
+   the substring `format` or `fmt` — the value must invoke a recognised
+   formatter.
+3. **Common tool commands**: if the lint command identifies the toolchain,
+   infer the format command:
+   - `ruff check` → `ruff format .`
+   - `eslint` → `prettier --write .`
+   - `flake8` → `black .`
+   - `scalafmtCheck` / `scalafmtCheckAll` → `sbt scalafmtAll`
+   - `gofmt -l` / `gofumpt` → `gofmt -w .` / `gofumpt -w .`
+
+If a format command is found, insert it immediately before the first lint
+command in the list. If the discovered list already contains a format command,
+do not add another — but ensure it runs before lint. If no format command can
+be determined, continue without one (do not halt).
+
+**Otherwise preserve pipeline order.** Apart from the format-before-lint
+insertion above, run all other commands in the order they appear in the CI
+configuration.
+
+---
+
+## Stage 3 — Autonomous scope validation
+
+This stage is fully autonomous — it contains NO interactive prompt. It
+classifies and selects from the **Stage 2-prepared command list** (i.e. the
+list after Stage 2's format-before-lint auto-prepend), biased toward running.
+Stage 3 does NOT re-discover commands and does NOT re-prepend a format step —
+it classifies and selects from the already-prepared list, and produces the
+tier-selected command list that Stage 4 consumes.
+
+### 3.1 — Determine the changed files
+
+Prefer a threaded `{changed file(s)}` input passed in the spawn brief. When it
+is empty or absent, fall back to deriving the changed files from git:
+
+```bash
+BASE=$(git merge-base HEAD origin/main 2>/dev/null) || BASE=""
+if [ -n "$BASE" ]; then
+  git diff "$BASE" --name-only
+else
+  echo "git-merge-base failed — running all tiers"  # triggers the broad/ambiguous fallback
+fi
+```
+
+This compares ALL commits on the feature branch against the default branch —
+NOT `HEAD~1`. If that command (or the inner `git merge-base`) exits non-zero
+(detached HEAD, shallow clone, no commits, no `origin/main`), do NOT halt and
+do NOT run nothing: treat the diff as broad/ambiguous, run ALL tiers, and
+report the git-diff failure as the reason.
+
+### 3.2 — Classify each command into a tier
+
+Classify every command in the prepared list into exactly one of four tiers
+using this tool-agnostic command/target-name keyword enumeration (it must be
+matched against each command's tokens; it works across Python, Scala, JS, Go):
+
+- **format/lint** ← `format`, `fmt`, `lint`, `ruff`, `scalafmt`, `prettier`,
+  `eslint`, `black`, `flake8`, `gofmt`
+- **unit** ← `test`, `pytest`, `sbt test`, `unit` (without an
+  integration/smoke marker)
+- **integration** ← `test-integration`, `integration-test`,
+  `sbt "integration-test/test"`, `it-test`
+- **smoke** ← `test-smoke`, `smoke`
+
+**Tier-classification priority — most-specific-first.** Patterns are matched
+in this order so that a more specific tier always claims the command before
+the broad unit `test` pattern can:
+
+1. format/lint patterns
+2. smoke patterns
+3. integration patterns
+4. the unit `test` pattern LAST
+
+Within a tier, a longer token match takes precedence. The first tier whose
+pattern matches claims the command; later patterns are not tried. This is why
+`test-integration` is classified as integration, NOT unit — the integration
+pattern is matched before the bare `test` (unit) pattern.
+
+**Unmatched commands.** A command that matches no tier is treated as must-run
+(upward bias): assign it to the broadest tier already selected for this run.
+It is never dropped.
+
+### 3.3 — Format-signal vs lint-signal sub-partition
+
+Within the format/lint tier, sub-partition each command for ordering:
+
+- **format-signals** ← `format`, `fmt`, `scalafmt`, `prettier`, `black`,
+  `gofmt` (canonical invocation writes files)
+- **lint-signals** ← `lint`, `ruff`, `eslint`, `flake8` (canonical invocation
+  reads and reports)
+
+A token matched by bare name alone where the mode is ambiguous (e.g. a target
+literally named `ruff`) defaults to lint-signal (conservative).
+
+Format-signals are ordered BEFORE lint-signals within the selected set.
+
+### 3.4 — "Non-code-only" definition
+
+A diff is **non-code-only** when it contains no source-language files —
+`.py`, `.ts`, `.tsx`, `.js`, `.jsx`, `.java`, `.kt`, `.scala`, `.go`, `.rb`,
+`.rs` — i.e. only documentation, configuration, or data files.
+
+Borderline cases are classified as code-affecting for tier purposes:
+
+- `.proto` definitions and SQL migration files count as code, AND as
+  service-boundary/converter touches → add integration.
+- Dependency manifests (`requirements.txt`, `pyproject.toml`, `package.json`,
+  `build.sbt`, lock files) and `Dockerfile`/startup config count as
+  dependency/startup touches → add smoke.
+
+### 3.5 — Select tiers by what the diff touches (err upward)
+
+- **non-code only** → format/lint only (or skip entirely if no format/lint
+  command exists — report each skipped tier with its reason).
+- **any code change** → always format + lint + unit.
+- **service boundary / I/O / API / DB / converter** (including `.proto`, SQL
+  migrations) → add integration.
+- **Dockerfile / dependency manifest / startup config** → add smoke.
+- **broad / mixed / ambiguous** (and the git-diff-failure fallback from 3.1)
+  → run all four tiers.
+
+### 3.6 — Report
+
+Report which tiers ran, which were skipped, and why. Every discovered command
+must appear with a ran/skipped + reason — no silent skips. Within the
+format/lint tier the selected output lists format-signal commands before
+lint-signal commands.
+
+Proceed to Stage 4 with the tier-selected command list.
+
+---
+
+## Stage 4 — Execute
+
+This stage consumes the tier-selected command list produced by Stage 3. It is
+fully autonomous — it contains NO interactive prompt.
+
+Note what is about to run:
+
+> Running CI validation: {comma-separated list of commands}.
+
+Run each command in order using `run_in_background` so execution is
+non-blocking.
+
+### 4.1 — Autonomous 20-minute hard-ceiling timeout
+
+Each command runs under a **hard ceiling of 20 minutes per command**. There is
+NO interactive check-in. If a command is still running when the 20-minute
+ceiling is exceeded:
+
+1. Kill the command.
+2. Record it as `failed` (never `skipped`, never silently continued).
+3. Report the elapsed time and the partial stdout/stderr captured so far.
+
+Never block on a human — the ceiling is a fixed autonomous bound.
+
+**The killed command's partial output is auth-checked before its verdict is
+emitted.** Pass the partial stdout/stderr through the same auth-signal check
+defined in 4.2 (Interface A), exactly as for a normally-exited command:
+
+- An auth signal from either family present in the partial output →
+  `precondition: authentication` (so the loop short-circuits rather than
+  feeding the fixer).
+- No auth signal in the partial output → plain `verdict: failed`.
+
+This keeps the bias-toward-precondition principle identical on the normal-exit
+and timeout paths.
+
+### 4.2 — Authentication / credentials precondition detection
+
+An auth or credentials failure is an environment precondition, not a code
+failure. The code fixer cannot fix it and must not be fed it. On any command
+failure (non-zero exit) — and on the partial output of a timed-out, killed
+command — check the full output for an auth signal BEFORE emitting the
+verdict. The behaviour is **detect-and-report only**: do NOT export missing
+variables, do NOT auto-run auth commands, and do NOT skip the command — all
+three would make the local run diverge from CI.
+
+Two signal families are checked independently of each other:
+
+**Family (a) — environment-variable-absence / expired-session strings.**
+Match these well-known patterns anywhere in the output:
+
+- `CODEARTIFACT_AUTH_TOKEN not set`
+- `Unable to set UV_INDEX_<INDEX>_PASSWORD`, where `<INDEX>` is any token
+  (real uv output substitutes the index name, e.g.
+  `Unable to set UV_INDEX_INTERNAL_PASSWORD`)
+- the SSO-session-expiry set (open-ended; anchored by these canonical
+  examples): `Error loading SSO Token`, `token is expired`,
+  `SSO session has expired`,
+  `The SSO session associated with this profile has expired`, and similar
+  phrasings.
+
+**Family (b) — HTTP registry auth statuses, tool-name-agnostic.**
+Match these status strings anywhere in fetch/dependency-resolution output,
+**regardless of the tool name**:
+
+- `401 Unauthorized`
+- `403 Forbidden`
+- `HTTP Error 401`
+- `received status code 401` / `received status code 403`
+
+A 401/403 from an unfamiliar tool MUST still classify as auth — it must never
+be swallowed as a generic failure merely because the tool was unrecognised.
+
+**Classification rule (bias toward the precondition).** When either family
+matches unambiguously, the classification is `precondition: authentication`
+EVEN WHEN the command is otherwise ambiguous (e.g. an exit code that could
+also indicate a compile error) — the remediation is non-destructive, so bias
+toward the precondition. A failure with no auth signal is plain
+`verdict: failed`.
+
+**Remediation, resolved per family.** Emit exactly ONE remediation line:
+
+- Family (a): name the documented path for the matched signal —
+  CodeArtifact / SSO expiry → `aws sso login`; a `UV_INDEX_*_PASSWORD`
+  absence → the documented UV index-credential refresh for that index.
+- Family (b): `refresh your registry credentials via the documented path
+  (see the repo's auth/registry documentation)`.
+- **Dual match** (the same output matches BOTH families): family (a)'s
+  remediation path takes precedence; emit exactly ONE remediation line
+  carrying family (a)'s path. Never emit two lines.
+
+### 4.3 — Emit the verdict
+
+- **On success:** record the command as passed and continue to the next.
+- **On failure (non-zero exit, or a 20-minute-ceiling kill) WITH an auth
+  signal:** do not run remaining commands. Return:
+
+  1. `verdict: failed`
+  2. A distinct classification LINE: `precondition: authentication`
+  3. The failing command name and exit code (or elapsed time for a killed
+     command)
+  4. The full (or partial, for a killed command) command output verbatim,
+     ending with exactly one appended line of the exact form:
+     `precondition: authentication — remediation: {documented path}`
+
+- **On failure (non-zero exit, or a 20-minute-ceiling kill) WITHOUT an auth
+  signal:** do not run remaining commands. Return:
+
+  1. `verdict: failed`
+  2. The failing command name and exit code (or elapsed time for a killed
+     command)
+  3. The full (or partial) command output verbatim
+
+  No `precondition: authentication` line — this is a generic code/test
+  failure. The fix loop will handle retries; this skill only discovers,
+  executes, and reports.
+
+After all commands complete successfully, report the outcome of every command:
+
+> CI validation passed:
+> - `{command 1}` — passed
+> - `{command 2}` — passed
+> - `{command 3}` — passed
+> - ...
+
+Return verdict: **passed**. The caller must surface this report so that every
+command's outcome is visible, not silently dropped.
+
+---
+
+## Rules
+
+- **CI validation must not be skipped when CI configuration exists.**
+  The skill gates the commit — if discovered commands fail, return the failure
+  to the implement skill. Do not retry or fix within this skill — the
+  implement skill's fix loop handles that.
+- **CI command discovery follows a strict priority chain.** Check
+  `ci-test-command` in CLAUDE.md frontmatter first, then
+  `.buildkite/pipeline.yml`, then `.github/workflows/*.yml`. Stop at the first
+  source that yields commands. Do not merge commands from multiple sources.
+- **Do not hardcode `make` target names.** Discover targets from the CI
+  configuration at runtime. The skill must work across repos with different
+  target names and build systems.
+- **Halt when `make` is referenced but no Makefile exists.** Do not guess the
+  underlying tool command and do not silently skip the command. A missing
+  Makefile when the pipeline references `make` targets is a misconfiguration
+  that must be surfaced, not papered over.
+- **Auto-format before lint.** The implement agent does not run formatters,
+  so CI validation must prepend a format step when lint is discovered but
+  format is not. Search the Makefile, pipeline, and common tool conventions.
+- **Scope validation and execution are fully autonomous.** Neither Stage 3
+  nor Stage 4 may prompt the user. There is no Accept/Select/Skip menu and no
+  keep-waiting / skip / fail check-in anywhere in the skill. Scope selection
+  errs upward (ambiguous/broad/mixed diffs and git-diff failures run
+  everything; no silent skips).
+- **Per-command timeout is an autonomous 20-minute hard ceiling.** Every CI
+  command runs in the background under a 20-minute hard ceiling. If the
+  command is still running when the ceiling is exceeded, kill it, record it as
+  `failed`, and report the elapsed time and partial output — do NOT prompt the
+  user, do NOT silently continue, and do NOT mark it skipped. The partial
+  output of a killed command is auth-checked (Stage 4.2) before the verdict is
+  emitted.
+- **Auth preconditions are detect-and-report only.** When a command's output
+  carries an auth signal (Stage 4.2, either family), classify it
+  `precondition: authentication` and report the remediation path. Never export
+  missing variables, never auto-run an auth command, and never skip the
+  command — all three would make the local run diverge from CI.
+
+---
+
+## Red flags — stop and reconsider
+
+These are the tool-agnostic rationalisations that quietly defeat local CI
+validation. If you catch yourself reasoning along any of these lines, stop and
+do the disciplined thing instead. (This table is deliberately self-contained
+and tool-agnostic; it does not reference or reconcile any steering-doc table.)
+
+| Rationalisation | Why it is wrong | Do this instead |
+|-----------------|-----------------|-----------------|
+| "I'll just run the bare tool (`pytest`, `ruff`, `sbt test`) directly instead of the discovered CI command." | The bare tool may use different flags, config, or scope than CI, so a local pass does not predict a CI pass. | Run the discovered CI command exactly as Stage 1–2 prepared it. |
+| "The bare tool passed, so I can trust that over the CI command." | A bare-tool pass is not equivalent to a CI-command pass — CI may add coverage gates, stricter config, or extra targets. | Trust only the discovered CI command's result; never substitute a bare-tool run for it. |
+| "This change is small, so I can skip local validation." | "Small" changes break CI as often as large ones; size is not a proxy for safety. | Run the tier-selected validation regardless of diff size. |
+| "These tests are slow, so I'll skip them." | Slow tests (integration/smoke) are exactly the ones that catch boundary regressions; skipping them defeats the gate. | Run the selected tiers; the 20-minute hard ceiling bounds runtime without skipping. |
+| "Only this one command is obviously related to my change, so I'll run just that." | Changes have non-obvious blast radius; running only the obviously-related command misses regressions the scope rules would have caught. | Let Stage 3's upward-biased tier selection decide; run every selected command. |
+| "I'll just export the missing credential / run the auth command by hand to get past this auth error." | Exporting a credential or running auth by hand makes the local run diverge from CI and masks an environment precondition the developer must fix. | Classify it `precondition: authentication`, report the remediation path, and stop — never export or auto-authenticate. |

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: create-pr
+description: You MUST use this when the user asks to open a pull request for a completed implementation.
+model: claude-sonnet-4-6
+allowed-tools:
+  - Bash
+  - Read
+---
+
+You are executing the `create-pr` skill. Your job is to open a pull
+request on GitHub that conforms to Zego's PR standards. You do not ask
+questions — all required inputs are provided below or derivable from the
+repository state.
+
+---
+
+## Inputs
+
+The caller must supply the three required inputs. If any required input is absent, stop and
+report which inputs are missing. The optional `base` input may be omitted.
+
+| Input              | Required | Description                                                  |
+|--------------------|----------|--------------------------------------------------------------|
+| `ticket`           | yes      | Jira ticket key, e.g. `AIDEV-25`                             |
+| `branch`           | yes      | Branch to open the PR from, e.g. `AIDEV-25_create_pr_automatically` |
+| `task_spec_path`   | yes      | Relative path to the task spec, e.g. `docs/tasks/AIDEV-25-TASK-01-create-pr-automatically.md` |
+| `base`             | no       | Branch to target for the PR; if absent, defaults to the repo default branch |
+
+---
+
+## Stage 1 — Validate inputs and read the task spec
+
+Confirm that all three required inputs (`ticket`, `branch`, `task_spec_path`) are present.
+
+Determine the operative base branch, then fetch it:
+
+```bash
+if [ -n "{base}" ]; then
+  BASE="{base}"
+else
+  BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+fi
+git fetch origin "$BASE"
+```
+
+Store `BASE` — it is referenced in Stage 3 (diff) and Stage 6 (PR base).
+
+Read the task spec at `task_spec_path` in full. Extract:
+
+- **`ticket`** — confirm it matches the `ticket` frontmatter field. If the
+  task spec has no `ticket` field, stop immediately and report:
+  > Task spec has no `ticket` frontmatter field. A ticket prefix is
+  > required for the PR title. Cannot proceed.
+- **Objective or Goal** — the section that explains *why* the change exists.
+  This becomes the Background section of the PR body.
+
+---
+
+## Stage 2 — Derive the PR title
+
+Construct the title as:
+
+```
+{ticket}: {imperative-title}
+```
+
+- `ticket` is the value supplied as input (and confirmed in the task spec
+  frontmatter).
+- `imperative-title` is a concise imperative-mood phrase derived from the
+  task spec's Objective/Goal — not the output spec, not the task slug.
+- The complete title must be **≤70 characters**. Truncate or rephrase the
+  imperative phrase to fit; never truncate the ticket prefix.
+
+Examples of correct form:
+
+```
+# good
+AIDEV-25: Add automatic PR creation after PASS
+
+# bad — passive voice, no ticket prefix
+Adding pull request creation to implement skill
+```
+
+---
+
+## Stage 3 — Derive the Changes section
+
+Run:
+
+```bash
+git diff "origin/$BASE" --stat
+```
+
+If the output is non-empty, run:
+
+```bash
+git diff "origin/$BASE" --name-only
+```
+
+Use the list of changed files to write one verb-first bullet per meaningful
+change. Each bullet opens with an imperative verb (Add, Remove, Update, Fix,
+Extract). Group related files into a single bullet where appropriate.
+
+If the diff produces no output (empty diff), write:
+
+```
+- No diff against base branch detected
+```
+
+Do not leave the Changes section blank under any circumstances.
+
+---
+
+## Stage 4 — Check for a PR template
+
+Run:
+
+```bash
+test -f .github/PULL_REQUEST_TEMPLATE.md && echo "PRESENT" || echo "ABSENT"
+```
+
+- **PRESENT** — read `.github/PULL_REQUEST_TEMPLATE.md` in full. Keep its
+  section headings, ordering, and any placeholder text. Use it as the
+  authoritative skeleton in Stage 6: fill in each section with the gathered
+  context. Do not add, remove, or reorder sections beyond what the template
+  defines.
+- **ABSENT** — no template exists. Stage 6 will use a default three-section
+  fallback (Background, Changes, Jira Ticket/s). Do not warn or error.
+
+---
+
+## Stage 5 — Verify clean working tree
+
+Check whether there are uncommitted changes:
+
+```bash
+git status --porcelain
+```
+
+If the output is **empty** (tree is clean), skip to Stage 6.
+
+If the output is **non-empty**, print the list of uncommitted files to the user
+and **stop**. Do not offer to commit, do not run `git add` or `git commit`.
+Instruct the user to commit their changes before running create-pr. Example
+message:
+
+> The working tree has uncommitted changes (listed above). Please commit them
+> before running create-pr.
+
+---
+
+## Stage 6 — Construct and submit the PR
+
+### Template-driven path (Stage 4 result: PRESENT)
+
+Use the template content stored in Stage 4 as the PR body skeleton. Preserve
+every section heading from the template in the order the template defines.
+Fill in each section using the following derivation rules:
+
+- A section whose heading matches **Background** (accepted synonyms,
+  case-insensitive: *Context*, *Why*, *Motivation*, *Summary*, *Goal*,
+  *Objective*, *Overview*): one or two sentences of flowing prose that answer
+  *why* this change exists. Derive from the task spec's Objective/Goal
+  section. Do not restate the diff. Do not hard-wrap prose.
+- A section whose heading matches **Changes**: bulleted list from Stage 3.
+  One bullet per meaningful change, verb-first.
+- A section whose heading matches **Jira Ticket/s** (accepted synonyms,
+  case-insensitive: *Jira Ticket*, *Jira Tickets*, *Ticket*, *Tickets*,
+  *Links*, *References*, *Related Issues*): one bullet containing the full
+  Atlassian URL:
+  `https://zegons.atlassian.net/browse/{ticket}`
+- Any other section defined in the template: preserve the heading and fill it
+  in from available context (task spec, diff, or repository state). If no
+  content can be derived, write `_TBD_` as the section body instead of leaving
+  template placeholder text. Always strip HTML comments (`<!-- ... -->`) and
+  `{placeholder}` syntax from the final body — these must never appear in the
+  published PR.
+
+Do not add sections that are not in the template. Do not remove sections that
+are in the template.
+
+### Fallback path (Stage 4 result: ABSENT)
+
+When no template exists, use the default three-section structure shown in the
+example below. The body must contain exactly these three sections in this
+order: Background, Changes, Jira Ticket/s.
+
+### Open the PR
+
+Open the PR using `gh pr create` with a HEREDOC body.
+
+**Fallback HEREDOC example** (used only when no template is present):
+
+```bash
+gh pr create \
+  --title "{ticket}: {imperative-title}" \
+  --base "$BASE" \
+  --body "$(cat <<'EOF'
+## Background
+
+{Background prose derived from task spec Objective/Goal}
+
+## Changes
+
+{Verb-first bullet list from Stage 3}
+
+## Jira Ticket/s
+
+- https://zegons.atlassian.net/browse/{ticket}
+EOF
+)"
+```
+
+When a template is present, the HEREDOC must mirror the template's section
+structure instead of the fallback above. Apply the same derivation rules to
+each section.
+
+Do not pass `--force`, `--draft`, or any flag that bypasses branch protection.
+Do not embed credentials, tokens, or environment variables in the command.
+
+---
+
+## Stage 7 — Handle the result
+
+**On success** — report to the caller:
+
+- PR URL (from `gh pr create` output)
+- Title used
+- Branch
+
+**On failure** — if `gh pr create` exits with a non-zero status:
+
+1. Print the error output verbatim.
+2. Stop. Do not retry, do not proceed to any subsequent stage.
+
+Covered failure cases include (but are not limited to):
+
+- Authentication failure (`gh` not authenticated)
+- No remote configured
+- PR already exists for this branch
+- Branch protection rejection
+
+---
+
+## Rules
+
+- **PR body must match the template.** When `.github/PULL_REQUEST_TEMPLATE.md`
+  is present, the PR body must reproduce every section heading from the
+  template in the template's order — no sections added, none removed. When no
+  template is present, use the default three-section fallback (Background,
+  Changes, Jira Ticket/s).
+- **Ticket prefix is mandatory.** If the task spec has no `ticket`
+  frontmatter field, stop before constructing the title.
+- **HEREDOC is mandatory.** Always pass `--body` via a shell HEREDOC. Do not
+  use `--body "..."` with inline string quoting.
+- **Full Jira URL.** `https://zegons.atlassian.net/browse/{ticket}` — never a
+  bare ticket key, never a partial path.
+- **No branch protection bypass.** Do not pass `--force` or equivalent flags.
+- **No credentials in the skill.** `gh` must be pre-authenticated in the
+  environment; do not embed tokens or environment variable references.
+- **On gh failure, stop.** Do not swallow errors or proceed to any downstream
+  stage.

--- a/.claude/skills/extend-claude-standards/SKILL.md
+++ b/.claude/skills/extend-claude-standards/SKILL.md
@@ -1,0 +1,458 @@
+---
+name: extend-claude-standards
+description: You MUST use this when the user asks to deepen, update, or fill gaps in the repository context section of CLAUDE.local.md.
+model: claude-opus-4-8
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+---
+
+You are running the `extend-claude-standards` skill. You read an existing
+`CLAUDE.local.md`, classify the 10 canonical repository context topics as
+present, thin, or absent, present a gap summary, interview the engineer for
+thin and absent topics, and merge confirmed answers back into the file.
+
+This skill is collaborative, not adversarial. You ask, record, and format.
+You do not challenge the engineer's answers or verify claims against the
+codebase.
+
+---
+
+## Stage 1 — Validate input
+
+Check whether `CLAUDE.local.md` exists at the repository root:
+
+```bash
+test -f CLAUDE.local.md && echo "EXISTS" || echo "ABSENT"
+```
+
+- **ABSENT**: display the following error and stop. Do not create the file.
+
+  > No `CLAUDE.local.md` found. Run `init-claude-standards` first to
+  > bootstrap this repository, or create `CLAUDE.local.md` manually.
+
+- **EXISTS**: read the file in full with the Read tool.
+
+Check whether the file contains a `## Repository context` section. Use a
+normalised match: strip leading `#` and whitespace, lowercase, collapse
+whitespace. Look for an H2 heading that normalises to `repository context`.
+
+- **Section absent**: note that all 10 topics will be classified as absent.
+  The section will be appended to the end of the file after the interview,
+  preserving all existing content above.
+- **Section present**: extract the content from the `## Repository context`
+  heading to the next H2 heading (or end of file).
+
+---
+
+## Stage 2 — Classify topics
+
+### Canonical headings (in order)
+
+The 10 canonical H3 headings, in canonical order:
+
+1. `### Purpose`
+2. `### Domain ownership`
+3. `### Callers and interfaces`
+4. `### External dependencies`
+5. `### Domain concepts`
+6. `### Invariants`
+7. `### Gotchas`
+8. `### Operational profile`
+9. `### Test notes`
+10. `### Repository structure`
+
+### H3 match normalisation
+
+Normalise each H3 heading before matching: strip leading `#` characters and
+whitespace, lowercase, collapse runs of whitespace to a single space. For
+example, `### GOTCHAS`, `###  gotchas`, and `### Gotchas` all normalise to
+`gotchas` and match canonical heading 7.
+
+Use an inline `python3` script to perform deterministic classification.
+The script must:
+
+1. Read the `## Repository context` section content.
+2. For each canonical heading, apply the normalised match to find it.
+3. Count bullets (lines starting with `- `) under each found heading, up to
+   the next H3 or H2 heading or end of section.
+4. Check each bullet for markers.
+5. Output a classification for each topic.
+
+### Classification rules
+
+For each of the 10 canonical headings, classify as follows:
+
+| Condition | Classification |
+|-----------|---------------|
+| H3 heading not found in file | **absent** |
+| H3 present AND (<=1 bullet OR any bullet is a marker) | **thin** |
+| H3 present AND >=2 non-marker bullets (none match a marker) | **present** |
+
+**Marker definition:** a bullet is a marker if its trimmed content (after
+removing the leading `- `) equals `TBD`, `TODO`, `unknown`, or `n/a`
+(case-insensitive comparison), or if its trimmed content starts with
+`[inferred]`.
+
+When `## Repository context` is absent from the file, classify all 10 topics
+as **absent**.
+
+---
+
+## Stage 3 — Present gap summary
+
+Present the classification results to the engineer as a numbered list:
+
+```
+Gap summary for CLAUDE.local.md:
+
+1.  Purpose          — {present|thin|absent}
+2.  Domain ownership — {present|thin|absent}
+3.  Callers and interfaces — {present|thin|absent}
+4.  External dependencies  — {present|thin|absent}
+5.  Domain concepts  — {present|thin|absent}
+6.  Invariants       — {present|thin|absent}
+7.  Gotchas          — {present|thin|absent}
+8.  Operational profile — {present|thin|absent}
+9.  Test notes       — {present|thin|absent}
+10. Repository structure — {present|thin|absent}
+```
+
+### All topics present
+
+If all 10 topics are classified as **present**, report:
+
+> All topics are already covered.
+
+Then ask:
+
+> Would you like to revise any of these topics? Enter topic numbers to
+> revisit, or "done" to exit.
+
+- If the engineer enters topic numbers: treat those topics as **thin** for
+  the purpose of the interview (Stage 4). Present existing content as a
+  starting point.
+- If any entered token is not a valid topic number (1-10) or "done",
+  re-prompt with the valid options. Do not silently drop invalid entries.
+- If the engineer says "done" or declines: exit without interviewing.
+
+### Mixed or all gaps
+
+If any topics are thin or absent, state which topics will be interviewed:
+
+> I will interview you on the {N} thin/absent topics. Present topics will be
+> kept as-is.
+
+Proceed to Stage 4.
+
+---
+
+## Stage 4 — Interview
+
+Interview the engineer for each **thin** and **absent** topic, in canonical
+order. Skip **present** topics entirely.
+
+For each topic, use the question, intent, probes, and shape defined below.
+Ask one topic at a time and wait for the engineer's response before moving
+to the next topic.
+
+### Interview depth mechanics
+
+After the engineer's initial answer to each topic, use these two follow-up
+mechanisms to deepen thin answers:
+
+1. **Ask for an example file.** When the engineer describes a pattern or
+   convention, ask which file best illustrates it. The captured bullet gains
+   a concrete, navigable path (e.g. "uses repository pattern (example:
+   `src/payments/PaymentRepository.ts`)").
+
+2. **Ask what an AI agent would get wrong.** Follow up on short answers
+   with: "Is there anything specific about how this works that an AI agent
+   would get wrong?" This surfaces surprising, non-obvious knowledge without
+   the agent presuming to know better.
+
+Use judgement on when to apply these follow-ups. Not every answer needs both.
+If the engineer gives a thorough, specific answer with concrete paths
+already included, do not ask redundant follow-ups.
+
+### Anti-pattern: adversarial verification
+
+**Do not** verify the engineer's claims against the codebase and challenge
+them when you disagree. Engineers documenting surprising or exceptional
+behaviour is exactly the high-value capture this interview exists for. An
+agent overruling them with "actually most of the code does X" drowns out the
+signal the engineer is trying to flag. The interview is collaborative, not
+adversarial. Accept the engineer's answers as authoritative.
+
+### Handling skips
+
+- **Absent topic, engineer skips** (says "skip", "none", or equivalent):
+  omit the topic from the output entirely. Do not write an empty heading.
+- **Thin topic with existing `[inferred]` bullets, engineer skips**: retain
+  the existing `[inferred]` bullets unchanged (prefix intact). The topic
+  stays in the file and will re-classify as thin on the next run.
+- **Thin topic with non-inferred content, engineer skips**: retain the
+  existing content unchanged.
+
+### Topic reference
+
+For **thin** topics, present the existing content as a starting point before
+asking the question:
+
+> Here is what is currently captured for **{topic}**:
+>
+> {existing bullets}
+>
+> {question}
+
+For **absent** topics, ask from scratch.
+
+---
+
+### Topic 1: Purpose
+
+- **Question:** "What is this service/application and what problem does it
+  solve?"
+- **Intent:** determine the scope of changes — whether a modification falls
+  within or outside this service's responsibility — and frame commit messages
+  and PR descriptions in terms of business impact.
+- **Probes:** What business problem does this solve? Who are the end users or
+  consuming systems? What would break for the business if this service went
+  down for an hour?
+- **Shape:** `- {business function} for {user/system} — {what distinguishes
+  this from adjacent services}`
+
+---
+
+### Topic 2: Domain ownership
+
+- **Question:** "Which team owns this repo and what domain does it cover?"
+- **Intent:** determine whether a change belongs in this repo or
+  upstream/downstream, and use correct domain language in code and
+  documentation.
+- **Probes:** What bounded context does this own? Are there domain concepts
+  that share names with other services but mean different things here? What
+  changes would you push back on as "not our responsibility"?
+- **Shape:** `- Owns {domain concept}; boundary: {what's in vs. out};
+  terminology: {term} means {definition} here (not {common
+  misunderstanding})`
+
+---
+
+### Topic 3: Callers and interfaces
+
+- **Question:** "Who calls this service and through what interfaces (gRPC,
+  REST, events, UI)?"
+- **Intent:** enable breaking-change impact analysis when modifying endpoints,
+  events, or response shapes.
+- **Probes:** Which endpoints/events does each caller consume, and what
+  business flow are they driving? Which fields or response-shape behaviours do
+  they depend on? What would break for them if X changed? Are any consumers
+  uncontrolled (external partners, mobile apps in the wild, third parties)
+  where we cannot ship a coordinated change?
+- **Shape:** `- {service} → consumes {endpoint/event} for {business
+  purpose}; depends on {fields/behaviour}; breaking-change impact: {what
+  fails for them if X changes}`
+
+---
+
+### Topic 4: External dependencies
+
+- **Question:** "What external systems does this depend on (databases, caches,
+  queues, third-party APIs)?"
+- **Intent:** anticipate failure modes, mock boundaries correctly in tests,
+  and assess blast radius of dependency changes.
+- **Probes:** Which dependencies have SLAs or rate limits that affect this
+  service? Which ones have caused outages? Are there dependencies that look
+  optional but are actually critical-path?
+- **Shape:** `- {dependency} via {protocol} — {what this service uses it
+  for}; failure mode: {what happens when it is down}; constraint: {rate
+  limit, SLA, quirk}`
+
+---
+
+### Topic 5: Domain concepts
+
+- **Question:** "What are the key domain concepts an AI agent must understand
+  to work here?"
+- **Intent:** use correct terminology in code, comments, and commit messages,
+  and recognise when a change affects a domain concept's semantics.
+- **Probes:** What terms do new engineers consistently misunderstand? Are
+  there concepts that have different meanings in different parts of the
+  codebase? What domain rules are enforced in code vs. by convention?
+- **Shape:** `- {term}: {definition in this context} — not {common
+  confusion}; enforced by {code/convention/both}`
+
+---
+
+### Topic 6: Invariants
+
+- **Question:** "What business rules or invariants must never be violated?"
+- **Intent:** recognise when a proposed change would violate a hard
+  constraint, and write assertions or tests that protect invariants.
+- **Probes:** What business rules can never be broken? What schema constraints
+  or ordering guarantees exist? What idempotency expectations do callers
+  have? What would cause data corruption if violated?
+- **Shape:** `- {invariant}: {what must hold}; enforced by {mechanism};
+  violation consequence: {what breaks}`
+
+---
+
+### Topic 7: Gotchas
+
+- **Question:** "What non-obvious quirks, dead code, or surprising behaviours
+  exist?"
+- **Intent:** avoid known footguns and understand why code looks the way it
+  does when the reason is not obvious from the code itself.
+- **Probes:** What has tripped up new engineers? Is there dead code or
+  deprecated paths that look active? Are there flaky tests or known fragile
+  areas? What historical decisions look wrong but are intentional?
+- **Shape:** `- {gotcha}: {what it looks like} vs. {what is actually
+  happening}; consequence of getting it wrong: {impact}`
+
+---
+
+### Topic 8: Operational profile
+
+- **Question:** "What is the traffic/load profile, latency targets, and
+  alerting setup?"
+- **Intent:** make informed decisions about performance trade-offs, caching
+  strategies, and deployment safety.
+- **Probes:** What is the traffic shape (steady, bursty, time-of-day)? What
+  is the deployment cadence and strategy (blue-green, canary, feature flags)?
+  What resource constraints exist? What scaling limits have been hit?
+- **Shape:** `- {dimension}: {current profile}; constraint: {limit or
+  bottleneck}; decision it changes: {what an agent should do differently
+  because of this}`
+
+---
+
+### Topic 9: Test notes
+
+- **Question:** "What does an engineer need to know to run tests (setup,
+  fixtures, environments)?"
+- **Intent:** run the right tests after a change and understand which test
+  failures are signal vs. noise.
+- **Probes:** What test commands cover what scope? Are there tests that are
+  slow, flaky, or require special setup? What areas lack test coverage and
+  why?
+- **Shape:** `- {test tier}: {command}; covers {scope}; known gaps: {what is
+  not tested and why}; flaky: {yes/no and what to do}`
+
+---
+
+### Topic 10: Repository structure
+
+- **Question:** "How is the codebase organised (key directories, build
+  targets, generated code)?"
+- **Intent:** find the right place to make a change and follow existing
+  patterns when adding new code.
+- **Probes:** What is the organising principle (by domain, by layer, by
+  feature)? Where do new files go? Are there directories that look like they
+  serve one purpose but actually serve another?
+- **Shape:** `- {directory}: {what it contains and why it is separate};
+  pattern: {convention for adding new files here}`
+
+---
+
+## Stage 5 — Merge answers
+
+After all topics have been interviewed, merge the confirmed answers back
+into `CLAUDE.local.md`.
+
+### Merge semantics
+
+- **Thin** topics: replace the entire H3 block (heading + all bullets) with
+  the new confirmed content. Exception: if the engineer skipped the topic,
+  retain existing content unchanged (see skip handling in Stage 4).
+- **Absent** topics: insert the new H3 block at its canonical position
+  within the `## Repository context` section. Exception: if the engineer
+  skipped the topic, do not write the heading.
+- **Present** topics: skip — not interviewed, not touched.
+
+### Canonical position insertion
+
+When inserting an absent topic, place it at its canonical position relative
+to the other headings in the section. Use the canonical order (1-10) defined
+in Stage 2. The new heading goes after the last heading that precedes it in
+canonical order, or at the start of the section if no preceding heading
+exists.
+
+Use an inline `python3` script for deterministic merge operations:
+normalising headings, locating insertion points, and replacing blocks. The
+script computes the new file content and emits it to stdout; capture the
+output and persist it with the `Write` tool. This keeps the deterministic
+transform in Python while keeping the side-effect on a tool the harness
+tracks. Do not write the file from within the Python script itself.
+
+### Section creation
+
+If `## Repository context` was absent from the file, append it to the end
+of `CLAUDE.local.md`. Ensure a blank line separates existing content from
+the new section heading. Write all confirmed topics under this heading in
+canonical order.
+
+### Content format
+
+Each topic is an H3 heading followed by declarative bullets. No prose
+paragraphs. Each bullet starts with `- `. Strip the `[inferred]` prefix
+from any bullet the engineer confirmed or replaced.
+
+Persist the merged content using the `Write` tool (the content was already
+computed by the `python3` script above).
+
+---
+
+## Stage 6 — Report
+
+After merging, present a summary to the engineer:
+
+> **Update complete.** `CLAUDE.local.md` has been updated.
+>
+> Topics updated: {list of topics that were written or replaced}
+> Topics skipped by engineer: {list, or "none"}
+> Topics already present: {list, or "none"}
+>
+> Review `CLAUDE.local.md` to confirm the changes.
+
+---
+
+## Rules
+
+- **`CLAUDE.local.md` must exist.** If it does not, display the error
+  message and stop. Do not create the file — that is the responsibility of
+  `init-claude-standards`.
+- **Interview only thin and absent topics.** Present topics are never
+  interviewed or modified.
+- **Present the gap summary before interviewing.** The engineer must see the
+  full classification before answering questions.
+- **Ask one topic at a time.** Wait for the engineer's response before
+  moving to the next topic. Do not batch multiple topics into a single
+  question, even when many topics are absent — batching produces shallow
+  answers.
+- **NEVER verify claims against the codebase.** The interview is
+  collaborative. Accept the engineer's answers as authoritative. Do not
+  cross-check code and challenge disagreements — this is an explicit
+  anti-pattern. Do not reframe verification as "clarifying", "helping
+  with accuracy", or "just checking" — these are verification under a
+  different name.
+- **Canonical order is maintained on write.** Inserted topics go at their
+  canonical position, not appended to the end of the section.
+- **Use `python3` for deterministic text operations.** H3 normalisation,
+  bullet counting, marker matching, and canonical-position insertion must
+  use inline `python3` scripts, not in-context string manipulation.
+  This applies regardless of perceived simplicity — even a file with two
+  headings must be classified via script, not in-context reasoning.
+- **Preserve content outside `## Repository context`.** All existing content
+  above and below the section remains untouched.
+- **UK English throughout.** All human-readable text in prompts and output
+  uses UK English spelling.
+- **Skip handling is context-dependent.** Absent + skip = omit. Thin +
+  skip with `[inferred]` bullets = retain unchanged. Thin + skip with
+  non-inferred content = retain unchanged.
+- **Empty topics are omitted.** Never write a heading with no bullets
+  beneath it.
+- **Do not modify any file other than `CLAUDE.local.md`.** This skill does
+  not touch `CLAUDE.md`, `bin/bundle`, or files under `standards/`.

--- a/.claude/skills/fix-buildkite/SKILL.md
+++ b/.claude/skills/fix-buildkite/SKILL.md
@@ -1,0 +1,621 @@
+---
+name: fix-buildkite
+description: You MUST use this when the user asks to diagnose, fix, or retry failed Buildkite CI builds.
+model: claude-opus-4-8
+allowed-tools:
+  - Agent
+  - Bash
+  - Read
+  - Write
+---
+
+You are the orchestrator for the `fix-buildkite` skill. You receive a single
+argument: a Buildkite build URL or bare build number. You do not write code or
+post comments yourself — you brief sub-agents and orchestrate results.
+
+---
+
+## Input
+
+The build input is the first argument passed to this skill. It must be either:
+
+- A full Buildkite build URL (e.g.
+  `https://buildkite.com/org/pipeline/builds/123`)
+- A bare build number (digits only, e.g. `123`)
+
+If no argument was provided or the value is neither a valid URL nor digits-only,
+stop:
+
+> fix-buildkite requires a Buildkite build URL or build number as its argument
+> (e.g. `/fix-buildkite https://buildkite.com/org/pipeline/builds/123` or
+> `/fix-buildkite 123`).
+
+Let `BUILD_INPUT` = the supplied argument for all subsequent steps.
+
+### Parse the build input
+
+**If `BUILD_INPUT` is a full URL:**
+
+1. Strip any query parameters (everything from `?` onward).
+2. Extract `ORG`, `PIPELINE`, and `BUILD_NUMBER` from the path. The URL may
+   contain trailing path segments after the build number (e.g. `/canvas`,
+   `/waterfall`) — ignore everything after `BUILD_NUMBER`:
+   `https://buildkite.com/{ORG}/{PIPELINE}/builds/{BUILD_NUMBER}[/...]`
+3. If the URL does not match this pattern, stop:
+   > Could not parse Buildkite URL: `{BUILD_INPUT}`. Expected format:
+   > `https://buildkite.com/org/pipeline/builds/123`
+
+**If `BUILD_INPUT` is a bare build number (digits only):**
+
+1. **Get the Buildkite org** by calling `user_token_organization` via MCP. This
+   returns the org slug (e.g. `tego`) associated with the user's token. Set
+   `ORG` to the returned value.
+
+   If `user_token_organization` fails, stop:
+
+   > Could not determine Buildkite organisation from your token.
+   > Please provide a full Buildkite URL instead
+   > (e.g. `https://buildkite.com/org/pipeline/builds/123`).
+
+2. **Get the repo name** from the git remote:
+
+   ```bash
+   git remote get-url origin
+   ```
+
+   Extract the **repo name only** (not the org) from the remote URL: strip any
+   scheme, host, and org prefix, strip a trailing `.git` suffix if present, and
+   lower-case the result. For example, all of these produce `repo`:
+
+   - `git@github.com:Zegocover/Repo.git` → `repo`
+   - `https://github.com/Zegocover/Repo.git` → `repo`
+   - `https://github.com/Zegocover/Repo` → `repo`
+
+3. **Find the pipeline** by calling `get_pipeline` via MCP with `org_slug` set
+   to `ORG` and `pipeline_slug` set to the repo name. Buildkite pipeline slugs
+   typically match the repository name. If `get_pipeline` succeeds, set
+   `PIPELINE` to the repo name. If it fails (404 / not found), stop:
+
+   > Could not find pipeline `{repo_name}` in org `{ORG}`.
+   > Please provide a full Buildkite URL instead
+   > (e.g. `https://buildkite.com/org/pipeline/builds/123`).
+
+Set `BUILD_NUMBER` = `BUILD_INPUT`.
+
+---
+
+## Gate 1 — Triage
+
+### Stage 1 — Fetch failed jobs and extract error context
+
+Call `get_build` via MCP with `ORG`, `PIPELINE`, and `BUILD_NUMBER`.
+
+**If the `get_build` call fails because the Buildkite MCP server is not
+installed or not reachable**, stop:
+
+> The Buildkite MCP server is not available. Install it with:
+>
+> ```
+> claude mcp add --transport http buildkite https://mcp.buildkite.com/mcp
+> ```
+>
+> Then re-run this skill.
+
+**If `get_build` succeeds but the build has no failed jobs**, report:
+
+> No failed jobs found in build #{BUILD_NUMBER}. Nothing to fix.
+
+Then exit cleanly.
+
+**If `get_build` returns failed jobs**, collect each failed job into a list.
+For each failed job:
+
+1. Record `job_id`, `job_name`, `exit_status`, and `state`.
+2. Call `tail_logs` via MCP to get the last portion of the job log.
+3. Call `search_logs` via MCP with relevant error patterns (e.g. `error`,
+   `FAILED`, `Exception`, `assert`) to extract targeted error context.
+4. Store the combined error context for each job as `error_context`.
+
+If a `tail_logs` or `search_logs` call fails for a specific job, record the
+error for that job and continue with remaining jobs. Do not stop the skill.
+
+---
+
+### Stage 2 — Classify failures
+
+Read each failed job's `error_context` and classify it using these rules:
+
+| Classification | Apply when |
+|----------------|------------|
+| `code-error`   | The failure is caused by a bug, type error, missing import, logic error, or other issue in the application or test code that requires a code change to fix |
+| `flaky-test`   | The failure appears to be a flaky or intermittent test — signals: timeout with no code change, non-deterministic assertion, network/service dependency failure in tests, "retry" or "flaky" in the test name or log |
+| `infra-error`  | The failure is caused by infrastructure — signals: Docker pull failure, agent disconnected, out of disk/memory, dependency installation failure, build agent timeout, permission denied on CI resources |
+
+For each entry, also write a one-line reason for the classification.
+
+---
+
+### Stage 3 — Present triage plan and confirm
+
+Present the classification plan as a table:
+
+```
+Build #{BUILD_NUMBER} — {N} failed job(s)
+
+| # | Job Name            | Exit Status | Classification | Reason                          |
+|---|---------------------|-------------|----------------|---------------------------------|
+| 1 | {job_name}          | {exit}      | code-error     | {one-line reason}               |
+| 2 | {job_name}          | {exit}      | flaky-test     | {one-line reason}               |
+| 3 | {job_name}          | {exit}      | infra-error    | {one-line reason}               |
+| ...
+
+Code errors to fix: {count code-error}
+Flaky tests to retry: {count flaky-test}
+Infra errors to skip: {count infra-error}
+
+Shall I proceed? You can override any classification before I start
+(e.g. "change job 2 to code-error — this is a real test failure").
+```
+
+**Wait for the developer's response.** Apply any overrides to the plan. The
+confirmed plan is authoritative for all subsequent stages.
+
+**`infra-error` entries are excluded from all further processing.** After
+confirmation, if any `infra-error` entries exist, report:
+
+> Skipping {count} infra-error job(s) — please raise an issue for:
+> {list each infra-error job name, one per line}
+
+If all entries are `infra-error` after confirmation, skip Gate 2 and Gate 3
+entirely — proceed directly to Stage 11 (summary). No code changes or commits
+are needed.
+
+If there are no `code-error` entries after confirmation (only `flaky-test` and
+`infra-error`), Gate 2 will handle retries and skip the implement flow.
+
+---
+
+## Gate 2 — Act
+
+### Stage 4 — Retry flaky-test entries
+
+For each `flaky-test` entry, call `retry_job` via MCP with the job's `job_id`.
+
+If a `retry_job` call fails for a specific job, record the error for that job
+(do not stop the skill) and surface it:
+
+> retry_job failed for "{job_name}": {error message}
+
+After all retries are attempted, report a summary:
+
+```
+Flaky-test retries:
+| # | Job Name            | Retry Result |
+|---|---------------------|--------------|
+| 1 | {job_name}          | retried      |
+| 2 | {job_name}          | retry-failed |
+```
+
+**If no `code-error` entries remain** (all failures were `flaky-test` or
+`infra-error`), skip the implement flow entirely and proceed to Stage 11
+(summary). No commit is needed.
+
+---
+
+### Stage 5 — Spawn fixer sub-agents (all code-error entries)
+
+Fix all `code-error` entries first, then run a single review cycle. Track a
+per-entry result. Initialise `iteration = 1` for the gate.
+
+For each `code-error` entry in sequence:
+
+**If `iteration = 1`**, send a fixer sub-agent with this brief:
+
+```
+You are fixing a CI failure from a Buildkite build.
+Do not ask questions — diagnose the error and make the targeted fix described
+below, then return.
+
+Failed job: {job_name}
+Exit status: {exit_status}
+
+Error context from build logs:
+---
+{error_context}
+---
+
+Read the error context carefully. Identify the failing file(s) and location(s)
+from the error messages, stack traces, and test output. Make the minimal code
+change needed to fix the failure.
+
+Scope constraint: limit all changes to the scope of the error above. Do not
+refactor surrounding code, add unrelated tests, or change any file not directly
+implicated by the failure. Stay as narrow as possible.
+
+After making the change, return:
+1. A brief description of what you changed (one or two sentences).
+2. The file(s) modified.
+3. Whether any files were modified (yes/no).
+```
+
+**If `iteration > 1`**: only process entries that have pending blocker or major
+findings from the most recent review. For each such entry, read the most recent
+findings file. Each finding is a markdown block headed
+`### F{n} — {severity} — {file}:{line}` with `- outcome: pending` beneath it.
+Extract every finding where outcome is `pending` AND severity is `blocker` or
+`major` AND the finding's file path was touched by this entry's original fix.
+Format each as:
+
+```
+F{n} ({severity}) — {file}:{line} — {issue} — Suggestion: {suggestion}
+```
+
+Then send a fixer sub-agent with this brief:
+
+```
+You are fixing a CI failure from a Buildkite build. A previous attempt failed
+review. Address the findings listed below in addition to the original error.
+
+Failed job: {job_name}
+Exit status: {exit_status}
+
+Error context from build logs:
+---
+{error_context}
+---
+
+Scope constraint: limit all changes to the scope of the error and the findings
+below. Do not refactor surrounding code or change any file not directly
+implicated.
+
+Previous attempt failed — address these findings:
+{formatted F{n} lines, one per line}
+
+After making the change, return:
+1. A brief description of what you changed (one or two sentences).
+2. The file(s) modified.
+3. Whether any files were modified (yes/no).
+```
+
+After each fixer returns, run the three-part diff check:
+
+```bash
+git diff HEAD
+git diff --cached
+git status --porcelain
+```
+
+If all three are empty, record result `skipped-no-changes` for that entry.
+Otherwise record `changes-made`. Continue to the next entry.
+
+---
+
+### Stage 6 — Spawn single review sub-agent
+
+After all fixer agents have run, if every entry recorded `skipped-no-changes`,
+proceed directly to Stage 11 (summary) with those results — there are no changes
+to commit, validate, or push, so Gate 3 is skipped entirely.
+
+Otherwise, derive `ticket` and `branch` from the current git branch:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+Parse the branch name against `^([A-Z][A-Z0-9]*-[0-9]+)[_-](.+)$`:
+- Group 1 → `ticket`
+- Group 2 → description slug
+
+Locate the task spec:
+
+```bash
+rg -l "^ticket: {ticket}$" docs/tasks/ 2>/dev/null | head -1
+```
+
+Locate the design docs (run only when the task spec was found; capture all
+matches):
+
+```bash
+rg -l "^JIRA: {ticket}$" docs/design/ 2>/dev/null
+```
+
+Store the task spec path as `TASK_SPEC_PATH` and all returned design doc paths
+as `DESIGN_DOC_PATHS` (a list; empty if none found).
+
+Spawn a fresh Agent with this brief (fill every placeholder; omit the design
+doc line entirely if `DESIGN_DOC_PATHS` is empty):
+
+```
+You are running the `review` skill.
+Read `.claude/skills/review/SKILL.md` and execute it from Stage 1.
+Do not ask questions — all context is below.
+
+Ticket: {ticket}
+Branch: {branch}
+
+The diff contains fixes for {N} Buildkite CI failures.
+Group E will check it against the task spec at {TASK_SPEC_PATH}.
+
+{If DESIGN_DOC_PATHS has one entry:}
+A design doc for this ticket exists at {DESIGN_DOC_PATHS[0]} — Group E will load it.
+
+{If DESIGN_DOC_PATHS has more than one entry:}
+Design docs for this ticket exist at: {DESIGN_DOC_PATHS list, one path per line} — Group E will load all of them.
+```
+
+Wait for the review agent to return the verdict string (`PASS` or `FAIL`) and
+the findings file path.
+
+If the review agent errors out, exceeds context, or returns a verdict string
+that is not exactly `PASS` or `FAIL`, treat this as a **malformed verdict**.
+
+---
+
+### Stage 7 — Act on verdict
+
+**PASS**: record result `pass` for all entries that had `changes-made`. Proceed
+to Stage 8.
+
+**FAIL and iteration < 3**: increment `iteration`. Map each pending
+blocker/major finding back to the entry whose fix introduced it (by matching
+the finding's file path to the files each entry touched). Return to Stage 5
+for entries with mapped findings.
+
+**FAIL and iteration = 3** (max iterations reached): record
+`failed-max-iterations` for entries with remaining pending blocker/major
+findings. Surface a summary:
+
+> Gate 2 — max iterations reached.
+> Remaining findings:
+>
+> {findings list — one line per pending blocker/major, with entry reference}
+>
+> Findings file: {path}
+
+Proceed to Stage 8.
+
+**Malformed or missing verdict**: the review agent returned something other
+than `PASS` or `FAIL` (e.g. an exception trace, a qualified verdict like
+"PASS (with caveats)", or no output at all). Do **not** retry the review.
+Record result `review-error` for all entries that had `changes-made`. Surface
+the raw review output to the developer:
+
+> Gate 2 — review returned a malformed verdict. Treating as FAIL with no
+> actionable findings. The loop will not retry.
+>
+> Raw review output (truncated to first 40 lines):
+>
+> {raw output}
+
+Proceed to Stage 8.
+
+---
+
+## Gate 3 — Commit, validate, and push
+
+### Stage 8 — Commit fixer work
+
+After the review passes (or max iterations is reached), present a summary.
+
+```
+Gate 2 complete — committing fixer work.
+
+| # | Job Name            | Classification | Result                  |
+|---|---------------------|----------------|-------------------------|
+| 1 | {job_name}          | code-error     | pass                    |
+| 2 | {job_name}          | code-error     | skipped-no-changes      |
+| 3 | {job_name}          | flaky-test     | retried                 |
+| 4 | {job_name}          | infra-error    | skipped                 |
+| 5 | {job_name}          | code-error     | failed-max-iterations   |
+```
+
+Proceed immediately (no developer prompt). Derive `ticket` from the current git
+branch (same parse as Stage 6).
+
+Commit all staged and unstaged changes from the fixer agents, plus the review
+findings file produced by Stage 6 (when one exists):
+
+```bash
+git add {files that were changed}
+# Only include the findings file if Stage 6 actually ran (i.e. at least one
+# entry recorded `changes-made` and a findings file was produced).
+git add {findings file path from Stage 6}   # omit this line when Stage 6 was skipped
+git commit -m "{ticket}: Fix Buildkite CI failures (build #{BUILD_NUMBER})
+
+{one-line summary per code-error entry whose diff is included in this commit,
+prefixed with - . Include entries with result `pass` or `failed-max-iterations`,
+but not `skipped-no-changes`. For `failed-max-iterations` entries, append
+' (review did not pass — fix incomplete)' to the summary line.}"
+```
+
+---
+
+### Stage 9 — CI validation and fix loop
+
+Determine whether CI validation should run. The skip predicate is: **at least
+one `code-error` entry recorded `changes-made` or `failed-max-iterations`**.
+
+- If no `code-error` entries exist (all failures were `flaky-test` or
+  `infra-error`), skip CI validation entirely and proceed to Stage 11 (summary).
+- If every `code-error` entry recorded `skipped-no-changes`, skip CI validation
+  entirely and proceed to Stage 11 (summary).
+- If at least one `code-error` entry recorded `changes-made` or
+  `failed-max-iterations` (including entries where the review did not pass but
+  partial changes were committed), run CI validation.
+
+**Note on `failed-max-iterations` entries:** These have partial fixer changes
+that are committed but did not pass the Gate 2 review. CI validation still runs
+on these changes — the code is being pushed regardless, so it should still pass
+CI where possible. If CI validation also fails for these entries, the developer
+is informed via the proceed/stop prompt and can decide whether to push.
+
+**Read `.claude/skills/shared/ci-validation-loop.md` and execute Steps 1, 2,
+3 defined there.** That document contains the sub-agent prompts, verdict
+handling, per-cycle commit flow, and fixer agent instructions for this stage.
+
+Fill the placeholders as follows before executing:
+
+| Placeholder | Value |
+|-------------|-------|
+| `{ticket}` | the ticket value derived in Stage 6 |
+| `{branch}` | the branch value derived in Stage 6 |
+| `{changed file(s)}` | all files changed by the fixer agents in Stage 5 |
+| `{task-nn}` | omit — not applicable to fix-buildkite |
+
+CI validation commit messages use the format:
+`{ticket}: CI validation cycle {N} — {PASS|FAIL}`
+
+**On `verdict: passed`:** proceed to Stage 10 (push).
+
+**On `verdict: failed-max-iterations`:** **check for the
+`precondition: authentication` marker line FIRST**, before surfacing the
+proceed/stop choice. The two branches below are mutually exclusive; the auth
+branch is checked first.
+
+**If the return carries the `precondition: authentication` marker (auth branch):**
+emit the reply-continue affordance and end the turn:
+
+> CI validation hit an authentication precondition — an environment problem, not a code failure, so the fix loop stopped without churning the fixer.
+>
+> Remediation: {remediation path from the marker}.
+>
+> Authenticate, then reply `continue` and I will re-run CI validation from the top.
+
+**Wait for the developer's `continue` reply.** On reply, RE-RUN the entire CI
+loop — a fresh invocation of `skills/shared/ci-validation-loop.md` Steps 1–3
+with the iteration counter starting at 1 (the auth short-circuit consumed no
+iteration budget, so the fresh loop begins at iteration 1). This re-run logic
+lives here in the caller, never in `ci-validation-loop.md`.
+
+**If the return does NOT carry the marker (real code failure — existing behaviour, unchanged):** surface the failure to the developer:
+
+> CI validation failed after 5 fix attempts.
+>
+> Failing command: `{command}`
+> Most recent output is above.
+>
+> Options:
+> 1. **Proceed** — push despite the CI failure.
+> 2. **Stop** — do not push. Resolve the failure manually.
+>
+> Each cycle's state is preserved as a commit; inspect `git log` to walk
+> the iteration history.
+
+**Wait for the developer's response.**
+
+- If the developer chooses **Proceed**, continue to Stage 10 (push).
+- If the developer chooses **Stop**, halt the skill. The fixer work and up to 5
+  CI validation cycle commits are already in your local history (see `git log`).
+  Stopping here leaves them committed locally but unpushed — review the log
+  before any subsequent `git push`.
+
+---
+
+### Stage 10 — Push
+
+Push the branch:
+
+```bash
+git push
+```
+
+If `git push` fails, surface the error verbatim. Do not retry automatically.
+
+---
+
+### Stage 11 — Summary
+
+Report:
+
+```
+fix-buildkite — build #{BUILD_NUMBER} complete.
+
+| # | Job Name            | Classification | Result                  |
+|---|---------------------|----------------|-------------------------|
+| 1 | {job_name}          | code-error     | pass                    |
+| 2 | {job_name}          | flaky-test     | retried                 |
+| 3 | {job_name}          | infra-error    | skipped                 |
+| ...
+
+Code errors fixed: {count}
+Flaky tests retried: {count}
+Infra errors skipped: {count}  (raise an issue for these)
+Skipped (no changes): {count}
+Failed (max iterations): {count}  {list findings file paths if any}
+Failed (retry): {count}
+
+CI validation: passed (after {N} cycle(s)) | failed (overridden by developer) | skipped
+```
+
+---
+
+## Rules
+
+- **One mandatory confirmation, one conditional choice.** The triage gate
+  (Stage 3) requires explicit developer confirmation before proceeding. There is
+  no pre-commit confirmation gate — the skill commits immediately after the
+  review verdict. If CI validation fails after max iterations (Stage 9), the
+  developer is given a proceed/stop choice.
+- **Developer overrides are final.** Do not re-assert the AI's original
+  classification after the developer changes it.
+- **Sequential fixers, single review.** Run fixer agents for all `code-error`
+  entries sequentially, then spawn one review agent for the combined diff. Do
+  not interleave fix and review cycles per entry.
+- **Fresh review agent every iteration.** Never reuse a review agent across
+  iterations.
+- **Fixer scope is narrow.** The fixer brief must include the full error context,
+  job name, and exit status, and must instruct the agent to limit changes to
+  the scope of the error. Do not refactor, add unrelated tests, or change files
+  not implicated by the failure.
+- **Three-part empty-diff check.** Use `git diff HEAD`, `git diff --cached`,
+  and `git status --porcelain`. All three must be empty before recording
+  `skipped-no-changes`.
+- **Anchored ticket regex.** Use `^ticket: {ticket}$` — not a prefix match.
+- **Commit fixer work before CI validation. The confirm-before-commit gate is
+  removed — show the summary table but proceed without waiting.**
+- **CI validation runs after commit, before push. Max 5 iterations, separate
+  counter from the Gate 2 review loop (max 3).**
+- **Spawn the CI validation agent from step 1 in a fresh message each
+  iteration.**
+- **The CI fixer in step 3 applies minimal fixes only.**
+- **CI validation failure after max iterations gives the developer a choice:
+  proceed or stop.**
+- **An auth precondition is checked before the proceed/stop choice.** On
+  `failed-max-iterations`, check for the `precondition: authentication` marker
+  line FIRST. Present → emit "authenticate, then reply `continue`" and, on the
+  reply, re-run the whole CI loop from iteration 1. Absent → the existing
+  proceed/stop choice is unchanged.
+- **Skip CI validation when no code-error entries recorded changes-made or
+  failed-max-iterations.**
+- **Push before reporting.** Push in Stage 10, then report in Stage 11. Never
+  report a commit SHA before that commit is on the remote.
+- **Max 3 gate iterations** — not 5. Each iteration fixes all entries with
+  pending findings and re-reviews the combined diff.
+- **`infra-error` entries are skipped from all processing after triage.** They
+  never enter the implement flow or the retry flow. The developer is told to
+  raise an issue.
+- **MCP unavailability is detected on the first `get_build` call.** Do not add
+  a separate preliminary MCP check. If the call fails due to the MCP not being
+  installed, surface the install command and stop.
+- **MCP call failures mid-flow are per-job.** If `retry_job` or a log-fetching
+  call fails for one job, record the error for that job and continue with
+  remaining jobs. Do not stop the skill.
+- **Do not open a PR.** The skill commits, pushes, and reports. PR creation is
+  done manually or via `create-pr`.
+- **Do not post replies or resolve threads.** This is not `fix-pr-comments`.
+- **Do not re-trigger the full Buildkite build.** The developer decides when to
+  re-run the pipeline.
+- **Do not silently drop edge cases.** Every entry must produce a recorded
+  result in the Stage 11 summary.
+- **All failures are flaky-test: retry all, skip implement flow, go straight to
+  summary.** No commit is needed.
+- **All failures are infra-error: skip all, report summary, suggest raising
+  issues.** No commit, no implement flow.
+- **Mixed classifications after developer overrides: re-check whether any
+  `code-error` entries remain** before entering the implement flow.
+- **Build URL with query params or trailing path segments: strip before
+  parsing.** URLs may include suffixes like `/canvas` or `/waterfall` after the
+  build number — ignore everything after the build number.
+- **Bare-build-number path uses `user_token_organization` + `get_pipeline`.**
+  Get the Buildkite org from the user's token, extract the repo name from the
+  git remote, and call `get_pipeline` directly. One call, no pagination.

--- a/.claude/skills/fix-pr-comments/SKILL.md
+++ b/.claude/skills/fix-pr-comments/SKILL.md
@@ -1,0 +1,773 @@
+---
+name: fix-pr-comments
+description: You MUST use this when the user asks to address or fix unresolved review threads on a pull request.
+model: claude-opus-4-8
+allowed-tools:
+  - Agent
+  - Bash
+  - Read
+  - Write
+---
+
+You are the orchestrator for the `fix-pr-comments` skill. You receive a single
+argument: a PR number (integer). You do not write code or post comments
+yourself — you brief sub-agents and orchestrate results.
+
+---
+
+## Input
+
+The PR number is the first argument passed to this skill. It must be a positive
+integer. If no argument was provided or the value is not digits-only, stop:
+
+> fix-pr-comments requires a PR number as its argument (e.g. /fix-pr-comments 42).
+
+Let `PR_NUM` = the supplied PR number for all subsequent steps.
+
+---
+
+## Gate 1 — Triage
+
+### Stage 1 — Fetch unresolved threads and comments
+
+Run:
+
+```bash
+.claude/scripts/pr-comments.sh <PR_NUM>
+```
+
+**If `pr-comments.sh` exits non-zero**: surface the full error output verbatim
+and stop the skill.
+
+**If `pr-comments.sh` returns `[]`**: report:
+
+> No unresolved review threads or comments on PR #<PR_NUM>.
+
+Then exit cleanly.
+
+**If `pr-comments.sh` returns a non-empty array**: parse it into comment
+objects. Each object has a `type` field that determines which other fields are
+present:
+
+| Field        | `review_thread`                                                     | `top_level_comment`                          | `review_body`                                |
+|--------------|---------------------------------------------------------------------|----------------------------------------------|----------------------------------------------|
+| `type`       | `"review_thread"`                                                   | `"top_level_comment"`                        | `"review_body"`                              |
+| `thread_id`  | GraphQL node ID — pass verbatim to `pr-resolve.sh`                  | *(absent)*                                   | *(absent)*                                   |
+| `comment_id` | REST comment ID — pass verbatim to `pr-reply.sh`                    | REST issue comment ID — used to name the reply scratch file | REST review ID — used to name the reply scratch file |
+| `path`       | File path the thread is anchored to                                 | *(absent)*                                   | *(absent)*                                   |
+| `line`       | Line number the thread is anchored to                               | *(absent)*                                   | *(absent)*                                   |
+| `body`       | Full comment thread (all messages oldest-first, separated by `---`) | Comment body                                 | Review body text                             |
+| `author`     | *(absent)*                                                          | Reviewer login                               | Reviewer login                               |
+
+---
+
+### Stage 2 — Classify comments
+
+Read each entry's `body` and classify it using these rules:
+
+| Classification  | Apply when |
+|-----------------|------------|
+| `will-fix`      | The comment requests a specific, actionable code change that has not yet been made |
+| `question`      | The reviewer is asking for clarification or an explanation — no code change needed |
+| `acknowledged`  | The reviewer is making a suggestion, nit, or raising a concern but not demanding a change (signals: "nit:", "consider:", "minor:", "up to you", "optional") |
+| `skip`          | The comment is clearly already addressed, is out of scope for this branch, or no action is warranted |
+
+**Default classification for `review_body` entries:** classify as `acknowledged`
+unless the body contains a specific, actionable code change request. Review
+bodies are typically high-level summaries ("overall looks good", "a few nits
+below") and rarely warrant direct code changes. Only classify a `review_body`
+as `will-fix` if it contains an explicit, concrete change request.
+
+For each entry, also write a one-line reason for the classification.
+
+---
+
+### Stage 3 — Present triage plan and confirm
+
+Present the classification plan as a table:
+
+```
+PR #<PR_NUM> — <N> unresolved comments
+
+| # | Type                | File:Line           | Classification  | Reason                          |
+|---|---------------------|---------------------|-----------------|---------------------------------|
+| 1 | review_thread       | {path}:{line}       | will-fix        | {one-line reason}               |
+| 2 | review_thread       | {path}:{line}       | question        | {one-line reason}               |
+| 3 | top_level_comment   | (top-level)         | will-fix        | {one-line reason}               |
+| 4 | review_body         | (review body)       | acknowledged    | {one-line reason}               |
+| …
+
+Comments to implement: {count will-fix}
+Comments to reply only: {count question + acknowledged + skip}
+
+Shall I proceed? You can override any classification before I start
+(e.g. "change comment 2 to acknowledged — we addressed this in a previous PR").
+```
+
+Display rules for the File:Line column:
+- `review_thread`: show `{path}:{line}`
+- `top_level_comment`: show `(top-level)`
+- `review_body`: show `(review body)`
+
+**Wait for the developer's response.** Apply any overrides to the plan. The
+confirmed plan is authoritative for all subsequent stages.
+
+If there are no `will-fix` entries after confirmation, skip Gate 2 and proceed
+directly to Gate 3.
+
+---
+
+## Gate 2 — Implement
+
+Fix all `will-fix` entries first, then run a single review cycle. Track a
+per-entry result. Initialise `iteration = 1` for the gate.
+
+---
+
+### Stage 4 — Spawn fixer sub-agents (all will-fix entries)
+
+For each `will-fix` entry in sequence:
+
+**If `iteration = 1`**, determine the agent brief based on type:
+
+**For `review_thread` entries** (have `path` and `line`), send:
+
+```
+You are fixing a specific issue raised in a PR review thread.
+Do not ask questions — make the targeted change described below and return.
+
+Review thread (all comments oldest-first, separated by ---):
+---
+{entry.body}
+---
+
+If the thread contains multiple comments, treat the conversation as a whole.
+The last message is the most recent instruction; earlier messages provide
+context and may have been amended or retracted.
+
+File to change: {entry.path}
+Line: {entry.line}
+
+Scope constraint: limit all changes to the scope of the reviewer's comment
+above. Do not refactor surrounding code, add tests, or change any file not
+directly implicated by the comment. If the fix requires touching more than the
+named file, explain why in your return message, but still stay as narrow as
+possible.
+
+After making the change, return:
+1. A brief description of what you changed (one or two sentences).
+2. Whether any files were modified (yes/no).
+```
+
+**For `top_level_comment` and `review_body` entries** (no `path` or `line`),
+send:
+
+```
+You are fixing a specific issue raised in a PR comment.
+Do not ask questions — make the targeted change described below and return.
+
+Comment body:
+---
+{entry.body}
+---
+
+This comment is not anchored to a specific file or line. Read the comment
+carefully and identify the relevant file(s) and location(s) from the context
+of the comment and the current branch diff. Use `git diff HEAD~1` or read
+the files mentioned or implied by the comment to determine where to apply
+the change.
+
+Scope constraint: limit all changes to the scope of the reviewer's comment
+above. Do not refactor surrounding code, add tests, or change any file not
+directly implicated by the comment. Stay as narrow as possible.
+
+After making the change, return:
+1. A brief description of what you changed (one or two sentences).
+2. Whether any files were modified (yes/no).
+```
+
+**If `iteration > 1`**: only process entries that have pending blocker or major
+findings from the most recent review. For each such entry, read the most recent
+findings file. Each finding is a markdown block headed
+`### F{n} — {severity} — {file}:{line}` with `- outcome: pending` beneath it.
+Extract every finding where outcome is `pending` AND severity is `blocker` or
+`major` AND the finding's file path was touched by this entry's original fix.
+Format each as:
+
+```
+F{n} ({severity}) — {file}:{line} — {issue} — Suggestion: {suggestion}
+```
+
+Then determine the agent brief based on type:
+
+**For `review_thread` entries** (have `path` and `line`), send:
+
+```
+You are fixing a specific issue raised in a PR review thread. A previous
+attempt failed review. Address the findings listed below in addition to
+the original comment.
+
+Review thread (all comments oldest-first, separated by ---):
+---
+{entry.body}
+---
+
+File to change: {entry.path}
+Line: {entry.line}
+
+Scope constraint: limit all changes to the scope of the reviewer's comment
+and the findings below. Do not refactor surrounding code or change any file
+not directly implicated.
+
+Previous attempt failed — address these findings:
+{formatted F{n} lines, one per line}
+
+After making the change, return:
+1. A brief description of what you changed.
+2. Whether any files were modified (yes/no).
+```
+
+**For `top_level_comment` and `review_body` entries** (no `path` or `line`),
+send:
+
+```
+You are fixing a specific issue raised in a PR comment. A previous
+attempt failed review. Address the findings listed below in addition to
+the original comment.
+
+Comment body:
+---
+{entry.body}
+---
+
+This comment is not anchored to a specific file or line. Identify the
+relevant file(s) from the comment context and the findings below.
+
+Scope constraint: limit all changes to the scope of the reviewer's comment
+and the findings below. Do not refactor surrounding code or change any file
+not directly implicated.
+
+Previous attempt failed — address these findings:
+{formatted F{n} lines, one per line}
+
+After making the change, return:
+1. A brief description of what you changed.
+2. Whether any files were modified (yes/no).
+```
+
+After each fixer returns, run the three-part diff check:
+
+```bash
+git diff HEAD
+git diff --cached
+git status --porcelain
+```
+
+If all three are empty, record result `skipped-no-changes` for that entry.
+Otherwise record `changes-made`. Continue to the next entry.
+
+---
+
+### Stage 5 — Spawn single review sub-agent
+
+**Skip predicate (used by Stages 5, 7, 8, and 9):** at least one `will-fix`
+entry must have recorded `changes-made`. If every entry recorded
+`skipped-no-changes`, no code was changed and there is nothing to review,
+commit, validate, or push. This predicate is evaluated once after Stage 4 and
+governs the review spawn here, the commit in Stage 7, the CI validation in
+Stage 8, and the push in Stage 9.
+
+After all fixer agents have run, if the skip predicate is false (every entry
+recorded `skipped-no-changes`), proceed directly to Stage 10 with those results.
+
+Otherwise, derive `ticket` and `branch` from the current git branch:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+Parse the branch name against `^([A-Z][A-Z0-9]*-[0-9]+)[_-](.+)$`:
+- Group 1 → `ticket`
+- Group 2 → description slug
+
+Locate the task spec:
+
+```bash
+rg -l "^ticket: {ticket}$" docs/tasks/ 2>/dev/null | head -1
+```
+
+Locate the design docs (run only when the task spec was found; capture all matches — more than one file may share the same `JIRA:` value):
+
+```bash
+rg -l "^JIRA: {ticket}$" docs/design/ 2>/dev/null
+```
+
+Store the task spec path as `TASK_SPEC_PATH` and all returned design doc paths as `DESIGN_DOC_PATHS` (a list; empty if none found).
+
+Spawn a fresh Agent with this brief (fill every placeholder; omit the design doc line entirely if `DESIGN_DOC_PATHS` is empty):
+
+```
+You are running the `review` skill.
+Read `.claude/skills/review/SKILL.md` and execute it from Stage 1.
+Do not ask questions — all context is below.
+
+Ticket: {ticket}
+Branch: {branch}
+
+The diff contains fixes for {N} PR review comments.
+Group E will check it against the task spec at {TASK_SPEC_PATH}.
+
+{If DESIGN_DOC_PATHS has one entry:}
+A design doc for this ticket exists at {DESIGN_DOC_PATHS[0]} — Group E will load it.
+
+{If DESIGN_DOC_PATHS has more than one entry:}
+Design docs for this ticket exist at: {DESIGN_DOC_PATHS list, one path per line} — Group E will load all of them.
+```
+
+Wait for the review agent to return the verdict string (`PASS` or `FAIL`) and
+the findings file path.
+
+---
+
+### Stage 6 — Act on verdict
+
+**PASS**: record result `pass` for all entries that had `changes-made`. Show
+the Gate 2 summary table (same format as below) and proceed to Stage 7.
+
+**FAIL and iteration < 3**: increment `iteration`. Map each pending
+blocker/major finding back to the entry whose fix introduced it (by matching
+the finding's file path to the files each entry touched). Return to Stage 4
+for entries with mapped findings.
+
+**FAIL and iteration = 3** (max iterations reached): record
+`failed-max-iterations` for entries with remaining pending blocker/major
+findings. Surface a summary:
+
+> Gate 2 — max iterations reached.
+> Remaining findings:
+>
+> {findings list — one line per pending blocker/major, with entry reference}
+>
+> Findings file: {path}
+
+Show the Gate 2 summary table (same format as below) and proceed to Stage 7.
+
+---
+
+### Stage 7 — Commit fixer work
+
+Present the Gate 2 summary table:
+
+```
+Gate 2 complete.
+
+| # | Type                | File:Line         | Result                  |
+|---|---------------------|-------------------|-------------------------|
+| 1 | review_thread       | {path}:{line}     | pass                    |
+| 2 | top_level_comment   | (top-level)       | skipped-no-changes      |
+| 3 | review_body         | (review body)     | failed-max-iterations   |
+```
+
+Display rules for the File:Line column are the same as Stage 3.
+
+Do not wait for developer confirmation — proceed immediately.
+
+Run `git status --porcelain` to check whether any files were changed:
+
+```bash
+git status --porcelain
+```
+
+**Skip check:** if the output of `git status --porcelain` is empty, no files
+were changed — skip the commit and proceed directly to Stage 10.
+
+Otherwise, commit all staged and unstaged changes from the fixer agents, plus
+**all** review findings files produced by Stage 5 across iterations (one file
+per iteration — e.g. both the FAIL findings from iteration 1 and the PASS
+findings from iteration 2). Every untracked or modified file reported by
+`git status --porcelain` must be included.
+
+```bash
+git add {files that were changed} {all findings file paths from Stage 5}
+git commit -m "{ticket}: Fix PR review comments
+
+{one-line summary per entry that was fixed, prefixed with - }"
+```
+
+Capture the commit SHA:
+
+```bash
+git rev-parse HEAD
+```
+
+Store as `COMMIT_SHA` for use in reply bodies.
+
+---
+
+### Stage 8 — CI validation and fix loop
+
+**Skip check:** evaluate the skip predicate defined in Stage 5. If every
+`will-fix` entry recorded `skipped-no-changes`, skip CI validation entirely —
+no code was changed, nothing to validate. Proceed directly to Stage 10.
+
+Otherwise, read `.claude/skills/shared/ci-validation-loop.md` and execute Steps 1, 2,
+3 defined there. That document contains the sub-agent prompts, verdict
+handling, per-cycle commit flow, and fixer agent instructions for this stage.
+Fill the placeholders as follows before executing:
+
+| Placeholder | Value |
+|-------------|-------|
+| `{ticket}` | the `ticket` value derived in Stage 5 |
+| `{branch}` | the `branch` value derived in Stage 5 |
+| `{changed file(s)}` | all files in the Stage 7 commit (`git show --name-only --pretty=format: $COMMIT_SHA`) |
+| `{task-nn}` | *(omit — not applicable to fix-pr-comments)* |
+
+CI validation commit messages use the format:
+`{ticket}: CI validation cycle {N} — {PASS|FAIL}`
+
+The CI validation loop runs up to 5 iterations (separate counter from the
+Gate 2 review loop max of 3).
+
+**On `verdict: passed`**: proceed to Stage 9 (push).
+
+**On `verdict: failed-max-iterations`**: **check for the
+`precondition: authentication` marker line FIRST**, before presenting the
+proceed/stop choice. The two branches below are mutually exclusive; the auth
+branch is checked first.
+
+**If the return carries the `precondition: authentication` marker (auth branch):**
+emit the reply-continue affordance and end the turn:
+
+> CI validation hit an authentication precondition — an environment problem, not a code failure, so the fix loop stopped without churning the fixer.
+>
+> Remediation: {remediation path from the marker}.
+>
+> Authenticate, then reply `continue` and I will re-run CI validation from the top.
+
+**Wait for the developer's `continue` reply.** On reply, RE-RUN the entire CI
+loop — a fresh invocation of `skills/shared/ci-validation-loop.md` Steps 1–3
+with the iteration counter starting at 1 (the auth short-circuit consumed no
+iteration budget, so the fresh loop begins at iteration 1). This re-run logic
+lives here in the caller, never in `ci-validation-loop.md`.
+
+**If the return does NOT carry the marker (real code failure — existing behaviour, unchanged):** present the failure to the developer:
+
+> CI validation failed after 5 fix attempts.
+>
+> Failing command: `{failing_command}`
+> Most recent output is above.
+>
+> Options:
+> 1. **Proceed** — push despite the CI failure.
+> 2. **Stop** — do not push. Resolve the failure manually.
+>
+> Each cycle's state is preserved as a commit; inspect `git log` to walk
+> the iteration history.
+
+**Wait for the developer's response.**
+
+- If the developer chooses **Proceed**, continue to Stage 9 (push).
+- If the developer chooses **Stop**, halt the skill. The fixer work is already
+  committed in Stage 7 — stopping here means the commit exists locally but is
+  not pushed.
+
+---
+
+### Stage 9 — Push
+
+**Skip check:** evaluate the skip predicate defined in Stage 5. If every
+`will-fix` entry recorded `skipped-no-changes`, skip the push — no commit was
+created. Proceed directly to Stage 10.
+
+Otherwise, push the branch so the commit is visible to reviewers before any
+replies are posted:
+
+```bash
+git push
+```
+
+---
+
+## Gate 3 — Resolve
+
+---
+
+### Stage 10 — Post replies and resolve
+
+Present the reply plan before executing:
+
+```
+Ready to post replies and resolve threads.
+
+| # | Type                | File:Line         | Classification  | Reply preview                         |
+|---|---------------------|-------------------|-----------------|---------------------------------------|
+| 1 | review_thread       | {path}:{line}     | will-fix/pass   | Fixed in {sha} — {summary}            |
+| 2 | top_level_comment   | (top-level)       | will-fix/pass   | Fixed in {sha} — {summary}            |
+| 3 | review_thread       | {path}:{line}     | question        | {answer preview}                      |
+| 4 | top_level_comment   | (top-level)       | acknowledged    | Acknowledged — {reason}               |
+| 5 | review_body         | (review body)     | acknowledged    | Acknowledged — {reason}               |
+| 6 | review_thread       | {path}:{line}     | skip            | Skipping — {reason}                   |
+| 7 | review_thread       | {path}:{line}     | will-fix/failed | (no reply — thread left unresolved)   |
+| 8 | top_level_comment   | (top-level)       | will-fix/failed | Attempted but unable to address…      |
+| 9 | review_body         | (review body)     | will-fix/failed | Attempted but unable to address…      |
+
+Shall I post these replies and resolve the threads?
+```
+
+Display rules for the File:Line column are the same as Stage 3.
+
+**Wait for the developer's confirmation.**
+
+Then, for each entry in order, route by type and classification:
+
+---
+
+#### `review_thread` entries
+
+**`will-fix` + `pass`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-{thread_id}.md`:
+   ```
+   Fixed in {COMMIT_SHA} — {one sentence describing what changed}.
+   ```
+2. Post: `.claude/scripts/pr-reply.sh {PR_NUM} {entry.comment_id} .claude/scripts/_replies/{PR_NUM}-{thread_id}.md`
+3. Resolve: `.claude/scripts/pr-resolve.sh {entry.thread_id} {PR_NUM}`
+
+**`will-fix` + `failed-max-iterations`**: skip — no reply, thread left
+unresolved.
+
+**`question`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-{thread_id}.md`: a direct answer to the
+   reviewer's question (one to three sentences, plain prose).
+2. Post: `.claude/scripts/pr-reply.sh {PR_NUM} {entry.comment_id} .claude/scripts/_replies/{PR_NUM}-{thread_id}.md`
+
+Do not resolve the thread — leave it open for the reviewer to read the answer
+and follow up.
+
+**`acknowledged`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-{thread_id}.md`:
+   ```
+   Acknowledged — {reason the suggestion was not actioned}.
+   ```
+2. Post: `.claude/scripts/pr-reply.sh {PR_NUM} {entry.comment_id} .claude/scripts/_replies/{PR_NUM}-{thread_id}.md`
+3. Resolve: `.claude/scripts/pr-resolve.sh {entry.thread_id} {PR_NUM}`
+
+**`skip`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-{thread_id}.md`:
+   ```
+   Skipping — {reason}.
+   ```
+2. Post: `.claude/scripts/pr-reply.sh {PR_NUM} {entry.comment_id} .claude/scripts/_replies/{PR_NUM}-{thread_id}.md`
+3. Resolve: `.claude/scripts/pr-resolve.sh {entry.thread_id} {PR_NUM}`
+
+---
+
+#### `top_level_comment` entries
+
+**Hard constraint: never call `.claude/scripts/pr-resolve.sh` for `top_level_comment`
+entries.** Top-level comments have no resolvable thread.
+
+**`will-fix` + `pass`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-toplevel-{entry.comment_id}.md`:
+   ```
+   Fixed in {COMMIT_SHA} — {one sentence describing what changed}.
+   ```
+2. Post: `.claude/scripts/pr-issue-reply.sh {PR_NUM} .claude/scripts/_replies/{PR_NUM}-toplevel-{entry.comment_id}.md`
+
+**`will-fix` + `failed-max-iterations`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-toplevel-{entry.comment_id}.md`:
+   ```
+   Attempted but unable to address automatically after 3 iterations — see findings file for details.
+   ```
+2. Post: `.claude/scripts/pr-issue-reply.sh {PR_NUM} .claude/scripts/_replies/{PR_NUM}-toplevel-{entry.comment_id}.md`
+
+**`question`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-toplevel-{entry.comment_id}.md`: a direct
+   answer to the reviewer's question (one to three sentences, plain prose).
+2. Post: `.claude/scripts/pr-issue-reply.sh {PR_NUM} .claude/scripts/_replies/{PR_NUM}-toplevel-{entry.comment_id}.md`
+
+**`acknowledged`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-toplevel-{entry.comment_id}.md`:
+   ```
+   Acknowledged — {reason the suggestion was not actioned}.
+   ```
+2. Post: `.claude/scripts/pr-issue-reply.sh {PR_NUM} .claude/scripts/_replies/{PR_NUM}-toplevel-{entry.comment_id}.md`
+
+**`skip`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-toplevel-{entry.comment_id}.md`:
+   ```
+   Skipping — {reason}.
+   ```
+2. Post: `.claude/scripts/pr-issue-reply.sh {PR_NUM} .claude/scripts/_replies/{PR_NUM}-toplevel-{entry.comment_id}.md`
+
+---
+
+#### `review_body` entries
+
+**Hard constraint: never call `.claude/scripts/pr-resolve.sh` for `review_body`
+entries.** Review bodies have no resolvable thread.
+
+**`will-fix` + `pass`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-reviewbody-{entry.comment_id}.md`:
+   ```
+   Fixed in {COMMIT_SHA} — {one sentence describing what changed}.
+   ```
+2. Post: `.claude/scripts/pr-issue-reply.sh {PR_NUM} .claude/scripts/_replies/{PR_NUM}-reviewbody-{entry.comment_id}.md`
+
+**`will-fix` + `failed-max-iterations`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-reviewbody-{entry.comment_id}.md`:
+   ```
+   Attempted but unable to address automatically after 3 iterations — see findings file for details.
+   ```
+2. Post: `.claude/scripts/pr-issue-reply.sh {PR_NUM} .claude/scripts/_replies/{PR_NUM}-reviewbody-{entry.comment_id}.md`
+
+**`question`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-reviewbody-{entry.comment_id}.md`: a
+   direct answer to the reviewer's question (one to three sentences, plain
+   prose).
+2. Post: `.claude/scripts/pr-issue-reply.sh {PR_NUM} .claude/scripts/_replies/{PR_NUM}-reviewbody-{entry.comment_id}.md`
+
+**`acknowledged`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-reviewbody-{entry.comment_id}.md`:
+   ```
+   Acknowledged — {reason the suggestion was not actioned}.
+   ```
+2. Post: `.claude/scripts/pr-issue-reply.sh {PR_NUM} .claude/scripts/_replies/{PR_NUM}-reviewbody-{entry.comment_id}.md`
+
+**`skip`**:
+
+1. Write to `.claude/scripts/_replies/{PR_NUM}-reviewbody-{entry.comment_id}.md`:
+   ```
+   Skipping — {reason}.
+   ```
+2. Post: `.claude/scripts/pr-issue-reply.sh {PR_NUM} .claude/scripts/_replies/{PR_NUM}-reviewbody-{entry.comment_id}.md`
+
+---
+
+#### Error handling for reply and resolve scripts
+
+**On `pr-reply.sh` exit 3**: surface the full error and **stop the entire
+skill**. Do not process further entries.
+
+**On `pr-issue-reply.sh` exit 3**: surface the full error and **stop the entire
+skill**. Do not process further entries.
+
+**On `pr-issue-reply.sh` other non-zero exit**: record result `failed-reply`
+("reply failed"). Continue to the next entry.
+
+**On `pr-resolve.sh` exit 3**: surface the full error and **stop the entire
+skill**.
+
+**On `pr-resolve.sh` other non-zero exit**: record result `failed-resolve`
+("reply posted but thread not resolved"). Continue to the next entry.
+
+---
+
+### Stage 11 — Cleanup and summary
+
+Remove reply scratch files:
+
+```bash
+rm -f .claude/scripts/_replies/${PR_NUM}-*.md
+```
+
+Report:
+
+```
+fix-pr-comments — PR #{PR_NUM} complete.
+
+| Entry | Type                | File:Line         | Classification  | Result          |
+|-------|---------------------|-------------------|-----------------|-----------------|
+| …     | …                   | …                 | …               | …               |
+
+Resolved: {count}  (review_thread entries only)
+Replied, awaiting reviewer: {count}  (question threads — not auto-resolved)
+Replied (no thread to resolve): {count}  (top_level_comment and review_body entries that were replied to)
+Skipped (no changes): {count}
+Failed (max iterations): {count}  {list findings file paths if any}
+Failed (resolve only): {count}
+Failed (reply): {count}
+```
+
+Display rules for the File:Line column are the same as Stage 3.
+
+---
+
+## Rules
+
+- **Three gates, two mandatory confirmations.** Gate 1 (triage, Stage 3) and
+  Gate 3 (resolve, Stage 10) always require explicit developer confirmation.
+  Gate 2 (implement) proceeds without confirmation. Stage 8 additionally
+  requires a developer choice (proceed/stop) only on the CI validation
+  `failed-max-iterations` path.
+- **Developer overrides are final.** Do not re-assert the AI's original
+  classification after the developer changes it.
+- **Sequential fixers, single review.** Run fixer agents for all `will-fix`
+  entries sequentially, then spawn one review agent for the combined diff. Do
+  not interleave fix and review cycles per entry.
+- **Fresh review agent every iteration.** Never reuse a review agent across
+  iterations.
+- **Fixer scope is narrow.** For `review_thread` entries, the fixer brief must
+  include the full comment thread, file path, and line, and must instruct the
+  agent to limit changes to that scope. For `top_level_comment` and
+  `review_body` entries, the fixer brief must omit file/line and instead
+  instruct the agent to identify relevant files from the comment context.
+- **Three-part empty-diff check.** Use `git diff HEAD`, `git diff --cached`,
+  and `git status --porcelain`. All three must be empty before recording
+  `skipped-no-changes`.
+- **Anchored ticket regex.** Use `^ticket: {ticket}$` — not a prefix match.
+- **Commit all findings files.** Stage 8 must include every findings file
+  produced across iterations, not just the final one. Run `git status` before
+  staging to verify nothing is missed.
+- **Push before replies.** Commit, then push, then post replies. Never post a
+  reply citing a commit SHA before that commit is on the remote.
+- **Reply files in `.claude/scripts/_replies/` only.** Never pass a body file from any
+  other location to `pr-reply.sh` or `pr-issue-reply.sh`.
+- **Reply routing by type.** `review_thread` entries use `pr-reply.sh`.
+  `top_level_comment` and `review_body` entries use `pr-issue-reply.sh`.
+- **Never resolve non-thread entries.** `pr-resolve.sh` must only be called for
+  `review_thread` entries. Never call it for `top_level_comment` or
+  `review_body` entries — they have no resolvable thread.
+- **`pr-reply.sh` exit 3 stops the skill.** The branch context is wrong;
+  continuing would post to the wrong PR.
+- **`pr-issue-reply.sh` exit 3 stops the skill.** Same reason.
+- **`pr-resolve.sh` exit 3 stops the skill.** Same reason.
+- **`pr-resolve.sh` other failure after a successful reply** is recorded but
+  does not stop the skill.
+- **`pr-issue-reply.sh` other failure** is recorded but does not stop the skill.
+- **Max 3 Gate 2 iterations** — not 5. Each iteration fixes all entries with
+  pending findings and re-reviews the combined diff.
+- **Default-classify `review_body` as `acknowledged`.** Only override to
+  `will-fix` if the body contains a specific, actionable code change request.
+- **Do not silently drop edge cases.** Every entry must produce a recorded
+  result in the Stage 11 summary.
+- **CI validation runs after commit, before push.** Max 5 iterations, separate
+  counter from the Gate 2 review loop (max 3).
+- **Spawn the CI validation agent from step 1 in a fresh message each
+  iteration.** Never reuse a CI validation agent across iterations.
+- **The CI fixer in step 3  applies minimal fixes only.** Do not refactor,
+  add tests, or change anything unrelated to the CI failure.
+- **CI validation failure after max iterations gives the developer a choice:
+  proceed or stop.** Do not halt unconditionally.
+- **An auth precondition is checked before the proceed/stop choice.** On
+  `failed-max-iterations`, check for the `precondition: authentication` marker
+  line FIRST. Present → emit "authenticate, then reply `continue`" and, on the
+  reply, re-run the whole CI loop from iteration 1. Absent → the existing
+  proceed/stop choice is unchanged.
+- **Skip CI validation when all entries recorded skipped-no-changes.** Evaluate
+  the skip predicate defined in Stage 5 — if no code was changed, there is
+  nothing to validate.
+- **Commit fixer work before CI validation.** The confirm-before-commit gate is
+  removed — show the summary table but proceed without waiting.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: implement
+description: You MUST use this when the user asks to implement a task spec or produce the artefact it describes.
+model: claude-opus-4-8
+allowed-tools:
+  - Agent
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - WebFetch
+  - WebSearch
+---
+
+You are the orchestrator for the `implement` skill. Read a task spec,
+produce the described artefact, then call `review` and loop until PASS. You
+do not write artefacts or review findings yourself — you brief sub-agents and
+orchestrate results.
+
+---
+
+## Parse `--no-handoff-gate` override (strict)
+
+Before detecting input type, parse the override flag with strict semantics.
+This step runs FIRST so the JIRA-key/path detection below sees only the
+residual argument.
+
+1. Split `ARGUMENTS` into whitespace-delimited tokens.
+2. **Exact-match the override.** If the token `--no-handoff-gate` appears
+   exactly (case-sensitive, no trailing characters, no fuzzy or
+   typo-tolerant matching), remove it from the token list and set
+   `override_active = true`. Otherwise `override_active = false`.
+3. **Reject any other `--`-prefixed token.** Scan the remaining tokens. If
+   ANY token starts with `--` and is not exactly `--no-handoff-gate`, stop
+   immediately with this verbatim error (substituting the offending token):
+
+   > Unrecognised flag: `{token}`. The only flag `implement` accepts is `--no-handoff-gate`. Did you mean `--no-handoff-gate`?
+
+   This rejection is deliberately broad — it covers near-miss typos (e.g.
+   `--no-handoff_gate`) AND any other unknown flag (e.g. `--resume`,
+   `--force`). Do NOT silently consume unrecognised `--`-tokens into the
+   JIRA-key/path value.
+4. **Reject empty residual.** Concatenate the remaining tokens back into the
+   cleaned argument string. If the cleaned argument is empty (no JIRA key
+   and no task-spec path/fragment remains after stripping
+   `--no-handoff-gate`), stop with this verbatim error:
+
+   > `--no-handoff-gate` is a modifier on an invocation, not a standalone command. Pass a JIRA key or task-spec path/fragment alongside it (e.g. `implement AIDEV-103 --no-handoff-gate`).
+
+The cleaned argument and `override_active` are passed to whichever companion
+file is routed below.
+
+---
+
+## Detect input type
+
+Check the cleaned argument:
+
+- Matches `^[A-Z][A-Z0-9]*-[0-9]+$` (a JIRA ticket key, e.g. `AIDEV-70`) → read `.claude/skills/implement/feature-orchestrator.md` and execute it from OM-1. Pass `override_active` to the orchestrator.
+- Otherwise → read `.claude/skills/implement/task-implementer.md` and execute it from Stage 0. Pass `override_active` to the task-implementer.
+
+If the companion file cannot be read, stop with the verbatim error:
+
+> Companion file `{path}` could not be read — `implement` skill is broken. Surface to engineer.

--- a/.claude/skills/implement/feature-orchestrator.md
+++ b/.claude/skills/implement/feature-orchestrator.md
@@ -1,0 +1,292 @@
+Ticket-level orchestration of the implement skill. Reached via the SKILL.md dispatcher when the input matches a JIRA ticket key.
+
+Inputs from the dispatcher:
+- `TICKET` — the JIRA ticket key (already validated by the dispatcher).
+- `override_active` — boolean. The dispatcher has already parsed `--no-handoff-gate`; this orchestrator trusts the value verbatim and never re-parses arguments. It propagates the value into each OM-5 sub-agent prompt (see OM-5).
+
+## Orchestration mode
+
+Entered when the `Detect input type` section routes to orchestration mode. Runs all task specs for the ticket in dependency order using the single-task implement flow (Stages 0–7) per task via sub-agent. Does not reimplement any stage.
+
+### OM-1 — Discover task specs
+
+```bash
+ls docs/tasks/ | rg "^{TICKET}-TASK-[0-9]+-.*\.md$" | sort
+```
+
+If no files match, stop:
+
+> No task specs found for ticket {TICKET} in docs/tasks/. Cannot proceed.
+
+Store the sorted list as the task set.
+
+### OM-2 — Validate dependency graph
+
+For each task spec in the task set, read its `Depends on:` body header (absent → treat as `nothing`).
+
+**Reference check.** For each non-`nothing` value:
+
+- If the value ends in `.md`: confirm `docs/tasks/{filename}` exists. If not, stop:
+  > Broken Depends on: reference in {spec filename} — docs/tasks/{filename} not found.
+
+  If the referenced file does not match `^{TICKET}-TASK-[0-9]+-.*\.md$`, stop:
+  > Cross-ticket dependency in {spec filename} — {filename} belongs to a different ticket. Cross-ticket dependencies are not supported.
+
+- If the value does not end in `.md` (literal branch name): validate it exists on the remote:
+  ```bash
+  git ls-remote --exit-code origin refs/heads/{branch-name}
+  ```
+  If the command exits non-zero, stop:
+  > Broken Depends on: reference in {spec filename} — branch {branch-name} not found on remote.
+
+**Cycle check.** For each task, follow the `Depends on:` chain. If any chain revisits a task already in the chain, stop:
+
+> Dependency cycle detected: {task-A.md} → {task-B.md} → … → {task-A.md}. Resolve the cycle before proceeding.
+
+All reference and cycle checks must complete before any task starts.
+
+### OM-3 — Pre-flight checks
+
+Run before any task starts. Any failure stops the run entirely — no partial-run state results from pre-flight failures.
+
+**Clean working tree:**
+
+```bash
+git status --porcelain
+```
+
+If non-empty, stop and display the file list:
+
+> The working tree has uncommitted changes (listed above). Commit or stash them before running `implement {TICKET}`.
+
+**Push access:**
+
+```bash
+gh auth status
+```
+
+If this fails, stop and surface the error verbatim.
+
+```bash
+git ls-remote origin
+```
+
+If this fails, stop and surface the error verbatim.
+
+**Design-phase PR handoff gate (fail-fast).** Runs EXACTLY ONCE for the whole
+ticket, before OM-4. ORTHOGONAL to the per-task PR check in OM-5: OM-5
+handles per-task skip/resume on the task's own implementation branch and
+treats `CLOSED` as resume-with-warning; this gate checks the **design
+branch** and passes only on `OPEN` or `MERGED`. The insertion point is
+pinned to this sequential structure (see ADR 011 and ADR 009 — a future
+parallel scheduler may restructure this file, but the current sequential
+form is authoritative).
+
+Resolve the design branch from the design doc for `{TICKET}`:
+
+```bash
+rg -l "^(JIRA|Ticket): {TICKET}$" docs/design/
+```
+
+Both `^JIRA:` and `^Ticket:` are matched on purpose — the `docs/design/`
+inventory currently holds a genuine mix of both, and narrowing the lookup to
+a single key would silently miss design docs keyed with the other. Do NOT
+strip the `Ticket:` branch (ADR 011).
+
+**If `rg` returns no results** (and `override_active` is false): stop with
+this verbatim error before any sub-agent is spawned:
+
+> No design doc found for ticket `{TICKET}` (searched `docs/design/` for both `^JIRA:` and `^Ticket:` headers). `implement` requires a design doc to verify the design-phase PR handoff. If this ticket legitimately has no design doc (e.g. a spike), re-run with `--no-handoff-gate`.
+
+**If `rg` returns one or more design docs:** for each match, attempt to read
+its `Branch:` header (matching the regex `^Branch:[[:space:]]+([^[:space:]].*)$`).
+Collect the set of resolved design branches.
+
+**If no design doc has a resolvable `Branch:` header** (every match is a
+legacy doc) and `override_active` is false: stop with this verbatim error:
+
+> Found {N} design doc(s) for ticket `{TICKET}` but none carry a resolvable `Branch:` header (legacy docs). Cannot resolve the design-phase branch to verify its PR. Normalise the design doc by adding a `Branch:` header, or re-run with `--no-handoff-gate`.
+
+**Run the handoff gate against the resolved design branches.** The gate is
+a pure query (see `.claude/skills/shared/handoff-gate.md`): it returns a sentinel
+object describing the PR state and never halts itself. OM-3 inspects the
+sentinel and either proceeds or halts the orchestrator using the canonical
+halt-message templates from `.claude/skills/shared/handoff-gate.md`. The gate passes
+if ANY resolved design branch returns a pass sentinel (`OVERRIDE`, `OPEN`,
+or `MERGED`).
+
+If `override_active` is true: read `.claude/skills/shared/handoff-gate.md` and execute
+Step 1 (the override short-circuit) once with placeholders:
+
+| Placeholder | Value |
+|-------------|-------|
+| `{branch}` | the first resolved design branch (only used in the override notice — the gate makes no `gh` call) |
+| `{phase_name}` | `design` (substituted into the override notice line printed by Step 1) |
+| `{override_active}` | `true` |
+
+The gate prints the override notice and returns `{state: "OVERRIDE"}`. Treat
+this as a pass and proceed to OM-4.
+
+If `override_active` is false: for each resolved design branch in turn, read
+`.claude/skills/shared/handoff-gate.md` and execute it with placeholders:
+
+| Placeholder | Value |
+|-------------|-------|
+| `{branch}` | the resolved design branch |
+| `{override_active}` | `false` |
+
+Inspect the returned sentinel's `.state`:
+
+- `OPEN` or `MERGED` → the gate passes for this branch. Exit the loop and
+  proceed to OM-4.
+- `NONE`, `CLOSED`, `DRAFT`, or `GH_FAIL` → record the sentinel and move on
+  to the next candidate branch. The gate did not halt; OM-3 owns the halt
+  decision.
+
+If every resolved design branch returned a non-pass sentinel, halt the
+orchestrator here — no sub-agent is spawned. Emit exactly ONE halt message
+using the canonical halt-message template from `.claude/skills/shared/handoff-gate.md`
+corresponding to the **last** (final) candidate branch's sentinel state.
+Fill `{phase_name}` = `design`, `{skill_name}` = `implement`, `{branch}` =
+the last candidate branch, and (for `CLOSED` / `DRAFT`) `{number}` and
+`{url}` from the sentinel, or (for `GH_FAIL`) `{stderr}` from the sentinel.
+Because the gate is a pure query, non-final candidate branches produce no
+noisy false halts — only the final halt message is printed.
+
+### OM-4 — Build execution order
+
+Assign each task a depth: `Depends on: nothing` (or absent) → depth 0; `Depends on: {branch-name}` (literal branch name, no `.md` suffix) → depth 0 (external dependency, not a member of the task set); `Depends on: {filename}` (ends in `.md`) → dependency's depth + 1. Sort by depth ascending, then TASK-NN ascending within the same depth. Each task starts only after all tasks it depends on complete.
+
+### OM-5 — Execute tasks in order
+
+For each task in execution order:
+
+**Idempotency check.** Read the task spec's `branch` frontmatter. Check whether the branch exists locally:
+
+```bash
+git rev-parse --verify {branch} 2>/dev/null && echo "exists" || echo "absent"
+```
+
+If the branch exists, check PR state (use the most recent PR by creation date if multiple exist):
+
+```bash
+gh pr list --head {branch} --state all --json state,createdAt --jq 'if length == 0 then empty else sort_by(.createdAt) | last | .state end'
+```
+
+Decide:
+- Branch absent → **start fresh** — invoke single-task implement
+- Branch exists, PR state `OPEN` or `MERGED` → **skip** — report to user and move to next task:
+  > Task {filename}: skipped — already complete (PR {state}).
+- Branch exists, PR state `CLOSED` → **resume with warning** — report to user before invoking single-task implement:
+  > Task {filename}: branch has a previously CLOSED PR — re-running the writer may reproduce a previously rejected artefact. Proceeding.
+  Then invoke single-task implement.
+- Branch exists, no PR (empty output) → **resume** — invoke single-task implement
+
+**Invoke single-task implement.** Spawn a sub-agent. Propagate
+`--no-handoff-gate` into the sub-agent's argument string when
+`override_active` is true. Without this propagation, each sub-agent's
+Stage 0 would re-halt on the same check this orchestrator already cleared
+(ADR 011, Risk 4). The token is appended to the sub-agent's argument
+exactly as the dispatcher's strict parser expects — whitespace-delimited,
+exact-match.
+
+When `override_active` is true, set:
+
+```
+ARGUMENTS_FOR_SUBAGENT = "docs/tasks/{filename} --no-handoff-gate"
+```
+
+When `override_active` is false, set:
+
+```
+ARGUMENTS_FOR_SUBAGENT = "docs/tasks/{filename}"
+```
+
+Then send this brief to the sub-agent (substitute the literal value of
+`ARGUMENTS_FOR_SUBAGENT` before sending):
+
+```
+You are running the `implement` skill for a single task.
+Read `.claude/skills/implement/SKILL.md` and execute it starting from Stage 0.
+The argument the dispatcher must parse is exactly: {ARGUMENTS_FOR_SUBAGENT}
+Do not ask questions — all context is below.
+
+Ticket: {TICKET}
+Mode: non-interactive sub-agent — do not prompt; on auth precondition return FAIL carrying precondition: authentication
+
+Execute Stages 0 through 7 in full. Return when Stage 7 completes or the task
+fails (5 review iterations without PASS, or a CI authentication precondition).
+Report back:
+1. Verdict: PASS or FAIL
+2. PR URL (if PASS)
+3. Branch name
+4. Number of review iterations used
+5. Path to most recent findings file
+6. If FAIL and an auth precondition was encountered, include a line
+   `precondition: authentication` followed by the documented remediation path.
+```
+
+The `Mode:` line above is a MANDATORY, literal element of this brief —
+task-implementer detects orchestration mode by its PRESENCE (see
+`task-implementer.md` Stage 4). It must be authored verbatim; do not omit,
+abbreviate, or reword it.
+
+The sub-agent's dispatcher parses `ARGUMENTS_FOR_SUBAGENT` with the same
+strict semantics defined in `.claude/skills/implement/SKILL.md`: it strips
+`--no-handoff-gate` (if present) and sets `override_active` accordingly,
+then routes to `task-implementer.md` for the cleaned path.
+
+Wait for the sub-agent to return before starting the next task.
+
+**Failure handling.** If the sub-agent return is **not a clean PASS** (no PR
+URL and iteration count), **check for a `precondition: authentication` marker
+line in the return FIRST** — search for the marker as well as for a `FAIL`
+verdict. This check is independent of both the `Mode:` signal and the `FAIL`
+verdict: it fires on the marker in ANY non-PASS sub-agent return, so it
+backstops not only a mis-authored or omitted mode-signal line but also a
+sub-agent that mis-detected the mode and returned the reply-continue affordance
+prose without a `FAIL` verdict (the prose still carries the marker; the
+orchestrator catches it here regardless).
+
+**If the return carries the `precondition: authentication` marker (auth halt):**
+
+> Task FAIL (authentication precondition): {filename}
+> Branch: {branch}
+> Remediation: {remediation path from the marker}
+>
+> CI validation hit an authentication precondition — an environment problem, not a code failure. Authenticate, then re-invoke `implement {TICKET}` — completed and skipped tasks will not repeat. No sub-agent is re-spawned here.
+
+Do not re-spawn the sub-agent and do not proceed to subsequent tasks.
+
+**If a FAIL return does NOT carry the marker (existing behaviour, unchanged):** halt immediately:
+
+> Task FAIL: {filename}
+> Branch: {branch}
+> Most recent findings: {findings file path}
+>
+> Run halted. Remaining tasks have not been started. Resolve the failure and
+> re-run `implement {TICKET}` — completed and skipped tasks will not repeat.
+
+Do not proceed to subsequent tasks.
+
+Record each result (filename, status: `complete` / `skipped` / `failed`, PR URL, iteration count) for OM-6.
+
+### OM-6 — Final summary
+
+Print a summary table of all tasks in execution order:
+
+| Task | Status | PR | Iterations |
+|------|--------|----|------------|
+| {filename} | complete | {URL} | {N} |
+| {filename} | skipped | — | — |
+| {filename} | failed | — | {N} |
+
+All tasks complete or skipped → exit cleanly (all-skipped is not an error). Task failed → the failure context was already reported in OM-5.
+
+---
+
+## Rules
+
+- **Orchestration mode does not run Stages 0–7 itself.** It discovers tasks, validates the graph, and spawns one sub-agent per task; each sub-agent runs the full single-task implement flow from Stage 0.
+- **The OM-3 design-PR gate runs EXACTLY ONCE for the whole ticket.** It is orthogonal to OM-5's per-task PR check; OM-5's CLOSED-as-resume behaviour is unchanged.
+- **Propagate `--no-handoff-gate` into every OM-5 sub-agent prompt** when `override_active` is true. Forgetting to propagate would cause each sub-agent's Stage 0 to re-halt on the same check this orchestrator already cleared.

--- a/.claude/skills/implement/task-implementer.md
+++ b/.claude/skills/implement/task-implementer.md
@@ -1,0 +1,442 @@
+Single-task implementation flow. Reached via the SKILL.md dispatcher when the input is a path or task-name fragment.
+
+Inputs from the dispatcher:
+- the cleaned argument (a task-spec path or task-name fragment, `--no-handoff-gate` already stripped).
+- `override_active` — boolean. The dispatcher has already parsed `--no-handoff-gate`; this stage trusts the value verbatim and never re-parses arguments.
+
+## Stage 0 — Locate task spec, verify design-phase PR handoff
+
+This stage locates the task spec, reads its `ticket`, and runs the handoff
+gate against the design branch BEFORE any branch/base resolution happens.
+
+### 0a — Locate the task spec
+
+If a path was given (e.g. "implement docs/tasks/AIDEV-29-TASK-02.md"),
+use it. If a task name or description was given, list `docs/tasks/` and
+find the matching file. If ambiguous, show the list and ask. If no matching
+file is found, stop:
+
+> `{input}` is not a recognised task spec path or name. Cannot proceed.
+
+**Pre-flight check.** Before proceeding, verify that the review skill exists:
+
+```bash
+test -f .claude/skills/review/SKILL.md && echo "OK" || echo "ERROR: .claude/skills/review/SKILL.md not found — implement cannot proceed without it"
+```
+
+If the file is not found, stop and report the error.
+
+Read the task spec in full. Extract from frontmatter:
+
+- **ticket** (frontmatter — required)
+- **branch** (frontmatter — required)
+
+Extract from the task spec **filename**:
+
+- **task-nn** — the `TASK-NN` segment from the filename using the pattern `TASK-[0-9]+` (e.g. `TASK-01`). If absent (older spec without a task number in the filename), use an empty string. Hold this value for commit messages throughout the run.
+
+If either `ticket` or `branch` is missing from the frontmatter, surface a
+specific error naming the missing field and stop before the gate runs:
+
+> Task spec is missing required frontmatter field: `{field}`. Add it and re-run.
+
+### 0b — Resolve the design branch from the design doc
+
+Locate every design doc that carries this ticket, matching BOTH header forms:
+
+```bash
+rg -l "^(JIRA|Ticket): {ticket}$" docs/design/
+```
+
+Both `^JIRA:` and `^Ticket:` are matched on purpose — the `docs/design/`
+inventory currently holds a genuine mix of both, and narrowing the lookup to
+a single key would silently miss design docs keyed with the other. Do NOT
+strip the `Ticket:` branch.
+
+**If `rg` returns no results** (and `override_active` is false): stop with
+this verbatim error:
+
+> No design doc found for ticket `{ticket}` (searched `docs/design/` for both `^JIRA:` and `^Ticket:` headers). `implement` requires a design doc to verify the design-phase PR handoff. If this ticket legitimately has no design doc (e.g. a spike), pass `--no-handoff-gate` to bypass the check.
+
+**If `rg` returns one or more design docs:** for each match, attempt to read
+its `Branch:` header. The `Branch:` line is a body header (not frontmatter)
+matching the regex `^Branch:[[:space:]]+([^[:space:]].*)$`. Collect the set
+of resolved design branches.
+
+**If no design doc has a resolvable `Branch:` header** (every match is a
+legacy doc that predates the convention) and `override_active` is false:
+stop with this verbatim error:
+
+> Found {N} design doc(s) for ticket `{ticket}` but none carry a resolvable `Branch:` header (legacy docs). Cannot resolve the design-phase branch to verify its PR. Normalise the design doc by adding a `Branch:` header, or pass `--no-handoff-gate` to bypass the check.
+
+### 0c — Run the handoff gate against each resolved design branch
+
+The gate is a pure query (see `.claude/skills/shared/handoff-gate.md`): it returns
+a sentinel object describing the PR state and never halts itself. This stage
+inspects the sentinel and either proceeds or halts the calling skill using
+the canonical halt-message templates from `.claude/skills/shared/handoff-gate.md`.
+The gate passes if ANY resolved design branch returns a pass sentinel
+(`OVERRIDE`, `OPEN`, or `MERGED`).
+
+**If `override_active` is true:** read `.claude/skills/shared/handoff-gate.md` and
+execute Step 1 (the override short-circuit) once with placeholders:
+
+| Placeholder | Value |
+|-------------|-------|
+| `{branch}` | the first resolved design branch (only used in the override notice — the gate makes no `gh` call) |
+| `{phase_name}` | `design` (substituted into the override notice line printed by Step 1) |
+| `{override_active}` | `true` |
+
+The gate prints the override notice and returns `{state: "OVERRIDE"}`. Treat
+this as a pass and proceed to Stage 0d.
+
+**If `override_active` is false:** for each resolved design branch in turn,
+read `.claude/skills/shared/handoff-gate.md` and execute it with placeholders:
+
+| Placeholder | Value |
+|-------------|-------|
+| `{branch}` | the resolved design branch |
+| `{override_active}` | `false` |
+
+Inspect the returned sentinel's `.state`:
+
+- `OPEN` or `MERGED` → the gate passes for this branch. Exit the loop and
+  proceed to Stage 0d.
+- `NONE`, `CLOSED`, `DRAFT`, or `GH_FAIL` → record the sentinel and move on
+  to the next candidate branch. The caller (this stage) is responsible for
+  the halt decision; the gate did not halt.
+
+If every resolved design branch returned a non-pass sentinel, halt the
+calling skill here. Use the canonical halt-message template from
+`.claude/skills/shared/handoff-gate.md` corresponding to the **last** candidate
+branch's sentinel state, filling `{phase_name}` = `design`,
+`{skill_name}` = `implement`, `{branch}` = the last candidate branch, and
+(for `CLOSED` / `DRAFT`) `{number}` and `{url}` from the sentinel, or (for
+`GH_FAIL`) `{stderr}` from the sentinel. Emit exactly one halt message — no
+noisy false halts on non-final candidate branches.
+
+### 0d — Resolve base branch, create or check out the task branch
+
+Re-read the task spec to extract:
+
+- **`Depends on:`** (body header — optional). If absent, treat as `Depends on: nothing`.
+
+**Resolve the base branch.** Do this unconditionally on every invocation — both fresh runs and resumes. Base resolution runs before the branch creation or checkout step.
+
+- `Depends on:` header absent, or value is `nothing`:
+  ```bash
+  BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+  ```
+- `Depends on: {filename}` (value ends in `.md`; `{filename}` is the bare filename inside `docs/tasks/`, not a path — e.g. `AIDEV-70-TASK-02-foo.md`, not `docs/tasks/AIDEV-70-TASK-02-foo.md`):
+  - Read `docs/tasks/{filename}`. If the file does not exist, stop:
+    > Dependency task spec not found: docs/tasks/{filename}. Cannot proceed.
+  - Extract the `branch` field from its frontmatter. If absent, stop:
+    > Dependency task spec docs/tasks/{filename} is missing required frontmatter field: `branch`. Cannot proceed.
+  - Set `BASE` to that branch value.
+- `Depends on: {branch-name}` (value does not end in `.md` and is not `nothing`): treat as a literal branch name; set `BASE` to that value directly. No file lookup is performed.
+
+Store `BASE` — it is used in Stage 6 to determine whether to pass `base` to `create-pr`.
+
+**Refuse if the branch already exists; otherwise create it from `BASE`:**
+
+```bash
+if git show-ref --verify --quiet "refs/heads/{branch}"; then
+  echo "Branch {branch} already exists locally — delete it (git branch -D {branch}) before re-running. No automatic reset or reuse."
+  exit 1
+fi
+git checkout -b {branch} {BASE}
+```
+
+There is no silent branch reuse: a pre-existing local branch is a hard refusal, not a checkout. The engineer's recovery is to run `git branch -D {branch}` and re-invoke. If `git checkout -b {branch} {BASE}` itself fails (e.g. `BASE` is not a valid local ref), surface its error verbatim and halt before Stage 1 runs — do not let the run continue and trip Stage 1's branch-mismatch assertion as a misleading proxy.
+
+---
+
+## Stage 1 — Confirm branch
+
+The task spec was located, parsed, and gated in Stage 0; `ticket`, `branch`,
+and `task-nn` are already in scope from Stage 0a. This stage only confirms
+the working tree matches the task spec's `branch` before any artefact is
+produced.
+
+**Confirm branch.** Run:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+If the current branch does not match the task spec's `branch` field, stop with an error:
+
+> Branch mismatch: task spec targets `{doc-branch}` but the current branch is `{current-branch}`. Stage 0 should have resolved this — do not proceed.
+
+---
+
+## Stage 2 — Spawn writer agent
+
+Tell the user: "Producing artefact for {ticket}."
+
+Spawn a general-purpose Agent. Fill every placeholder before sending — do not
+leave any placeholder unfilled.
+
+```
+You are producing an artefact described by a task spec.
+Do not ask questions — all decisions are in the task spec below.
+
+Task spec path: {path}
+
+Read the task spec in full before starting. The spec is your complete brief:
+- The Objective section tells you what to produce.
+- The Context section lists files to read; read them before writing.
+- The Implementation constraints, Inputs and outputs, Edge cases, and Out of
+  scope sections define exactly what to build and what to avoid.
+- The Required output format section defines the shape of the artefact.
+
+Task spec content:
+{Full content of the task spec file, verbatim}
+
+Task:
+1. Read the task spec in full (content is above; path is given if you need to re-read).
+2. Read every file listed in the Context section.
+3. Produce the artefact as described. Write it to the path specified in the
+   task spec's Required output format section.
+4. Return: the path written and a one-sentence summary of what was produced.
+```
+
+Wait for the writer agent to return before continuing.
+
+---
+
+## Stage 3 — Review and fix loop
+
+Maximum 5 iterations. Each iteration: run review → read verdict → exit (PASS)
+or fix and loop again.
+
+### 3a — Spawn review agent
+
+Spawn an Agent. Fill every placeholder before sending.
+
+```
+You are running the `review` skill.
+Read `.claude/skills/review/SKILL.md` and execute it from Stage 1.
+Do not ask questions — all context is below.
+
+Ticket: {ticket}
+Branch: {branch}
+
+The diff will contain the artefact just produced by implement. Group E will
+check it against the task spec for ticket {ticket} in docs/tasks/.
+```
+
+Wait for the review agent to return the verdict string and findings file path.
+
+### 3b — Read verdict and commit
+
+Commit the current state of the artefact and review findings, regardless of
+verdict. Only commit if there are actual changes:
+
+```bash
+git add -- "{artefact path(s)}"
+git add docs/ai/reviews/ 2>/dev/null || true
+git diff --cached --quiet || git commit -m "$(cat <<'EOF'
+{ticket} {task-nn}: Review cycle {N} — {PASS|FAIL}
+
+{one-line description of what changed this cycle}
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+- **PASS** → exit the loop. Proceed to Stage 4 (CI validation).
+- **FAIL** → continue to 3c.
+
+If this is iteration 5 and verdict is still FAIL, stop the loop. Before
+stopping, collect the blocker and major counts from each iteration's findings
+file and build a progress table:
+
+| Iteration | Findings file | Blockers | Majors |
+|-----------|--------------|----------|--------|
+| 1         | {path}       | {n}      | {n}    |
+| …         | …            | …        | …      |
+
+Then report:
+
+> Reached the maximum of 5 review iterations without a PASS.
+>
+> Progress across iterations:
+> {progress table}
+>
+> Most recent findings: {findings file path}
+> Each cycle's state is preserved as a commit (`{ticket} {task-nn}: Review cycle {N} — FAIL`); inspect `git log` to walk the iteration history.
+> Review the remaining blocker/major findings and decide how to proceed.
+
+Do not proceed to Stage 5.
+
+### 3c — Spawn fixer agent
+
+Spawn a general-purpose Agent. Fill every placeholder before sending.
+
+Before composing this prompt: read the most recent findings file yourself.
+Each finding is a markdown block headed `### F{n} — {severity} — {file}:{line}`
+with `- outcome: pending` beneath it. Extract every finding where the outcome
+is `pending` AND the severity is `blocker` or `major`. Format each one as:
+
+```
+F{n} ({severity}) — {file}:{line} — {issue} — Suggestion: {suggestion}
+```
+
+Then send the fixer agent this prompt, filling every placeholder:
+
+```
+You are fixing an artefact that failed review.
+Do not ask questions — apply every fix listed below and return.
+
+Artefact: {exact artefact path}
+
+Read before changing:
+- The artefact at {artefact path} — read it in full before making any changes.
+
+Items to fix:
+{The formatted F{n} lines you extracted above — one per line.}
+
+Do not add content, restructure, or change anything not listed above.
+After applying all fixes, return a bullet list of every change made,
+one line per fix.
+```
+
+Return to 3a.
+
+---
+
+## Stage 4 — CI validation and fix loop
+
+Run CI-equivalent validation locally, committing after each cycle. If validation fails,
+spawn a fixer agent and retry — same pattern as the review loop in Stage 3.
+
+Maximum 5 iterations. Each iteration: run CI validation → read verdict →
+exit (passed) or fix and loop again.
+
+**Read `.claude/skills/shared/ci-validation-loop.md` and execute Steps 1, 2,
+3 defined there.** That document contains the sub-agent prompts, verdict
+handling, per-cycle commit flow, and fixer agent instructions for this stage.
+
+Fill the shared document's placeholders as follows:
+- `{ticket}` → the ticket extracted in Stage 0a
+- `{branch}` → the branch extracted in Stage 0a
+- `{changed file(s)}` → the artefact path(s) produced by the writer agent
+- `{task-nn}` → the task-nn extracted in Stage 0a (include it; omit only if empty)
+
+On return:
+- `verdict: passed` → proceed to Stage 5.
+- `verdict: failed-max-iterations` → **check for the `precondition: authentication` marker line FIRST**, before any other handling. The two branches below are mutually exclusive; the auth branch is checked first.
+
+**If the return carries a `precondition: authentication` marker line (auth branch):**
+
+Detect the run mode by the PRESENCE of the OM-5 mode-signal line in this task-implementer's own invocation brief — the literal line `Mode: non-interactive sub-agent — do not prompt; on auth precondition return FAIL carrying precondition: authentication`. Mode detection is added ONLY here at the Stage 4 failed-max-iterations handler — not at Stage 0 and not globally.
+
+- **Mode-signal line PRESENT → orchestration sub-agent (non-interactive).** Do NOT prompt. Bubble the precondition up in this task's FAIL return per the orchestration return contract: return FAIL and include a `precondition: authentication` line followed by the documented remediation path. The orchestrator (feature-orchestrator OM-5) owns the halt.
+- **Mode-signal line ABSENT → top-level single-task (interactive).** Emit the reply-continue affordance and end the turn:
+
+  > CI validation hit an authentication precondition — it is an environment problem, not a code failure, so the fix loop stopped without churning the fixer.
+  >
+  > Remediation: {remediation path from the marker}.
+  >
+  > Authenticate, then reply `continue` and I will re-run CI validation from the top.
+
+  On the developer's `continue` reply, RE-RUN the entire CI loop — a fresh invocation of `skills/shared/ci-validation-loop.md` Steps 1–3 with the iteration counter starting at 1 (the auth short-circuit consumed no iteration budget, so the fresh loop naturally begins at iteration 1). This re-run logic lives here in the caller, never in `ci-validation-loop.md`.
+
+**If the return does NOT carry the marker (non-auth code failure — existing behaviour, unchanged):** stop. Report to the user:
+
+> CI validation failed after 5 fix attempts.
+>
+> Failing command: `{failing_command}`
+> Most recent output is above.
+> Each cycle's state is preserved as a commit (`{ticket} {task-nn}: CI validation cycle {N} — FAIL`); inspect `git log` to walk the iteration history.
+> Resolve the remaining failure manually and re-run.
+
+Do not proceed to Stage 5.
+
+---
+
+## Stage 5 — Push branch
+
+Push the branch to the remote so it is available for PR creation and stacked
+task branches.
+
+```bash
+git push -u origin HEAD
+```
+
+If `git push -u origin HEAD` fails, surface the error verbatim and stop. Do not proceed to
+Stage 6.
+
+---
+
+## Stage 6 — Create PR
+
+Spawn a sub-agent briefed to read and execute
+`.claude/skills/create-pr/SKILL.md`. Pass the three required inputs
+explicitly and, for stacked tasks, the optional `base` input — do not inline
+the PR creation logic here.
+
+Fill every placeholder before sending. The values are all already in scope
+from Stage 0.
+
+```
+You are executing the create-pr skill.
+Read `.claude/skills/create-pr/SKILL.md` and execute it from Stage 1.
+Do not ask questions — all inputs are below.
+
+ticket: {ticket}
+branch: {branch}
+task_spec_path: {task spec path}
+```
+
+If `Depends on:` resolved in Stage 0 is not `nothing`, append `base: {BASE}` as an additional line in the inputs block above before sending. When `Depends on: nothing`, omit the `base` line entirely — do not pass an empty or null value.
+
+Wait for the sub-agent to return before continuing.
+
+If the sub-agent reports that `gh pr create` failed, surface the error verbatim
+and stop. Do not proceed to Stage 7.
+
+---
+
+## Stage 7 — Confirm
+
+Report to the user:
+
+- Artefact: {path}
+- PR: {URL returned by create-pr sub-agent}
+- Task spec: {path}
+- Findings files: list all `{ticket}-*-*.md` in `docs/ai/reviews/`
+- Verdict: PASS
+- Iterations: {N} review pass(es)
+
+---
+
+## Rules
+
+- **Spawn the review agent from Stage 3a in a fresh message each iteration.**
+  The loop must not try to reuse a prior review agent's context.
+- **Do not produce or edit artefacts yourself.** All writes go through the
+  writer or fixer sub-agent. Your role is briefing and orchestration.
+- **The handoff gate in Stage 0 is a hard stop.** A missing design doc, an
+  unresolvable `Branch:` header, or a non-pass sentinel from the gate for
+  every candidate design branch halts the skill before any artefact is
+  produced. The gate itself is a pure query (`.claude/skills/shared/handoff-gate.md`);
+  Stage 0c owns the halt decision and emits the canonical halt-message
+  template. The override (`--no-handoff-gate`) is per-invocation only and is
+  parsed by the dispatcher — Stage 0 trusts `override_active` verbatim.
+- **The branch assertion in Stage 1 is a hard stop.** After Stage 0d creates or checks out the correct branch, Stage 1 must always see a match. A mismatch is an error, not a prompt.
+- **The fix in 3c covers blockers and majors only.** Minors and nits are
+  recorded in the findings file but do not trigger a fix iteration.
+- **Do not exceed 5 iterations.** Surface the remaining findings to the user
+  rather than looping indefinitely.
+- **CI validation follows a fix loop (max 5 iterations).** Run CI → fail →
+  spawn fixer → re-run. The CI validation sub-agent discovers and executes;
+  the fixer sub-agent applies minimal fixes. CI-specific rules live in
+  `.claude/skills/ci-validation/SKILL.md`.
+- **Spawn the CI validation agent from Step 1 in a fresh message each
+  iteration.** Same principle as the review loop — never reuse a prior agent's
+  context.
+- **The CI fixer in Step 3 applies minimal fixes only.** It addresses the failing
+  command's output — no refactoring, no unrelated changes.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,418 @@
+---
+name: review
+description: You MUST use this when the user asks to review their code, run a code review, or verify a branch against Zego coding standards (with or without a task spec).
+model: claude-opus-4-8
+allowed-tools:
+  - Agent
+  - Bash
+  - Read
+  - Write
+---
+
+You are the orchestrator for the `review` skill. Review the current branch diff against Zego coding standards as defined in `docs/ai/steering/base/code-review.md`. You do not fix anything — review, record, and return a verdict.
+
+---
+
+## Parse `--no-handoff-gate` override (strict)
+
+Before Stage 0, parse the override flag with strict semantics. This step
+runs FIRST so any downstream stages see only the residual argument.
+
+1. Split `ARGUMENTS` into whitespace-delimited tokens.
+2. **Exact-match the override.** If the token `--no-handoff-gate` appears
+   exactly (case-sensitive, no trailing characters, no fuzzy or
+   typo-tolerant matching), remove it from the token list and set
+   `override_active = true`. Otherwise `override_active = false`.
+3. **Reject any other `--`-prefixed token.** Scan the remaining tokens. If
+   ANY token starts with `--` and is not exactly `--no-handoff-gate`, stop
+   immediately with this verbatim error (substituting the offending token):
+
+   > Unrecognised flag: `{token}`. The only flag `review` accepts is `--no-handoff-gate`. Did you mean `--no-handoff-gate`?
+
+   This rejection is deliberately broad — it covers near-miss typos (e.g.
+   `--no-handoff_gate`) AND any other unknown flag (e.g. `--resume`,
+   `--force`). Do NOT silently consume unrecognised `--`-tokens.
+
+There is no empty-residual check for `review`: `review` takes no positional
+argument from the standalone CLI form (it derives its inputs from the
+current branch). The override is still rejected if it appears with any
+other unrecognised `--`-token.
+
+---
+
+## Stage 0 — Implementation-phase PR handoff gate
+
+This stage runs ONLY when `review` is invoked standalone. It is a **pure
+prepend**: review's existing Stage 1 and below are UNCHANGED — there is no
+renumbering. Internal callers (`task-implementer.md` Stage 3a,
+`.claude/skills/fix-pr-comments/SKILL.md`, `.claude/skills/fix-buildkite/SKILL.md`) invoke
+review "from Stage 1" and therefore enter BELOW this gate and skip it. This
+is the load-bearing structural guard described in ADR 011 — it is what
+prevents implement's Stage 3 review loop from deadlocking on the
+implementation PR that does not exist until implement's own Stage 6.
+
+Stage 0 captures the current branch via its own `git rev-parse`. Stage 1
+independently re-derives the branch via its own existing `git rev-parse` —
+no variable is threaded between Stage 0 and Stage 1. Stage 1's
+`git rev-parse` line is NOT rewritten into a reference to a Stage 0
+variable; the two stages each call `git rev-parse` and the outputs agree.
+
+Get the current branch:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+Store this as the gate's `{branch}` for the call below.
+
+Read `.claude/skills/shared/handoff-gate.md` and execute it with placeholders:
+
+| Placeholder | Value |
+|-------------|-------|
+| `{branch}` | the current branch captured above |
+| `{phase_name}` | `implementation` (substituted into the override notice line printed by Step 1 when the override is active) |
+| `{override_active}` | the value parsed by the dispatcher above |
+
+The gate is a pure query: it returns a sentinel object describing the PR
+state and never halts itself. Inspect the returned sentinel's `.state`:
+
+- `OVERRIDE`, `OPEN`, or `MERGED` → pass. Proceed to Stage 1.
+- `NONE`, `CLOSED`, `DRAFT`, or `GH_FAIL` → HALT. Print the canonical
+  halt-message template from `.claude/skills/shared/handoff-gate.md` for the
+  returned `.state`, filling `{phase_name}` = `implementation`,
+  `{skill_name}` = `review`, `{branch}` = the current branch, and (for
+  `CLOSED` / `DRAFT`) `{number}` and `{url}` from the sentinel, or (for
+  `GH_FAIL`) `{stderr}` from the sentinel. The calling skill stops — no
+  findings file is written.
+
+---
+
+## Stage 1 — Validate branch and get diff
+
+Get the current branch:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+Parse against the regex `^([A-Z][A-Z0-9]*-[0-9]+)[_-](.+)$`:
+- Group 1 is the **ticket** (e.g. `PLAT-4321`)
+- Group 2 is the **description slug**, derived in this exact order:
+  1. Lowercase group 2.
+  2. Truncate to 40 characters.
+  3. Strip all trailing hyphens (`s/-+$//`).
+
+  This derivation is the canonical slug; Stage 3 consumes it verbatim
+  and MUST NOT re-derive from the branch name.
+
+  Worked example — branch `AIDEV-65_TASK-01_add-red-flags-to-all-discipline-enforcin`:
+  - Group 2: `TASK-01_add-red-flags-to-all-discipline-enforcin`
+  - Lowercased: `task-01_add-red-flags-to-all-discipline-enforcin`
+  - Truncated to 40: `task-01_add-red-flags-to-all-discipline-`
+  - Trailing hyphens stripped: `task-01_add-red-flags-to-all-discipline`
+
+If the branch does not match, fail immediately:
+
+```
+Branch '{branch}' does not match the required format TICKET-description
+(e.g. PLAT-4321-add-auth-endpoints). Rename the branch before running review.
+```
+
+Determine the base branch:
+
+```bash
+git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo main
+```
+
+Get the diff and changed file list:
+
+```bash
+git fetch origin $BASE --quiet
+git diff origin/$BASE...HEAD
+git diff --cached
+git diff
+git diff --name-only origin/$BASE...HEAD
+git diff --name-only --cached
+git diff --name-only
+```
+
+Deduplicate the file list. If all diffs are empty, report "no changes to review" and exit cleanly.
+
+---
+
+## Stage 2 — Read code-review.md and determine active groups
+
+Read `docs/ai/steering/base/code-review.md` in full. This document is the authoritative source for all check definitions, severity semantics, and output format. Do not re-derive or invent checks — every sub-agent must work from this document.
+
+Determine which groups are active:
+
+- **A** — always active
+- **B** — always active
+- **C** — always active
+- **D** — always active
+- **E** — active only if a task spec exists for this ticket:
+  ```bash
+  rg -l "^ticket: {TICKET}$" docs/tasks/ 2>/dev/null | head -1
+  ```
+  If found, note the path as `TASK_SPEC_PATH`. If not found, skip Group E silently.
+
+  Also search for design docs (run only when the task spec was found; capture all matches — more than one file may share the same `JIRA:` value):
+  ```bash
+  rg -l "^JIRA: {TICKET}$" docs/design/ 2>/dev/null
+  ```
+  Collect all returned paths as `DESIGN_DOC_PATHS` (a list). If none are found, `DESIGN_DOC_PATHS` is empty — Group E still runs on task spec alone.
+- **F** — active only if the changed file list contains any `.py` files
+- **G** — active only if the changed file list contains any `.proto` files or files with `converter` in the path. Also confirm `docs/ai/steering/domains/protobuf-converters.md` exists — if the trigger fires but the file is missing, record a validation error and skip Group G.
+- **H** — always active
+
+`TASK_SPEC_PATH` (the path captured above when Group E activates, or empty when no task spec was found for the ticket) is a stage-scoped value that Stage 2b reads directly. Do not re-run the `rg -l "^ticket: {TICKET}$" docs/tasks/` lookup in Stage 2b.
+
+---
+
+## Stage 2b — Pre-implementation detection
+
+Inputs:
+
+- `TICKET` — captured in Stage 1.
+- `TASK_SPEC_PATH` — set by Stage 2 (empty string when no task spec exists for the ticket; literal path otherwise).
+- Changed-file list with add/modify/delete status from `git diff --name-status` against the base branch:
+
+  ```bash
+  git diff --name-status origin/$BASE...HEAD
+  git diff --name-status --cached
+  git diff --name-status
+  ```
+
+  Deduplicate by file path (for `R`/`C` entries, key on the new/destination path); if the same file appears with different status letters across the three commands, keep the most-additive entry (`A` > `M` > `R`/`C` > `D` — any non-deletion status beats `D`). The command runs against the same base as the Stage 1 diff collection.
+
+Logic — set `PRE_IMPL = TRUE` iff ALL of the following hold:
+
+1. `TASK_SPEC_PATH` is non-empty (i.e. Group E would otherwise activate).
+2. Every entry in the deduplicated changed-file list matches at least one of:
+   - the literal `TASK_SPEC_PATH` (exact file-path match), OR
+   - `docs/design/{TICKET}-*.md` (path-segment glob — `*` does not cross `/`), OR
+   - `docs/tasks/{TICKET}-*.md` (path-segment glob — covers `{TICKET}-TASK-NN-*.md` plus any other ticket-scoped task files including `-v2` regeneration variants).
+
+   For rename (`R`) and copy (`C`) entries, which carry two paths (`old<TAB>new`), the match is evaluated against the **new path** (the destination) — the old path is ignored.
+
+   The literal `TASK_SPEC_PATH` alternative ensures Stage 2b agrees with Stage 2 even when the task-spec filename does not start with `{TICKET}-` (e.g. `docs/tasks/legacy-notes-AIDEV-111.md` whose frontmatter says `ticket: AIDEV-111`).
+3. At least one entry has status `A` (added), `M` (modified), `R` (renamed), or `C` (copied) — i.e. NOT every entry is a deletion; renames and copies are legitimate non-deletion changes that keep the diff `PRE_IMPL` eligible. Leave `PRE_IMPL = FALSE` only when EVERY entry has status `D`. A planning-cancellation/revert is not a pre-implementation state and must not be reported as one.
+
+Detection is path-based only. Do not inspect file contents. The `A`/`M`/`D`/`R`/`C` status column from `git diff --name-status` is structural metadata, not file content.
+
+Side effects when `PRE_IMPL = TRUE`:
+
+- Remove `E` from the active groups list before Stage 4 dispatch.
+- Queue a Validation-errors entry with the exact reason text: `Group E skipped: pre-implementation (diff contains only planning artefacts for {TICKET})` (substitute `{TICKET}` with the literal ticket key).
+
+When `PRE_IMPL = FALSE`, no changes — Stage 2's group activation stands as-is and Stage 4 proceeds against the full active set.
+
+Errors: none — Stage 2b is purely structural file-pattern matching plus a status check.
+
+> Note on interaction with `docs/ai/steering/base/pull-requests.md` rule 9: a `PRE-IMPLEMENTATION` verdict does not endorse running `review` on WIP branches — rule 9 still applies.
+
+---
+
+## Stage 3 — Compute revision number
+
+Use the canonical slug derived in Stage 1; do not re-derive from the branch name.
+
+```bash
+ls docs/ai/reviews/{TICKET}-{slug}-*.md 2>/dev/null
+```
+
+Extract revision numbers from filenames matching `{TICKET}-{slug}-(\d{3})\.md` exactly. New revision = max + 1, zero-padded to 3 digits. Start at `001` if none exist.
+
+New filename: `docs/ai/reviews/{TICKET}-{slug}-{revision}.md`
+
+---
+
+## Stage 4 — Spawn sub-agents in parallel
+
+Spawn all active group sub-agents in a **single message**. Running them in parallel is the whole point — spawning across messages serialises them and defeats the purpose.
+
+Every sub-agent receives:
+- The absolute repo path
+- The base branch name and the commands to obtain the diff (`git diff origin/{BASE}...HEAD`, plus `--cached` and unstaged)
+- A pointer to `docs/ai/steering/base/code-review.md` with the specific group section to apply
+- The path(s) to any standard files the group requires
+- The output format as defined in `docs/ai/steering/base/code-review.md` — per-check block with tagged lines, plus YAML findings list
+- Hard rule: every check that ran must appear as a line — `[pass]` lines are required
+
+**Sub-agent briefs — one per active group:**
+
+For each group, the brief follows this shape. Fill in the group letter, name, section heading, and standard file paths before sending.
+
+```
+You are running the {GROUP LETTER} — {GROUP NAME} checks for the current diff.
+
+Load docs/ai/steering/base/code-review.md and read the section "## Group {LETTER} — {NAME}" in full.
+Apply every check defined in that section.
+
+{If the group references standard files:}
+Load the following standard files in full and use them as the rule source:
+- {standard file path(s)}
+
+Obtain the diff with:
+  git diff origin/{BASE}...HEAD
+  git diff --cached
+  git diff
+
+{Group-specific context, if any — see below.}
+
+Return exactly what docs/ai/steering/base/code-review.md specifies under "## Output format":
+1. A per-check block headed "### Group {LETTER} — {NAME}".
+   One line per check, tagged [pass] / [advisory] / [warning] / [error].
+2. A YAML findings list for every [warning] and [error]. findings: [] if clean.
+```
+
+Group-specific context to append to the brief:
+
+- **Group A:** Include the branch slug (`{slug}`) and instruct the sub-agent to derive recent commit messages with `git log origin/{BASE}..HEAD --oneline` for the scope coherence check.
+- **Group B:** Standard files are `docs/ai/steering/base/logging.md`, `docs/ai/steering/base/observability.md`, and `docs/ai/steering/base/environment.md`. Check every new or modified log call, metric instrument, span operation, and configuration/environment variable usage. Honour each file's Applicability section: the backend-surface rules (OTel/Datadog metric & span instrumentation; the GitOps/Helm/`secrets-config` provisioning workflow) act only where the diff touches that surface — do not raise findings for their absence in a repo that has no such surface. The universal cores (no logged credentials/PII, structured messages, log levels, single config entry point, documented variables) apply wherever the relevant code exists. Gate by surface presence, not by classifying the repo's stack.
+- **Group C:** Standard file is `docs/ai/steering/base/testing.md`. Check every new or modified test file, fixture, and coverage configuration.
+- **Group D:** No standard file. Instruct the sub-agent to generate candidate risk scenarios specific to the code patterns present, then investigate each — grounding every finding in what the diff actually contains.
+- **Group E:** Use the task spec path (`{TASK_SPEC_PATH}`) and design doc paths (`{DESIGN_DOC_PATHS}`, may be empty list) found in Stage 2. Send the sub-agent this brief (fill every placeholder before sending; omit the design doc block entirely if no `DESIGN_DOC_PATHS` were found; if multiple design docs exist, include each under its own `### Design doc: {path}` header):
+
+  ```
+  You are running the E — Acceptance criteria checks for the current diff.
+
+  Task spec path: {TASK_SPEC_PATH}
+
+  Task spec content:
+  {Full content of the task spec file, verbatim}
+
+  {If DESIGN_DOC_PATHS is non-empty, for each path in DESIGN_DOC_PATHS:}
+  ### Design doc: {path}
+
+  {Full content of that design doc file, verbatim}
+
+  Obtain the diff with:
+    git diff origin/{BASE}...HEAD
+    git diff --cached
+    git diff
+
+  Instructions:
+  1. Read the task spec in full (content is above; path is given if you need to re-read).
+  2. If one or more design docs were provided, read each for additional context on the intent and constraints of the change.
+  3. Locate the Acceptance criteria section in the task spec. For each AC item,
+     determine pass or fail by checking whether the diff satisfies that criterion.
+  4. Return one [pass]/[error] line per AC item. If the task spec has no
+     Acceptance criteria section, return a single [advisory] line:
+     "no acceptance criteria found".
+
+  Load `docs/ai/steering/base/code-review.md` and read the section "## Output format"
+  in full — use it as the authoritative schema for the per-check block and
+  YAML findings list.
+
+  Return exactly what docs/ai/steering/base/code-review.md specifies under "## Output format":
+  1. A per-check block headed "### Group E — Acceptance criteria".
+     One line per AC item, tagged [pass] / [error]. Or one [advisory] if no ACs.
+  2. A YAML findings list for every [error]. findings: [] if all pass.
+  ```
+
+  Note: also log the matched task spec path (and all design doc paths if found) in the review report so they are visible.
+- **Group F:** Standard file is `docs/ai/steering/languages/python.md`. Check every new or modified Python file against Python conventions (including the Python-specific environment/config rules in that file).
+- **Group G:** Standard file is `docs/ai/steering/domains/protobuf-converters.md`. Check every new or modified proto and converter file.
+- **Group H:** Standard files are `docs/ai/steering/base/error-handling.md`, `docs/ai/steering/base/file-organisation.md`, `docs/ai/steering/base/resilience.md`, and `docs/ai/steering/base/spelling.md`. Check error handling patterns, file sizes and structure, retry/timeout/idempotency logic, and human-readable text spelling. Honour each file's Applicability section: translate error-handling's "exception" vocabulary into the diff's language idiom (typed-result patterns such as Rust/Swift `Result`, Scala `Either`/`Try`, or Go `(value, error)`) rather than applying it literally, and read file-organisation's line-count targets as language-relative signals — do not raise findings against verbose languages or framework-shaped files on a literal line count. Gate by surface presence, not by classifying the repo's stack.
+
+If a sub-agent returns malformed output or fails: retry that group once. If it fails again, run that group's checks inline in the orchestrator. Do not silently drop a group — every active group must produce output.
+
+---
+
+## Stage 5 — Merge results
+
+1. Collect the per-check block from every sub-agent.
+2. Concatenate findings lists from all sub-agents.
+3. De-duplicate: if two sub-agents flag the same finding, keep the higher-severity entry. Match on `(file, line, rule)` when `rule` is present; fall back to `(file, line, issue)` when `rule` is absent or `n/a` (Groups A and D have no rule file).
+4. Recount: blockers, majors, minors, nits.
+5. Verdict (evaluate top-to-bottom; first match wins):
+   - If blockers or majors > 0 → **FAIL**
+   - Else if PRE_IMPL=TRUE → **PRE-IMPLEMENTATION**
+   - Else → **PASS**
+6. Renumber findings F1, F2, … sorted by severity (blocker → major → minor → nit), then alphabetically by file path within each severity group.
+7. Convert each YAML finding to markdown:
+
+```markdown
+### F{n} — {severity} — {file}:{line}
+
+- rule: {rule link}
+- issue: {issue}
+- suggestion: {suggestion}
+- outcome: pending
+- outcome-note:
+```
+
+---
+
+## Stage 6 — Write findings file
+
+```bash
+mkdir -p docs/ai/reviews
+```
+
+Write to: `docs/ai/reviews/{TICKET}-{slug}-{revision}.md`
+
+```markdown
+# Code review {TICKET}-{slug}-{revision}
+
+- ticket: {TICKET}
+- revision: {revision}
+- branch: {branch}
+- base: origin/{BASE}
+- created: {ISO 8601 UTC timestamp}
+- status: {clean | in-progress | pre-implementation}
+- verdict: {PASS | FAIL | PRE-IMPLEMENTATION}
+- blockers: {count}
+- majors: {count}
+- minors: {count}
+- nits: {count}
+- groups-active: {comma-separated list of group letters that ran, e.g. A, B, C, D, F, H}
+
+## Summary
+
+{One paragraph: what the diff does, which groups ran, and the outcome. For PASS: confirm all checks passed and note any advisories. For FAIL: name the blocking issues and which group found them.}
+
+## Review detail
+
+{Per-check blocks from all sub-agents in group order: A → B → C → D → E → F → G → H.
+Each block is the sub-agent's per-check output verbatim — tagged lines only, no prose.}
+
+## Validation errors
+
+{One bullet per skipped group, with reason — for missing standard files, or other validation conditions such as pre-implementation. Omit section if none. When Stage 2b set PRE_IMPL=TRUE, include the exact reason string: `Group E skipped: pre-implementation (diff contains only planning artefacts for {TICKET})`.}
+
+## Findings
+
+{All numbered findings in markdown form from Stage 5. If none:}
+{When verdict is PASS:} No findings — diff meets all active standards.
+{When verdict is PRE-IMPLEMENTATION:} Implementation not yet present; AC verification deferred.
+```
+
+Set `status: clean` if PASS, `status: in-progress` if FAIL, `status: pre-implementation` if verdict is `PRE-IMPLEMENTATION`. When Stage 2b set `PRE_IMPL=TRUE`, `groups-active` excludes `E` (the post-skip set), and the `## Validation errors` section carries the queued skip-reason entry from Stage 2b.
+
+---
+
+## Stage 7 — Report
+
+In the chat:
+
+1. Path to the findings file written.
+2. Verdict and counts: `PASS`, `PRE-IMPLEMENTATION`, or `FAIL — {n} blocker(s), {n} major(s), {n} minor(s), {n} nit(s)`.
+3. If FAIL: list each blocker and major finding (issue only, one line each).
+4. If PASS: "Diff meets all active standards." If PRE-IMPLEMENTATION: "Implementation not yet present; AC verification deferred." instead.
+5. Any groups skipped (missing standard files, or pre-implementation) — name each skipped group with its reason. When verdict is `PRE-IMPLEMENTATION`, name Group E with reason "pre-implementation (diff contains only planning artefacts for {TICKET})" and list findings from the groups that did run.
+
+---
+
+## Rules
+
+- **Spawn all sub-agents in a single message.** Parallel execution is the whole point.
+- **Every check must be listed.** Sub-agents that return only failures are not providing an audit trail. `[pass]` lines are required.
+- **Checks come from code-review.md, not from this file.** Sub-agents must load and apply the group section from `docs/ai/steering/base/code-review.md`. Do not invent or re-derive checks.
+- **Do not fix anything.** Review and record only.
+- **Do not edit prior findings files.** They are historical record.
+- **Group E is silently skipped when no task spec is found in `docs/tasks/`.** Do not emit a finding for its absence. The design doc is supplementary — its absence does not prevent Group E from running.
+- **Pre-implementation guard (Stage 2b).** When a task spec exists for the ticket AND every changed file matches the literal `TASK_SPEC_PATH`, `docs/design/{TICKET}-*.md`, or `docs/tasks/{TICKET}-*.md` (matching the new/destination path for `R`/`C` entries), AND at least one entry has status `A`, `M`, `R`, or `C`, Stage 2b sets `PRE_IMPL=TRUE`, removes `E` from the active groups, and queues the exact Validation-errors entry `Group E skipped: pre-implementation (diff contains only planning artefacts for {TICKET})`. The verdict is `PRE-IMPLEMENTATION` and the status is `pre-implementation` iff no remaining group produced a blocker or major — `FAIL` still wins otherwise. Detection is path-based only; only deletion-only diffs (EVERY entry status `D`) do NOT classify as pre-implementation. No override flag exists. This does not endorse running review on WIP branches; `pull-requests.md` rule 9 still applies.
+- **Group G is silently skipped when no proto/converter files are in the diff.** Record a validation error only if the trigger fires but the standard file is missing.
+- **Do not flag issues caught by pre-commit, lint, or type checking.** Only flag what structural review can see.

--- a/.claude/skills/shared/ci-validation-loop.md
+++ b/.claude/skills/shared/ci-validation-loop.md
@@ -1,0 +1,178 @@
+# CI validation fix loop — shared across skills
+
+This file is referenced by calling skills (e.g. `.claude/skills/implement/SKILL.md`,
+`.claude/skills/fix-pr-comments/SKILL.md`, `.claude/skills/fix-buildkite/SKILL.md`). It
+contains the detailed steps (Step 1, Step 2, Step 3) and the per-cycle commit
+flow for the CI validation and fix loop.
+
+## Caller contract
+
+The calling skill must fill the following placeholders before executing:
+
+| Placeholder | Required | Description |
+|-------------|----------|-------------|
+| `{ticket}` | yes | JIRA ticket key (e.g. `AIDEV-77`) |
+| `{branch}` | yes | Git branch name |
+| `{changed file(s)}` | yes | Space-separated list of files the calling skill changed |
+| `{task-nn}` | no | Task number segment (e.g. `TASK-01`). Omit when the calling skill has no task number. |
+
+### Return verdicts
+
+When the loop exits, it returns one of two verdicts to the calling skill:
+
+- **`verdict: passed`** — CI validation passed (or was a no-op). The calling
+  skill may proceed to its next stage.
+- **`verdict: failed-max-iterations`** — Either the maximum of 5 iterations was
+  exhausted and CI is still failing, OR an authentication precondition
+  short-circuited the loop (see Step 2). The return includes failure details:
+  - `failing_command` — the command that failed
+  - `most_recent_output` — the full output from the most recent failing run
+  - On an auth short-circuit ONLY: a distinct marker LINE
+    `precondition: authentication` returned alongside the verdict (NOT embedded
+    inside `most_recent_output`), and `most_recent_output` ends with exactly
+    one appended line of the form
+    `precondition: authentication — remediation: {documented path}`.
+
+The `failed-max-iterations` terminal verdict vocabulary is unchanged — the
+`precondition: authentication` marker is additive.
+
+On `failed-max-iterations`, the calling skill owns the user-facing response.
+This document does not print a report, halt, re-run, or emit any resume
+affordance — it returns the failure details (and, on an auth short-circuit,
+the marker) and control to the caller.
+
+---
+
+### Step 1 — Spawn CI validation agent
+
+Spawn an Agent. Fill every placeholder before sending.
+
+```
+You are running the `ci-validation` skill.
+Read `.claude/skills/ci-validation/SKILL.md` and execute it from Stage 1.
+Do not ask questions — all context is below.
+
+Ticket: {ticket}
+Branch: {branch}
+Changed file(s): {changed file(s)}
+
+Discover the repo's CI commands, run Stage 3 autonomous scope validation
+against the changed file(s) above (falling back to the git-diff derivation if
+the list is empty/absent), execute the selected commands, and return:
+1. A verdict line: either "verdict: passed" or "verdict: failed".
+2. The per-command report listing every command and its outcome (passed, failed, etc.).
+3. If failed: the full command output and the failing command. If the failure
+   is an authentication/credentials precondition (Stage 4.2), include a
+   distinct line "precondition: authentication" and the resolved remediation
+   path.
+4. A brief summary of what ran.
+```
+
+Wait for the sub-agent to return.
+
+**No-verdict spawn return.** If the spawned agent returns no verdict at all
+(crash, context-limit, hang, or any output without a `verdict:` line), treat
+this iteration as `verdict: failed` with the spawn error captured as
+`most_recent_output`, and proceed through the normal Step 2 / failed-max-iterations
+path below. Do not abort the loop.
+
+### Step 2 — Read verdict and commit
+
+Commit the current state of the changed files, regardless of verdict. This
+per-cycle commit MUST happen here, BEFORE the auth-marker short-circuit branch
+below — the auth path must not drop the commit for the cycle that ran. Only
+commit if there are actual changes:
+
+When `{task-nn}` is present:
+
+```bash
+git add -- {changed file(s)}
+git diff --cached --quiet || git commit -m "$(cat <<'EOF'
+{ticket} {task-nn}: CI validation cycle {N} — {PASS|FAIL}
+
+{one-line description of what changed this cycle}
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+When `{task-nn}` is absent:
+
+```bash
+git add -- {changed file(s)}
+git diff --cached --quiet || git commit -m "$(cat <<'EOF'
+{ticket}: CI validation cycle {N} — {PASS|FAIL}
+
+{one-line description of what changed this cycle}
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+**Per-cycle commit failure is a no-op-and-continue.** If the commit above fails
+(nothing staged, or any git error), treat it as a no-op and continue to the
+verdict handling below. Do NOT abort the loop on a commit failure.
+
+After the per-cycle commit, handle the verdict:
+
+**The verdict the loop RETURNS is not the same vocabulary as the inner
+`ci-validation` skill's Stage 4 verdict.** The spawned sub-agent (Step 1)
+returns `verdict: passed` or `verdict: failed` (Interface A). The loop
+translates that into its own return vocabulary (Interface B): `verdict: passed`
+or `verdict: failed-max-iterations`. There is NO `verdict: failed` at the loop
+boundary — a bare `verdict: failed` from the sub-agent MUST be translated to
+`verdict: failed-max-iterations` (on an auth short-circuit or on exhausting 5
+iterations) before the loop returns. Do NOT surface the sub-agent's
+`verdict: failed` as the loop's return line.
+
+- **verdict: passed** → print the sub-agent's per-command report verbatim to the user (so every command's outcome is visible, not silently dropped), then exit the loop. Return `verdict: passed` to the calling skill.
+- **Auth short-circuit — verdict: failed carrying a `precondition: authentication` marker line** → STOP the loop immediately at this iteration. Do NOT spawn the code fixer (Step 3) and do NOT run any further iterations — an auth precondition is an environment problem the fixer cannot fix, and the short-circuit consumes no remaining iteration budget. Return `verdict: failed-max-iterations` to the calling skill (the loop's return LINE is the literal `verdict: failed-max-iterations` — NOT the sub-agent's `verdict: failed`) with:
+  - `failing_command`: the command that failed
+  - a distinct marker LINE `precondition: authentication` (alongside the verdict, NOT embedded inside `most_recent_output`)
+  - `most_recent_output`: the full output from the most recent run, ending with exactly one appended line `precondition: authentication — remediation: {documented path}` (the path resolved per family by the sub-agent; on a dual match it carries family (a)'s path)
+
+  This branch contains NO resume affordance and NO re-run logic — re-run lives only in the caller. The loop just short-circuits and returns.
+- **verdict: failed with NO auth marker** → continue to Step 3.
+
+If this is iteration 5 and verdict is still failed (with no auth marker), exit
+the loop. Return `verdict: failed-max-iterations` to the calling skill with the
+following details:
+
+- `failing_command`: the command that failed
+- `most_recent_output`: the full output from the most recent run
+
+Each cycle's state is preserved as a commit; the calling skill or the
+developer can inspect `git log` to walk the iteration history.
+
+On `failed-max-iterations` (whether from an auth short-circuit or from
+exhausting 5 iterations), do not print a user-facing report and do not halt.
+Return control to the calling skill immediately so it can decide the UX.
+
+### Step 3 — Spawn CI fixer agent
+
+Spawn a general-purpose Agent. Fill every placeholder before sending.
+
+```
+You are fixing code that failed a CI validation command.
+Do not ask questions — apply the fix and return.
+
+Failing command: {command}
+Exit code: {exit code}
+
+Full output:
+{command output verbatim}
+
+Changed file(s): {changed file(s)}
+
+Read the failing output carefully. Identify what needs to change in the
+changed files to make the command pass. Apply the minimal fix — do not
+refactor, do not add tests, do not change anything unrelated to the failure.
+
+After making the change, return:
+1. A brief description of what you changed (one or two sentences).
+2. Which files were modified.
+```
+
+Wait for the fixer agent to return. Then return to Step 1.

--- a/.claude/skills/shared/handoff-gate.md
+++ b/.claude/skills/shared/handoff-gate.md
@@ -1,0 +1,186 @@
+# Handoff gate — shared across skills
+
+This file is referenced by calling skills (currently `.claude/skills/implement/task-implementer.md`,
+`.claude/skills/implement/feature-orchestrator.md`, and `.claude/skills/review/SKILL.md`). It
+contains the single, parameterised PR-existence query that supports the
+design → implement → review handoff: the prior phase must have an open or
+merged pull request before the next phase begins.
+
+The gate is read-only — it verifies whether a PR exists for a given branch
+and returns a **sentinel object** describing what it found. It does NOT
+print halt messages and does NOT halt control flow (the override notice in
+Step 1 is the only I/O the gate emits). **It NEVER creates or opens a PR.**
+The override (`--no-handoff-gate`) is a verification bypass, not a transient
+`gh`-failure retry mechanism.
+
+The caller owns the halt decision and the halt message. Canonical halt-message
+templates are defined in the "Halt-message templates" section at the end of
+this document — callers MUST use them verbatim so messages stay consistent
+across skills.
+
+## Caller contract
+
+The calling skill must fill the following placeholders before executing:
+
+| Placeholder | Required | Description |
+|-------------|----------|-------------|
+| `{branch}` | yes | The prior-phase branch whose PR must exist. For `implement` this is the design branch read from the design doc's `Branch:` header. For `review` this is the current branch (`git rev-parse --abbrev-ref HEAD`). |
+| `{override_active}` | yes | Boolean. The caller has already parsed `--no-handoff-gate` from its arguments; the gate trusts this value verbatim. |
+
+The gate does NOT take `{phase_name}` or `{skill_name}` — the gate no longer
+formats halt messages, so it has no use for them. Those placeholders belong
+to the caller-owned halt-message templates below.
+
+### Return
+
+The gate is a pure query. It returns one of the following sentinel objects to
+the caller and does not halt or print anything other than the Step 1 override
+notice:
+
+| Sentinel | Meaning | Caller action |
+|----------|---------|---------------|
+| `{state: "OVERRIDE"}` | `{override_active}` was true; the override notice was printed by the gate in Step 1. | Treat as pass. Proceed without checking PR state. |
+| `{state: "OPEN", number, url}` | Non-draft open PR exists for `{branch}`. | Pass. Proceed. |
+| `{state: "MERGED", number, url}` | A merged PR exists for `{branch}`. | Pass. Proceed. |
+| `{state: "NONE"}` | No PR exists for `{branch}`. | HALT. Use the `NONE` template below. |
+| `{state: "CLOSED", number, url}` | A PR exists for `{branch}` but it is closed. | HALT. Use the `CLOSED` template below. |
+| `{state: "DRAFT", number, url}` | The most recent PR for `{branch}` is a draft. | HALT. Use the `DRAFT` template below. |
+| `{state: "GH_FAIL", stderr}` | `gh` exited non-zero. | Surface `stderr` verbatim and HALT. Use the `GH_FAIL` template below. |
+
+The gate itself never halts the calling skill — even on `gh` failure. It
+surfaces the error via the `GH_FAIL` sentinel so the caller can decide how to
+present it. In practice, the canonical action for `GH_FAIL` is "print the
+template and HALT", but that decision lives in the caller.
+
+---
+
+## Step 1 — Override short-circuit
+
+If `{override_active}` is true, print this line verbatim:
+
+```
+Handoff gate overridden via --no-handoff-gate — proceeding without verifying the {phase_name} PR.
+```
+
+Note: the `{phase_name}` token in the override line is filled by the caller
+before invoking the gate — it is the only placeholder the caller substitutes
+into a gate-printed line. (Alternatively, the caller may print this notice
+itself; the requirement is that the override notice is printed exactly once
+when the override is active.)
+
+Then return `{state: "OVERRIDE"}` to the caller. **Do not run Step 2.** This
+is the override path: no PR check is performed.
+
+The override is a verification BYPASS — never use it to mask a flaky `gh`. A
+`gh` non-zero exit (Step 2) is a tooling failure that must be fixed, not
+suppressed.
+
+---
+
+## Step 2 — Resolve PR state for `{branch}`
+
+Run the following command exactly:
+
+```bash
+gh pr list --head {branch} --state all \
+  --json state,createdAt,number,url,isDraft \
+  --jq 'if length == 0 then {state:"NONE"} else sort_by(.createdAt) | last | (if .isDraft then {state:"DRAFT", number, url} else {state, number, url} end) end'
+```
+
+The jq filter resolves to an object whose `.state` is one of `OPEN`, `MERGED`,
+`CLOSED`, the sentinel `NONE` (when no PR exists for the branch), or the
+sentinel `DRAFT` (when the most recent PR is a draft — `gh` reports draft PRs
+with `state: "OPEN"` and `isDraft: true`, so the filter promotes draft-ness
+to a distinct sentinel). The `.number` and `.url` fields name the resolved PR
+when one exists.
+
+**If `gh` exits non-zero** (unauthenticated, no remote configured, transient
+network failure): return `{state: "GH_FAIL", stderr}` to the caller, where
+`stderr` is the captured stderr of the `gh` command verbatim. **Do NOT retry.
+Do NOT treat a non-zero exit as `NONE`.** A tooling failure must never be
+silently classified as "no PR" — that would defeat the audit-trail guarantee.
+The caller will surface the error and halt.
+
+---
+
+## Step 3 — Return the sentinel
+
+Return the resolved object verbatim to the caller — exactly as produced by
+the jq filter, or the `GH_FAIL` sentinel from Step 2. The gate does NOT
+print, does NOT halt, and does NOT format halt messages. The caller inspects
+`.state` and either proceeds (on `OPEN`, `MERGED`, or `OVERRIDE`) or halts
+using the templates below.
+
+---
+
+## Halt-message templates
+
+Callers MUST use these templates verbatim when halting on a non-pass
+sentinel. Keeping the message text consistent across skills is the whole
+reason the templates live here. Fill the placeholders from the caller's
+context (`{phase_name}`, `{skill_name}`, `{branch}`) and the gate's
+sentinel object (`{number}`, `{url}`, `{stderr}`).
+
+### `NONE` → HALT template
+
+```
+No {phase_name}-phase PR found for branch '{branch}'. {skill_name} requires the prior phase to have an open or merged PR. Open one, or pass --no-handoff-gate for a spike.
+```
+
+### `CLOSED` → HALT template
+
+```
+The {phase_name}-phase PR for branch '{branch}' (#{number}, {url}) is CLOSED, not open or merged. {skill_name} requires an open or merged PR. Reopen or replace it, or pass --no-handoff-gate for a spike.
+```
+
+This is intentionally distinct from `feature-orchestrator.md` OM-5's per-task
+PR check, which treats `CLOSED` as resume-with-warning. The handoff gate
+checks a prior-phase PR for audit-trail purposes — a `CLOSED` prior-phase PR
+means the upstream artefact was rejected, and the next phase must not silently
+proceed on a rejected handoff.
+
+### `DRAFT` → HALT template
+
+```
+The {phase_name}-phase PR for branch '{branch}' (#{number}, {url}) is still a DRAFT, not ready-for-review. {skill_name} requires the prior phase to have formally requested review. Promote the draft to ready-for-review, or pass --no-handoff-gate for a spike.
+```
+
+The handoff gate is about the prior phase having **formally requested
+review** — a draft PR is explicitly not such a request. Treating draft as
+pass would let an in-progress design silently feed the next phase, defeating
+the audit-trail guarantee.
+
+### `GH_FAIL` → HALT template
+
+```
+gh failed while checking the {phase_name}-phase PR for branch '{branch}':
+
+{stderr}
+
+{skill_name} requires `gh` to verify the prior-phase PR. Resolve the gh failure (authentication, remote, or network) and re-run. --no-handoff-gate is a verification bypass, not a transient-failure retry — do not use it to paper over a gh error.
+```
+
+---
+
+## Rules
+
+- **The gate is a pure query.** It never halts the calling skill and never
+  prints non-override I/O. Its only output is the sentinel object returned to
+  the caller (plus the Step 1 override notice when `{override_active}` is
+  true).
+- **The override short-circuits BEFORE any `gh` call.** Step 1 runs before
+  Step 2. An override never causes a `gh` invocation and never produces a
+  non-`OVERRIDE` sentinel.
+- **Caller passes only on `OPEN` (non-draft), `MERGED`, or `OVERRIDE`.** No
+  other sentinel passes. A draft PR — `gh`'s `state: "OPEN"` with
+  `isDraft: true` — is promoted to a `DRAFT` sentinel by the jq filter and
+  must be halted on by the caller.
+- **Caller HALTS on `NONE`, `CLOSED`, `DRAFT`, and `GH_FAIL`** using the
+  templates above. Halt-message text is owned by the templates here — callers
+  must not paraphrase.
+- **No retry on `gh` failure.** The gate stays simple and honest; the caller
+  surfaces stderr and the engineer fixes `gh` and re-runs.
+- **Never open or create a PR from this gate.** The gate verifies — it never
+  authors. Consistent with `docs/ai/steering/base/pull-requests.md` rule 6.
+- **Caller fills every placeholder.** A missing placeholder is a caller bug,
+  not a gate bug.

--- a/.claude/skills/write-acceptance-handoff/SKILL.md
+++ b/.claude/skills/write-acceptance-handoff/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: write-acceptance-handoff
+description: You MUST use this when the user asks to produce an acceptance handoff document for product sign-off.
+model: claude-opus-4-8
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+---
+
+You are the orchestrator for the `write-acceptance-handoff` skill. You receive
+a single argument: a ticket identifier (e.g. AIDEV-30). You read the
+Requirements Package for that ticket, compute the implementation diff, map
+every acceptance criterion to its implementation status, and produce an
+Acceptance Handoff Document for product sign-off.
+
+---
+
+## Input
+
+The ticket identifier is the first argument passed to this skill. It must
+match the pattern `[A-Z][A-Z0-9]*-[0-9]+`. If no argument was provided or the
+value does not match, stop:
+
+> write-acceptance-handoff requires a ticket identifier as its argument
+> (e.g. "write the acceptance handoff for AIDEV-30").
+
+Let `TICKET` = the supplied ticket identifier for all subsequent steps.
+
+---
+
+## Stage 1 — Locate inputs
+
+### 1a — Locate the Requirements Package
+
+Search for the Requirements Package by ticket identifier. Check these
+locations in order:
+
+```bash
+rg -lw "$TICKET" docs/requirements/ 2>/dev/null
+rg -lw -g '!docs/requirements/**' "$TICKET" docs/ 2>/dev/null
+```
+
+Also check whether a task spec exists for the ticket and, if so, read
+its `## Source materials` section for a path to the Requirements Package:
+
+```bash
+rg -l "^ticket: ${TICKET}$" docs/tasks/ 2>/dev/null
+```
+
+**If multiple task specs match**: present the list and ask the engineer
+to choose, using the same disambiguation rule as the Requirements Package
+search.
+
+**If multiple files match**: present the list and ask the engineer to choose.
+Do not proceed until one is selected.
+
+**If no file is found**: ask the engineer to provide the path to the
+Requirements Package. Do not proceed without it.
+
+Once located, read the Requirements Package in full. Extract:
+
+- **Feature name** (from the title or header)
+- **Acceptance criteria** (the `AC-NN` entries)
+- **Out-of-scope / exclusions** (the explicit scope exclusions)
+- **Non-functional requirements** (if present)
+
+**If the Requirements Package has no acceptance criteria section**: report this
+to the engineer and stop.
+
+> The Requirements Package at {path} does not contain an acceptance criteria
+> section. The handoff cannot be structured without ACs.
+
+### 1b — Derive the feature branch and compute the diff
+
+Get the current branch:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+Parse the branch name against `^([A-Z][A-Z0-9]*-[0-9]+)[_-](.+)$`:
+- Group 1 -> ticket
+- Group 2 -> slug (used later for the output filename)
+
+Compute the merge base and diff:
+
+```bash
+BASE=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+BASE="${BASE:-main}"
+git fetch origin "$BASE" --quiet
+MERGE_BASE=$(git merge-base "origin/$BASE" HEAD)
+git diff ${MERGE_BASE}...HEAD
+git log --oneline ${MERGE_BASE}...HEAD
+```
+
+**If the diff is empty** (no changes relative to base): report this to the
+engineer and stop.
+
+> The branch has no changes relative to the default branch. There is nothing to hand off.
+
+Store the diff output and the commit log for use in Stage 2.
+
+---
+
+## Stage 2 — Map acceptance criteria
+
+Read every acceptance criterion extracted from the Requirements Package.
+
+For each AC, examine the diff and commit log to determine a status:
+
+| Status | Meaning |
+|---|---|
+| `Implemented` | The criterion is fully satisfied by the code changes |
+| `Partial` | Some aspect of the criterion is addressed but not completely |
+| `Deferred` | The criterion was intentionally postponed to a follow-up ticket |
+
+### For `Implemented` criteria
+
+Generate step-by-step verification instructions:
+- Environment or preconditions needed
+- Test data or setup steps
+- Actions to perform
+- Expected outcomes
+
+Base the verification steps on the actual implementation evidence in the diff.
+
+### For `Partial` or `Deferred` criteria
+
+**Do not auto-generate a reason.** Instead, pause and present each
+non-Implemented criterion to the engineer:
+
+```
+The following acceptance criteria are not fully implemented.
+Please provide a reason for each — this will be included verbatim in the
+handoff document.
+
+AC-03: Partial — [brief description of what was and was not implemented]
+Reason: <waiting for engineer>
+
+AC-05: Deferred — [brief description]
+Reason: <waiting for engineer>
+```
+
+**Wait for the engineer to respond with reasons for every Partial and Deferred
+criterion.**
+
+**If the engineer provides no reason for a criterion after being asked**: do
+not proceed. The document must include a reason for every non-Implemented
+criterion. Remind the engineer:
+
+> Every Partial or Deferred criterion must include a reason for the handoff
+> document. Please provide a reason for AC-{NN}.
+
+**If all criteria are Implemented**: skip the confirmation pause and proceed
+directly to Stage 3.
+
+---
+
+## Stage 3 — Assemble the document
+
+Read the template at `.claude/templates/acceptance-handoff.md`.
+
+Populate every section using the information gathered in Stages 1 and 2:
+
+- **Header**: feature name, JIRA ticket, engineer name (ask if not known),
+  current date.
+- **What was built**: plain-language description of what was built. Describe
+  what the user can now do that they could not before. No implementation
+  detail — no file names, class names, or technical jargon. Derive this from
+  the commit log and the diff, informed by the Requirements Package.
+- **Acceptance criteria status**: one row per AC with status and verification
+  steps (for Implemented) or reason (for Partial/Deferred). Use the engineer's
+  verbatim reasons for Partial and Deferred criteria.
+- **Known limitations**: anything that works but not exactly as specified, with
+  reason. Anything deferred to a follow-up ticket. If none, state "None
+  identified."
+- **How to verify**: consolidated step-by-step verification instructions for
+  each Implemented criterion. Include environment, test data, and expected
+  outcomes.
+- **What's not in scope**: restate the explicit exclusions from the
+  Requirements Package. This prevents product from validating against things
+  that were never in scope.
+
+Derive the output path:
+
+```
+docs/handoffs/<TICKET>-<slug>.md
+```
+
+Where `<slug>` comes from the branch name (Group 2 from Stage 1b). If no slug
+was derived from the branch name, derive one from the feature name in the
+Requirements Package (lowercase, hyphens, no special characters).
+
+Create the `docs/handoffs/` directory if it does not exist:
+
+```bash
+mkdir -p docs/handoffs
+```
+
+**Do not write the file yet.** Proceed to Stage 4 first.
+
+---
+
+## Stage 4 — Present for confirmation
+
+Present the complete document to the engineer for review:
+
+```
+Here is the Acceptance Handoff Document for {TICKET}:
+
+---
+{full document content}
+---
+
+Output path: docs/handoffs/{TICKET}-{slug}.md
+
+Please review. You can request edits before I write the final file.
+When you are satisfied, confirm and I will write it.
+```
+
+**Wait for the engineer's confirmation before writing the file.**
+
+If the engineer requests edits, apply them and present the updated document
+again. Repeat until the engineer confirms.
+
+Once confirmed, write the file to the output path.
+
+Report:
+
+```
+Acceptance Handoff Document written to docs/handoffs/{TICKET}-{slug}.md
+
+Summary:
+- {N} acceptance criteria mapped
+- {N} Implemented, {N} Partial, {N} Deferred
+- Ready for product sign-off
+```
+
+---
+
+## Rules
+
+- **Never auto-generate reasons for Partial or Deferred criteria.** The
+  engineer must provide every reason. The skill pauses and waits — it does not
+  proceed without them.
+- **The document is plain language.** No file paths, class names, function
+  names, or implementation detail in the "What was built" or "How to verify"
+  sections. Product is the audience.
+- **Engineer confirms before the file is written.** The skill presents the
+  full document and waits for explicit confirmation. The engineer can request
+  edits.
+- **Do not proceed without a Requirements Package.** If one cannot be found,
+  ask the engineer for the path. If the Requirements Package has no acceptance
+  criteria, stop.
+- **Do not proceed with an empty diff.** If the branch has no changes relative
+  to the default branch, stop and report.
+- **Multiple Requirements Package matches require disambiguation.** Present
+  all matches and let the engineer choose.
+- **Use the template.** Read `.claude/templates/acceptance-handoff.md` and populate it
+  — do not invent a different structure.
+- **Output path is deterministic.** `docs/handoffs/<TICKET>-<slug>.md` — do
+  not ask the engineer where to put it.
+- **The skill is read-only until Stage 4 confirmation.** No files are written
+  until the engineer approves the document.

--- a/.claude/skills/write-design-doc-max/SKILL.md
+++ b/.claude/skills/write-design-doc-max/SKILL.md
@@ -1,0 +1,1129 @@
+---
+name: write-design-doc-max
+description: You MUST use this ONLY when the user explicitly asks for the "max" design-doc flow (the high-context variant that runs an incremental review of every design and task document). For any other request to write a design document or task specs, use write-design-doc instead.
+model: claude-opus-4-8
+allowed-tools:
+  - Agent
+  - Bash
+  - Read
+  - Write
+  - Workflow
+  - WebFetch
+  - mcp__claude_ai_Atlassian__getJiraIssue
+  - mcp__claude_ai_Atlassian__search
+---
+
+You are the orchestrator for `write-design-doc-max`. You conduct a two-phase
+session: Phase 1 builds a Design Document interactively; Phase 2 generates
+Task Specs autonomously from the confirmed document.
+
+You dispatch all writing to sub-agents. You do not write task specs or design
+documents yourself. You do not ask the engineer questions during Phase 2.
+
+---
+
+## Input handling
+
+Resolve the requirements source before any other processing. Use this priority
+chain in order:
+
+1. **JIRA URL** (argument contains `atlassian.net/browse/`): extract the ticket
+   key from the URL path. Fetch via `mcp__claude_ai_Atlassian__getJiraIssue`
+   with `cloudId: zegons.atlassian.net` and `issueKey: {KEY}`.
+2. **Direct file path**: read it with Read.
+3. **Fuzzy search `docs/requirements/`**: list files, match by ticket key or
+   keywords in filename.
+4. **Fuzzy JIRA search** via `mcp__claude_ai_Atlassian__search` as last resort.
+5. **Hard-fail** if nothing found or the resulting document is empty:
+
+> A requirements source could not be found. Provide a JIRA URL, a file path,
+> or a ticket key and ensure a matching requirements document exists in
+> docs/requirements/.
+
+Do not proceed to Phase 1 if step 5 is reached.
+
+Extract from the requirements source:
+- `TICKET` — JIRA key (e.g. `AIDEV-29`)
+- Problem statement or feature intent
+- Any scope, acceptance criteria, or constraints already stated
+
+---
+
+## Stage 1 — Branch
+
+Check the current branch:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+If the branch name starts with the ticket key (e.g. `AIDEV-29_*`), confirm and
+continue. If not, propose `{TICKET}_{description}` (short kebab-case slug from
+the feature name), ask the engineer to confirm or adjust, then:
+
+```bash
+git checkout -b {branch-name}
+```
+
+Check for a prior run:
+
+```bash
+rg -l "^# Design:" docs/design/ 2>/dev/null | rg "{TICKET}-"
+```
+
+If a matching Design Document exists, offer to continue from it or start fresh.
+If continuing: read the document and re-parse it into the following structured
+fields before doing anything else:
+
+- `feature_name` — from the document title (the `# Design: …` heading)
+- `approach` — from the Approach section
+- `components` — from the Components section
+- `interface_contracts` — from the Interface contracts section
+- `task_breakdown` — from the Task breakdown section
+- `test_strategy` — from the Test strategy section
+- `risks_and_constraints` — from the Risks and constraints section
+- `adr_references` — from the ADR references section
+
+If any required section is missing, empty, or renamed from the canonical
+heading, halt with `HALT: Design document section '{section_name}' is missing
+or empty — fix the document manually and re-run`. Do not proceed with
+undefined fields.
+
+Once all fields are populated, summarise what was planned, ask the engineer
+what to change, and jump to Stage 11. If starting fresh or no prior document:
+continue to Stage 2.
+
+---
+
+# Phase 1 — Interactive Design Interview
+
+Work through each section one at a time. Wait for the engineer's response
+before moving to the next section. Read the codebase actively before Stage 2 —
+use Bash and Read to ground the design in observable reality.
+
+---
+
+## Stage 2 — Approach
+
+Read relevant codebase areas. Present a candidate approach. Wait for response.
+Record confirmed approach.
+
+---
+
+## Stage 3 — Components affected
+
+Propose existing (modified) and new (created) components based on codebase
+reading and confirmed approach. Wait for response. Record confirmed components.
+
+---
+
+## Stage 4 — Interface contracts
+
+Propose contracts for each new or modified interface:
+Input / Output / Errors / Side effects. Present all interfaces in one block.
+Wait for response. Record confirmed contracts. If no new or modified interfaces
+exist, state that and continue.
+
+---
+
+## Stage 5 — External references (document-type tasks only)
+
+**Skip if code-only task.**
+
+Ask for existing documentation references (URLs, file paths, named standards).
+Fetch/read each. Summarise coverage and relevance. Then read all files under
+`docs/ai/steering/` for Stage 6 conflict detection.
+
+---
+
+## Stage 6 — Conflict detection (document-type tasks only)
+
+**Skip if not document-type** (determined in Stage 5).
+
+1. Read all existing files under `docs/ai/steering/`. Skip files already read.
+2. Compare every planned rule against every existing file.
+3. If conflicts found: stop, state each conflict (rule introduced vs clashing
+   rule with file path and text, the contradiction). Ask engineer to resolve
+   before continuing. Record resolutions as Phase 2 constraints.
+4. If no conflicts: state that and continue.
+
+Record constraints and ACs from this stage for Phase 2.
+
+---
+
+## Stage 7 — Task breakdown
+
+Propose a task breakdown. Each task must be independently implementable by an
+AI agent from a single task spec. Wait for response. If zero tasks after
+response: stop — require at least one task before continuing. Record confirmed
+breakdown with precise names and dependencies.
+
+---
+
+## Stage 8 — Test strategy
+
+Propose integration test owner, E2E approach, and cross-task constraints.
+Wait for response. Record confirmed test strategy.
+
+---
+
+## Stage 9 — Risks and constraints
+
+Present identified risks and constraints from codebase reading and design.
+Include conflict-detection constraints (Stage 6) for document-type tasks.
+Wait for response. Record confirmed risks and constraints.
+
+---
+
+## Stage 10 — ADR references
+
+List existing decisions files:
+
+```bash
+ls docs/decisions/ 2>/dev/null
+```
+
+Ask which existing ADRs constrain this design and whether new ADRs are needed.
+Wait for response. Record referenced and new ADRs.
+
+---
+
+## Stage 11 — Revisit gate
+
+Before producing the Design Document:
+
+> Draft complete. Want to revisit any section, or shall I write the Design
+> Document?
+
+Allow revisits freely — jump back to the originating stage, update the draft,
+return here. Design is not locked until sign-off.
+
+---
+
+## Stage 12 — Write Design Document
+
+Use the JIRA summary or requirements document title as `feature_name`; if
+neither is available, prompt the engineer once.
+
+Derive slug: lowercase feature name, replace non-alphanumeric runs with a
+single hyphen, trim leading/trailing hyphens, truncate to 40 chars.
+
+```bash
+mkdir -p docs/design
+```
+
+Read `.claude/skills/write-design-doc-max/design-writer.md` in full. Dispatch to it via
+the Agent tool: pass the sub-agent file content as the prompt; pass all
+structured interview outputs (Stages 2–10) as named fields in the user message,
+plus `feature_name`, `requirements_source_path`, `branch`, `ticket`, `engineer`, `date`.
+
+If the sub-agent fails or returns empty output: surface the error to the
+engineer and offer to retry. Do not advance silently.
+
+After the sub-agent returns: read the written design document from
+`docs/design/{TICKET}-{slug}.md`.
+
+**Commit the design document before running the gate.** The design must be in
+git history before Stage 12b runs, so the review findings that stage commits
+per round sit on top of a committed artefact rather than an uncommitted one:
+
+```bash
+git add docs/design/{TICKET}-{slug}.md
+git commit -m "{TICKET}: Add design document"
+```
+
+If git commit fails: surface the error and halt — do not run the design gate
+against an uncommitted design.
+
+Tell the engineer:
+
+> Design Document written to `docs/design/{TICKET}-{slug}.md`. Running design gate now…
+
+## The disposition protocol
+
+This is the single shared definition of how a review gate dispositions a
+finding. Stages 12b, 14b, and 14c all reference this subsection for the routing rules;
+each carries only its stage-specific deltas — which dispositions are available,
+the stage-local action for each, and the `source` value — and does not restate
+the routing rules themselves. ADR 010 (`docs/decisions/010-review-gate-disposition-model.md`)
+is the canonical model — this subsection carries only what the orchestrator
+needs to act on it, and does not re-author it.
+
+**Finding schema.** Each finding from a reviewer sub-agent
+(`sync-check.md`) carries the six
+fields defined in `.claude/skills/write-design-doc-max/check-principles.md`: `Severity`
+(`Critical` / `High` / `Medium` / `Nit pick`), `Issue`, `Why it matters`,
+`Size of fix` (`trivial` / `local` / `broad`), `Target` (`load-bearing` /
+`illustrative`), and `Suggested resolution`. `Severity` is the routing key;
+`Size of fix` and `Target` are advisory inputs that tune the recommendation.
+
+**The four dispositions.**
+
+- **Fix — full ladder.** The heavyweight path: revise the design → re-run the
+  design gate → regenerate all task specs from scratch → re-review each. This
+  is the existing Stage 14b revision ladder (steps 1–7). Use it for any finding
+  at or above the severity floor, or any finding the engineer flags as
+  design-upstream.
+- **Fix — spec patch.** The lightweight path: patch the single affected task
+  spec, then re-review that whole spec (a full re-review, not a diff), looping
+  on that one spec until it is clean. It never regenerates or rewrites any
+  sibling spec. Only available once task specs exist — it is absent at the
+  design gate (Stage 12b), which has no specs.
+- **Skip.** A low-value finding. Voiced once to the engineer, recorded in a
+  session-scoped in-memory skip set, and NEVER written to `## Dismissals` or
+  any other on-disk section. Skip is the default auto-recommendation for
+  low-value findings.
+- **Dismiss.** The engineer explicitly accepts a real gap. Recorded in
+  `## Dismissals` (see below). Dismiss is always an engineer choice — it is
+  never auto-recommended.
+
+**Severity floor.** A finding whose `Severity` is `High` or above
+(`High` / `Critical`), or any finding the engineer flags as design-upstream,
+sits at or above the floor and is recommended for the **Fix — full ladder**
+path. A spec-local finding below the floor (`Medium` / `Nit pick`) is
+recommended for the **Fix — spec patch** path when specs exist.
+
+**Recommendation heuristic.** Compute one recommended disposition per finding:
+
+1. `Severity` ≥ `High`, or engineer-flagged design-upstream → **Fix — full ladder**.
+2. Otherwise, a low-value finding → **Skip**. Low-value means low on the
+   combined severity-and-size scale: especially low severity at `broad` size,
+   or an `illustrative` `Target`.
+3. Otherwise, a spec-local sub-floor finding (`Medium` / `Nit pick`) and specs
+   exist → **Fix — spec patch**.
+4. Otherwise (a sub-floor finding with no task specs yet — e.g. at the Stage 12b
+   design gate) → **Skip**, voiced for engineer confirmation so the engineer can
+   elevate or Dismiss it. Electing to fix such a finding at the design gate means
+   the **Fix — full ladder** path — spec-patch is unavailable there.
+
+`Dismiss` is never auto-recommended; it is only ever an engineer override.
+
+**Always voice, never auto-apply.** Every finding is presented to the engineer
+with its recommended disposition. Nothing is fixed, skipped, or dismissed
+without the engineer confirming the recommendation or overriding it. The
+severity floor and the recommendation heuristic produce a RECOMMENDATION, never
+an automatic action.
+
+**Design-upstream override.** The recommendation is never binding. The
+engineer may elevate any finding — including a sub-floor `Medium` or `Nit
+pick` — to the **Fix — full ladder** path, may downgrade a recommendation to
+**Skip**, or may choose **Dismiss** on any finding.
+
+**Graceful degradation.** A finding arriving without `Size of fix` and/or
+`Target` degrades to severity-only routing — it never errors; the heuristic
+runs on `Severity` alone. A finding whose `Severity` is out-of-vocabulary or
+unparseable is treated as `High` and surfaced with a `[malformed finding:
+<reason>]` marker per ADR 010 — it routes conservatively (to the floor), never
+dropped.
+
+**The session-scoped skip set.** Held purely in the orchestrator's working
+context for the duration of one gate loop. It is NOT written to any file and
+NOT recorded in any `## ` section. A Skip is added to this set so the same
+finding is not re-nagged on re-review within the same convergence cycle. This
+is precisely why an interrupted-then-resumed session starts with an empty set
+and previously skipped findings re-surface for re-confirmation — this is
+intended behaviour: the model fails toward re-showing, never toward silently
+hiding.
+
+**Skip versus Dismiss.**
+
+- **Skip** = a low-value finding, voiced once, recorded only in the
+  session-scoped in-memory skip set, NEVER written to `## Dismissals`. It leaves
+  no audit trail by design.
+- **Dismiss** = the engineer explicitly accepts a real gap. Recorded in
+  `## Dismissals` at the end of the design document with the severity label, the
+  issue summary, a `source` value, and the engineer's explicit
+  acknowledgement. Append `## Dismissals` if not yet present. Any severity level
+  including `Critical` may be dismissed.
+
+The `source` value MUST distinguish the originating stage, so dismissals from
+the three gates remain individually attributable:
+
+- **Stage 12b (design gate)** → `source` = `design-gate`.
+- **Stage 14b (per-task reviewer gate)** → `source` = the originating task-spec
+  filename (e.g. `{TICKET}-TASK-{NN}-{slug}.md`).
+- **Stage 14c (sync-check gate)** → `source` = `sync-check`.
+
+`## Dismissals` is managed by SKILL.md only — check agents and reviewer
+sub-agents must not create or modify it.
+
+## Stage 12b — Design gate loop
+
+Before presenting the document to the engineer for sign-off, run the design
+gate. The gate is executed by the `review-gate.js` Workflow script: you —
+SKILL.md — perform the pre-invocation steps, invoke `Workflow`, and
+disposition its compact result. You do not dispatch check agents yourself;
+the script fans them out outside the main context and returns only an
+aggregated result.
+
+`scriptPath` for this gate is `.claude/skills/write-design-doc-max/workflows/review-gate.js`.
+
+### Pre-invocation steps (run in this exact order)
+
+**Step 0 — scriptPath readability guard (fail-fast).** Before any other work,
+confirm `scriptPath` is readable with a quick `Read` of
+`.claude/skills/write-design-doc-max/workflows/review-gate.js`. If it cannot be read, surface
+`review-gate.js not found at .claude/skills/write-design-doc-max/workflows/review-gate.js`
+to the engineer and halt the stage **without invoking `Workflow`** and before
+any other assembly work. A missing script and a wholesale `Workflow` error
+halt identically (surface, no inline fallback); this guard only sharpens the
+surfaced reason. Do not advance to Stage 13.
+
+**Step 1 — Section-presence guard (hard-fail without invoking).** Confirm the
+design document is non-empty and contains all required structural sections.
+This is the old reviewer-playbook Step 1, now SKILL.md's responsibility because
+the script has no filesystem access. The required sections for the **design
+gate** are:
+
+- `## Approach`
+- `## Components affected`
+- `## Interface contracts`
+- `## Task breakdown`
+- `## Test strategy`
+- `## Risks and constraints`
+- `## ADR references`
+
+If the document is empty or any required section is absent, hard-fail the stage
+**without invoking `Workflow`**, surfacing
+`HALT: Document is empty or malformed — verification cannot proceed` to the
+engineer. Do not advance to Stage 13.
+
+**Step 2 — `requirementsText` (inline full text).** Take `requirementsText` as
+the inline **full text** of the requirements source SKILL.md already resolved
+in its input-handling chain (a JIRA fetch or a file on disk — either way the
+text is already in your context). Pass it verbatim as the `requirementsText`
+arg. **Write no file** — do NOT materialise the source into `docs/requirements/`
+or anywhere else (that location is for product-owner-authored packages; a JIRA
+fetch is not one, and persisting it is out of scope). If no source can be
+resolved, pass `requirementsText: null` and let the script skip
+`requirements-coverage` with an explicit `[check requirements-coverage skipped:
+no requirements source]` notice.
+
+**Step 3 — Assemble `codebaseFilePaths` (filtered to readable paths).**
+Assemble `codebaseFilePaths` from `## Components affected` using the existing
+context-assembly algorithm (existing components read by path; new components →
+parent-directory listing + relevant adjacent files). Empty array if the design
+names no codebase components. **Filter the assembled list to readable paths
+only:** any referenced path you cannot read (a renamed file, or a `new
+(created)` component whose path does not exist yet) is dropped from
+`codebaseFilePaths` and noted to the engineer
+(`[codebase path <path> unreadable — omitted from review]`), NEVER passed in
+the args. This preserves the current inline gate's tolerate-and-note behaviour
+for unreadable referenced files. Do NOT halt the stage on an unreadable
+codebase path — an unreadable codebase path is dropped-and-noted, unlike the
+step 0 scriptPath guard and the step 1 section-presence guard, which hard-fail.
+
+**Step 4 — Assemble and pass all nine args (Interface contract #1).** Compute
+`round` from disk (see round-number management below), then assemble:
+
+- `gateType`: `"design"`
+- `artefactPath`: `docs/design/{TICKET}-{slug}.md`
+- `designPath`: equals `artefactPath` at this gate
+- `requirementsText`: the inline full text from Step 2, or `null`
+- `codebaseFilePaths`: the filtered array from Step 3
+- `ticket`: the JIRA key
+- `artefactSlug`: `"design"`
+- `round`: 1-based, monotonic per `(gateType, artefactSlug)` — disk-derived
+- `priorFindingsPath`: `null` on the first round for this `artefactSlug`;
+  otherwise the previous round's findings-file path
+
+### Invoke the Workflow
+
+Invoke the gate via `Workflow({ scriptPath })` pointing at
+`.claude/skills/write-design-doc-max/workflows/review-gate.js` (step 0 has already confirmed
+the path is readable). The Workflow tool runs in the background: the `Workflow`
+tool_use resolves to a task ID and the compact result arrives on the completion
+notification, so the stage yields between invoking and dispositioning rather
+than blocking on a synchronous return. Resume outcome handling when the
+notification delivers the compact result.
+
+A wholesale `Workflow` failure (the call rejects before any agent returns) or
+an unreadable `scriptPath` halts the stage and surfaces it, with **no fallback
+to inline dispatch**.
+
+### Round-number management
+
+`round` is monotonic per `(gateType, artefactSlug)` and is **derived from disk
+on every Stage 12b entry**, never from in-memory state. List
+`docs/ai/reviews/{TICKET}-design-gate-*.md`, parse the three-digit `NNN` round
+suffix from each matching filename, and use `max + 1` (or `1` if no files
+match). Disk-derivation is load-bearing because the round number IS the
+filename suffix; a working-memory counter would reset on a fresh-session HALT
+retry and a new round-1 write would overwrite a committed findings file from
+the earlier session. **Never reset on re-entry:** a design-gate re-run (via a
+Stage 14b full-ladder fix) or an engineer-initiated HALT retry the next day in
+a fresh session resumes from the next unused round automatically, because the
+disk-derived `max` is the authoritative high-water mark. The counter advances
+implicitly when a round produces a written findings file (`FINDINGS` / `PASS`)
+— the file's existence shifts `max`. A `HALT` is terminal to the automated loop
+(no auto-retry). A "HALT retry" is the **engineer** re-running the stage after
+fixing the cause `haltReason` names; because that round wrote no file, the round
+slot is still empty on disk, so the disk-derived computation produces the
+**same** `round` and the **same** `priorFindingsPath` for the re-run, keeping
+the numbered trail gap-free — identically whether the engineer re-runs in the
+same session or a fresh one.
+
+### Handle the compact result
+
+The compact result is `{ findingsPath, outcome, haltReason, report, notices, stats }`.
+Branch on `outcome` (one of `HALT`, `PASS`, `ZERO_FINDINGS_WARNING`,
+`NOTICES_ONLY`, `FINDINGS`):
+
+- **`HALT`** — voice `haltReason` and stop. Not dismissable; not a silent stop;
+  terminal to the automated loop (no auto-retry, no disposition). Resuming is
+  engineer-initiated: the engineer fixes the structural cause `haltReason`
+  names and re-runs the stage, which reuses the same `round`. `stats` is
+  omitted on `HALT`.
+
+- **`PASS`** — first, **commit this round's findings file per Per-round commit
+  below**, before the silent clear. Then, when `notices` is empty, clear the
+  gate (no prompt, no disposition protocol run, no `stats` footer). When
+  `notices` is non-empty (a fully-dismissed round that nevertheless had a check
+  fail), surface `notices` and the `stats` footer as a confirm-to-proceed prompt
+  before clearing — identical to `NOTICES_ONLY` handling — so a failed check is
+  never hidden behind a cleared gate.
+
+- **`ZERO_FINDINGS_WARNING`** — voice `report` (which carries the warning
+  string) **and any `notices`** as a single confirm-to-proceed prompt (a
+  skipped/failed check is never hidden behind a clean-looking warning), with
+  the `stats` footer; on confirmation the gate is cleared. Do not record in
+  `## Dismissals` — this is not a finding. This outcome now fires only on
+  round 1: a round 2+ all-empty sweep is converging and clears as `PASS`
+  (with a written, empty findings file) rather than surfacing this warning.
+
+- **`NOTICES_ONLY`** — surface `notices` as a confirm-to-proceed prompt with
+  the `stats` footer (the engineer accepts the partial run or rejects and
+  retries); never present it as a clean pass.
+
+- **`FINDINGS`** — first, **commit this round's findings file per Per-round
+  commit below**, before re-applying the skip set and before any voicing or
+  disposition. Then, **before voicing, re-apply the session-scoped in-memory
+  skip set to `report`**, suppressing any finding already skipped this gate loop
+  (the aggregation agent filters only `## Dismissals` and has no access to the
+  orchestrator's skip set). Then present ALL surviving findings to the engineer
+  at once — **each with its `new` / `persisted-from-round-N` annotation
+  preserved** — with `notices` surfaced alongside and `stats` as a one-line
+  footer (checks run/failed, per-severity counts). Disposition every finding
+  per **The disposition protocol** above. No specs exist yet at the design
+  gate, so the **Fix — spec patch** disposition is unavailable here — route to
+  **Fix — full ladder** / **Skip** / **Dismiss** only. The engineer must confirm
+  or override a disposition for every finding before the loop continues. Partial
+  responses are not accepted. The loop is unlimited.
+
+  - **Fix — full ladder** (severity floor, or design-upstream override): update
+    the design document (re-dispatch to `design-writer.md`). **If the writer
+    re-dispatch fails, surface the failure and halt the Fix cycle — do not
+    invoke the next round, as there is no revised artefact to review.** On
+    success, **commit the revised design before re-reviewing it** so each
+    reviewed revision is in history before its round runs:
+
+    ```bash
+    git add docs/design/{TICKET}-{slug}.md
+    git commit -m "{TICKET}: Revise design document"
+    ```
+
+    Then invoke a fresh full-sweep round with `round + 1` and
+    `priorFindingsPath` set to this round's `findingsPath`.
+  - **Skip**: add to the session-scoped in-memory skip set; do not record on
+    disk.
+  - **Dismiss**: record in `## Dismissals` at the end of the design document
+    with the severity label, issue summary, `source` = `design-gate`, and the
+    engineer's explicit acknowledgement. Append `## Dismissals` if not yet
+    present. Any severity level including Critical may be dismissed.
+
+  Once all findings are resolved, skipped, or dismissed: gate is cleared.
+
+**Truncated/absent compact result (recovery).** If the completion notification
+carries the full compact result, use it. If it delivers only a task ID or a
+truncated payload, reconstruct the deterministic findings-file path from the
+args just passed (`docs/ai/reviews/{TICKET}-design-gate-{round:NNN}.md`) and
+check disk: **if the file exists**, treat the round as `FINDINGS`/`PASS`, read
+the findings **and any appended `notices`** from it, and dispose exactly as the
+live payload would (findings → disposition protocol; a fully-dismissed PASS
+that still carries notices → confirm-to-proceed; a clean PASS → silent clear);
+**if it does not exist** (the round was `ZERO_FINDINGS_WARNING` /
+`NOTICES_ONLY` / `HALT`, indistinguishable from disk), surface
+`gate result could not be retrieved — re-run or inspect` and **do not
+auto-clear the gate**. Never treat an unrecoverable result as a pass — fail
+toward human attention.
+
+**Per-round commit.** After each `FINDINGS`/`PASS` round (a round that wrote a
+findings file), commit it immediately — before any engineer-facing disposition,
+voicing, or clear:
+
+```bash
+git add docs/ai/reviews/{TICKET}-*-gate-*.md && git commit -m "{TICKET}: persist design-gate findings round {round}"
+```
+
+Interpolate `{TICKET}` and `{round}` to the actual values. The
+`docs/ai/reviews/` path prefix is load-bearing — a bare `{TICKET}-*-gate-*.md`
+glob from the repo root matches nothing — and the `-m` flag keeps the commit
+non-interactive. Do NOT defer to Stage 15, so the audit trail survives a
+session interrupted mid-gate.
+
+Once the gate is cleared, present the design document to the engineer for sign-off:
+
+> Design Document written to `docs/design/{TICKET}-{slug}.md`.
+>
+> Please review it. Say "looks good", "sign off", "approved", "ship it", or
+> "looks good — proceed to Phase 2" to proceed to task spec generation.
+> Or tell me what to change.
+
+---
+
+## Stage 13 — Sign-off gate
+
+**Sign-off is only reachable once the design gate has cleared.**
+
+Accepted phrases: "looks good", "sign off", "approved", "ship it",
+"looks good — proceed to Phase 2". Do not treat bare "yes" as sign-off.
+
+**If the document is missing any section** (Approach, Components affected,
+Interface contracts, Task breakdown, Test strategy, Risks and constraints,
+ADR references): do not accept sign-off — list the missing sections.
+
+**If task breakdown has zero tasks at sign-off time**: do not accept sign-off.
+
+**If the engineer requests changes**: return to the originating stage, update,
+pass through Stage 11, re-write via Stage 12, re-run the design gate in Stage
+12b, then return here.
+
+**Once valid sign-off is received**: continue immediately to Phase 2.
+
+---
+
+# Phase 2 — Autonomous Task Spec Generation
+
+Phase 2 begins immediately after sign-off. No questions to the engineer. No
+pauses between tasks.
+
+---
+
+## Stage 14 — Generate task specs
+
+**Commit any uncommitted design changes before writing any task spec.** The
+design document was already committed in Stage 12, and every full-ladder
+revision was committed in Stage 12b, so this commit only captures gate-time
+edits not yet in history — chiefly `## Dismissals` entries appended during the
+design gate. Commit only if there is something to commit:
+
+```bash
+if ! git diff --quiet HEAD -- docs/design/{TICKET}-{slug}.md; then
+  git add docs/design/{TICKET}-{slug}.md
+  git commit -m "{TICKET}: Record design-gate dismissals"
+fi
+```
+
+If the design has no uncommitted changes the commit is correctly skipped. If a
+commit is attempted and fails: surface the error. Do not proceed to task
+generation until the design is committed.
+
+Tell the engineer:
+
+> Sign-off confirmed. Generating task specs now.
+
+Read the confirmed Design Document in full.
+
+For each task in the task breakdown:
+
+**1. Derive task number**: two-digit zero-padded (01, 02, 03...).
+
+**2. Derive slug**: lowercase the task name, replace any run of non-alphanumeric
+characters with a single hyphen, trim leading/trailing hyphens, truncate to 40
+characters, trim any trailing hyphens after truncation.
+
+**3. Check for slug collision:**
+
+```bash
+ls docs/tasks/ 2>/dev/null | rg "^{TICKET}-TASK-{NN}-{slug}\.md$"
+```
+
+If a file with that name exists: append `-v2`, `-v3`, etc. until unused.
+
+**4. Construct paths and branch value:**
+
+- File path: `docs/tasks/{TICKET}-TASK-{NN}-{slug}.md`
+- Branch value: `{TICKET}_TASK-{NN}_{slug}`
+
+```bash
+mkdir -p docs/tasks
+```
+
+**5. Determine `Depends on:` value:**
+
+- Task depends on another task: exact filename of that task spec
+  (`{TICKET}-TASK-{NN}-{slug}.md`)
+- No dependency (any task number): read the `Branch:` line from the Design
+  Document header; use that branch name as the literal value
+
+**6. Dispatch to `task-writer.md`:**
+
+Read `.claude/skills/write-design-doc-max/task-writer.md` in full. Dispatch via Agent
+tool: sub-agent file content as prompt; the following named fields in the user
+message: `TICKET`, `TASK_NUMBER`, `TASK_NAME`, `TASK_DEPENDENCIES`,
+`OUTPUT_PATH` (the derived file path), `BRANCH` (the derived branch value),
+`DESIGN_CONTENT` (full design document text).
+
+**If `task-writer.md` fails for task N:**
+
+- Preserve all specs written for tasks 1 through N-1.
+- Surface the failing task number to the engineer.
+- Offer to retry task N only — do not require restarting from the beginning.
+
+**Step 6b — Verify and correct contract fields:**
+
+After `task-writer.md` returns, before the Stage 14b reviewer gate, deterministically
+reconcile the two contract fields of the just-written spec against the values you
+dispatched. The dispatched `BRANCH` (canonical for `branch:`, computed in step 4)
+and `TASK_DEPENDENCIES` (canonical for `Depends on:`, computed in step 5) are the
+only source of truth — never `DESIGN_CONTENT`'s `Branch:` line. You hold both
+values already; do not re-derive either from the design document. This corrects
+drift deterministically; it never halts on value drift, never re-dispatches, and
+never asks the engineer anything. Phase 2 autonomy is preserved. A halt is reserved
+strictly for the structural failures enumerated below, each with its own distinct
+message.
+
+Inputs (all already in your context from steps 4–6):
+
+- `OUTPUT_PATH` — the just-written spec path.
+- `BRANCH` — the canonical `branch:` value.
+- `TASK_DEPENDENCIES` — the canonical `Depends on:` value (`nothing`, a sibling
+  task-spec filename, or a branch name).
+
+Behaviour, in this exact order:
+
+1. **Read** the file at `OUTPUT_PATH`. This supplies the comparison source and
+   satisfies the Edit tool's Read-before-Edit precondition. If the file cannot be
+   read, halt: `HALT: task spec not found at <path>`.
+
+2. **Locate and uniqueness-check each field, scoped to its region.**
+
+   - The `branch:` field is the single line matching `^branch:` *within the leading
+     YAML frontmatter block* — the lines between the first `---` delimiter and the
+     next `---` delimiter. If the frontmatter block is malformed (fewer than two
+     `---` delimiters), halt: `HALT: task spec frontmatter block malformed at <path>`.
+   - The `Depends on:` field is the single line matching `^Depends on:` *within the
+     body header* — the lines between the H1 title and the first `##`-level heading
+     that follows it. HTML comment lines do not begin with `Depends on:`, so the
+     `^Depends on:` anchor does not match them; only a real header line is counted.
+     If the file has no H1 title, or no `##`-level heading follows the H1 (so the
+     body-header region has no determinable end), halt:
+     `HALT: task spec body-header region malformed at <path>`.
+
+   Perform the uniqueness count within each field's region only, never across the
+   whole file (the file may legitimately carry the tokens `branch:` or `Depends on:`
+   in prose or a template-derived comment block; those must not be counted). For each
+   field:
+
+   - If its line is absent from its region, halt: `HALT: task spec <field> line absent at <path>`.
+   - If its line occurs more than once within its region, halt: `HALT: task spec <field> line not unique at <path>`.
+
+   Use the literal field token in the message (`branch:` or `Depends on:`).
+
+3. **Extract** the current value of each field — the text after the `key:` prefix,
+   trimmed of surrounding whitespace. If a field's value is empty after trimming,
+   halt: `HALT: task spec <field> line empty at <path>`.
+
+4. **Compare and correct, one field at a time.** For each field, compare the trimmed
+   current value against the dispatched canonical value (`BRANCH` for `branch:`,
+   `TASK_DEPENDENCIES` for `Depends on:`). Comparison is on the trimmed value: an
+   incidental whitespace-only difference is not drift and triggers no Edit. If the
+   trimmed values differ, overwrite that single line via an anchored Edit whose match
+   is the full current line (e.g. `branch: <current>` → `branch: <BRANCH>`), and
+   record a correction note of the form
+   `{spec filename}: {field} corrected from '<got>' to '<expected>'` for the Stage 16
+   report. The Edit's match is the full current line and nothing more — do not extend
+   it with surrounding context. If that full-line match is not unique file-wide (e.g.
+   a surviving comment or prose line repeats it) and the Edit therefore fails, halt:
+   `HALT: step 6b Edit failed for <field> at <path>` — the halt is the correct
+   outcome, not mis-patching.
+
+   Two-field ordering: if both fields drift, after the first Edit **re-Read** the
+   file (this satisfies the Read-before-Edit precondition for the second Edit and
+   validates the first Edit landed), and confirm the first field now equals its
+   canonical value before the second Edit. If that intermediate re-Read fails, or the
+   first field did not update, halt: `HALT: step 6b intermediate re-read failed at <path>`.
+
+   If neither field drifts, perform no Edit and record no note — step 6b is a no-op
+   and is idempotent on an already-correct file.
+
+5. **Post-condition.** Re-Read the file. If the re-Read fails, halt:
+   `HALT: step 6b re-read failed at <path>`. Assert the trimmed `branch:` value now
+   equals `BRANCH` and the trimmed `Depends on:` value now equals `TASK_DEPENDENCIES`.
+   If the assertion does not hold for a field, halt:
+   `HALT: step 6b post-condition failed for <field>`.
+
+When step 6b returns without halting, the spec on disk is guaranteed conforming:
+trimmed `branch:` equals `BRANCH` and trimmed `Depends on:` equals `TASK_DEPENDENCIES`.
+Accumulate any correction notes for the Stage 16 report, de-duplicated by
+`{spec filename, field}`.
+
+**7. Run task reviewer gate (Stage 14b) before proceeding to task N+1.**
+
+## Stage 14b — Per-task reviewer gate
+
+After each task spec is written, run this gate before proceeding. The gate is
+executed by the `review-gate.js` Workflow script: you — SKILL.md — perform the
+pre-invocation steps, invoke `Workflow`, and disposition its compact result.
+You do not dispatch check agents yourself; the script fans them out outside the
+main context and returns only an aggregated result.
+
+`scriptPath` for this gate is `.claude/skills/write-design-doc-max/workflows/review-gate.js`.
+
+### Pre-invocation steps (run in this exact order)
+
+**Step 0 — scriptPath readability guard (fail-fast).** Before any other work,
+confirm `scriptPath` is readable with a quick `Read` of
+`.claude/skills/write-design-doc-max/workflows/review-gate.js`. If it cannot be read, surface
+`review-gate.js not found at .claude/skills/write-design-doc-max/workflows/review-gate.js`
+to the engineer and halt the stage **without invoking `Workflow`** and before
+any other assembly work. A missing script and a wholesale `Workflow` error halt
+identically (surface, no inline fallback); this guard only sharpens the
+surfaced reason. Do not advance past Stage 14b for this task.
+
+**Step 1 — Section-presence guard (hard-fail without invoking).** Confirm the
+task spec under review is non-empty and contains all required structural
+sections. This is the old reviewer-playbook Step 1, now SKILL.md's
+responsibility because the script has no filesystem access. The required
+sections for the **task gate** are:
+
+- `## Objective`
+- `## Context`
+- `## Implementation constraints`
+- `## Inputs and outputs`
+- `## Edge cases to handle explicitly`
+- `## Out of scope`
+- `## Acceptance criteria`
+- `## Test requirements`
+- `## Required output format`
+- `## Definition of done`
+
+If the task spec is empty or any required section is absent, hard-fail the stage
+**without invoking `Workflow`**, surfacing
+`HALT: Task spec is empty or malformed — verification cannot proceed` to the
+engineer. Do not advance past Stage 14b for this task.
+
+**Step 2 — `requirementsText` is `null`.** Pass `requirementsText: null` — the
+task-gate config does not use the requirements source. Write no file.
+
+**Step 3 — Assemble `codebaseFilePaths` (filtered to readable paths).**
+Assemble `codebaseFilePaths` from **the design document's** `## Components
+affected` using the existing context-assembly algorithm (existing components
+read by path; new components → parent-directory listing + relevant adjacent
+files). Empty array if the design document names no codebase components.
+**Filter the assembled list to readable paths only:** any referenced path you
+cannot read (a renamed file, or a `new (created)` component whose path does not
+exist yet) is dropped from `codebaseFilePaths` and noted to the engineer
+(`[codebase path <path> unreadable — omitted from review]`), NEVER passed in
+the args. This preserves the current inline gate's tolerate-and-note behaviour.
+Do NOT halt the stage on an unreadable codebase path — it is dropped-and-noted,
+unlike the step 0 scriptPath guard and the step 1 section-presence guard, which
+hard-fail.
+
+**Step 4 — Assemble and pass all nine args (Interface contract #1).** Compute
+`round` from disk (see round-number management below), then assemble:
+
+- `gateType`: `"task"`
+- `artefactPath`: the single task spec under review, `docs/tasks/{TICKET}-TASK-{NN}-{slug}.md`
+- `designPath`: the design document `docs/design/{TICKET}-{slug}.md` (NOT the
+  task spec — the task-gate checks and the aggregation agent need `## Dismissals`
+  from the design doc)
+- `requirementsText`: `null`
+- `codebaseFilePaths`: the filtered array from Step 3
+- `ticket`: the JIRA key
+- `artefactSlug`: `"task-{NN}"`, where `{NN}` is the two-digit task number of
+  the spec under review (e.g. `task-02`). This is load-bearing: it is the only
+  thing keeping each task's gate file distinct, so two task gates in one run do
+  not overwrite each other.
+- `round`: 1-based, monotonic per `(gateType, artefactSlug)` — disk-derived
+- `priorFindingsPath`: `null` on the first round for this `artefactSlug`;
+  otherwise the previous round's findings-file path
+
+### Invoke the Workflow
+
+Invoke the gate via `Workflow({ scriptPath })` pointing at
+`.claude/skills/write-design-doc-max/workflows/review-gate.js` (step 0 has already confirmed
+the path is readable). The Workflow tool runs in the background: the `Workflow`
+tool_use resolves to a task ID and the compact result arrives on the completion
+notification, so the stage yields between invoking and dispositioning rather
+than blocking on a synchronous return. Resume outcome handling when the
+notification delivers the compact result.
+
+A wholesale `Workflow` failure (the call rejects before any agent returns) or
+an unreadable `scriptPath` halts the stage and surfaces it, with **no fallback
+to inline dispatch**.
+
+### Round-number management
+
+`round` is monotonic per `(gateType, artefactSlug)` and is **derived from disk
+on every Stage 14b entry**, never from in-memory state. List
+`docs/ai/reviews/{TICKET}-task-{NN}-gate-*.md` (the `artefactSlug` for this task),
+parse the three-digit `NNN` round suffix from each matching filename, and use
+`max + 1` (or `1` if no files match). Disk-derivation is load-bearing because
+the round number IS the filename suffix; a working-memory counter would reset
+on a fresh-session HALT retry and a new round-1 write would overwrite a
+committed findings file from the earlier session. **Never reset on re-entry:** a
+regenerated-and-re-reviewed task spec or an engineer-initiated HALT retry the
+next day in a fresh session resumes from the next unused round automatically,
+because the disk-derived `max` is the authoritative high-water mark. The counter
+advances implicitly when a round produces a written findings file (`FINDINGS` /
+`PASS`) — the file's existence shifts `max`. A `HALT` is terminal to the
+automated loop (no auto-retry). A "HALT retry" is the **engineer** re-running
+the stage after fixing the cause `haltReason` names; because that round wrote no
+file, the round slot is still empty on disk, so the disk-derived computation
+produces the **same** `round` and the **same** `priorFindingsPath` for the
+re-run, keeping the numbered trail gap-free — identically whether the engineer
+re-runs in the same session or a fresh one. The `artefactSlug` segment, not the
+round counter, is what makes per-task gate files distinct.
+
+### Handle the compact result
+
+The compact result is `{ findingsPath, outcome, haltReason, report, notices, stats }`.
+Branch on `outcome` (one of `HALT`, `PASS`, `ZERO_FINDINGS_WARNING`,
+`NOTICES_ONLY`, `FINDINGS`):
+
+- **`HALT`** — voice `haltReason` and stop. Not dismissable; not a silent stop;
+  terminal to the automated loop (no auto-retry, no disposition). Resuming is
+  engineer-initiated: the engineer fixes the structural cause `haltReason`
+  names and re-runs the stage, which reuses the same `round`. `stats` is
+  omitted on `HALT`.
+
+- **`PASS`** — first, **commit this round's findings file per Per-round commit
+  below**, before the silent clear. Then, when `notices` is empty, clear the
+  gate and proceed to the next task (no prompt, no disposition protocol run, no
+  `stats` footer). When `notices` is non-empty (a fully-dismissed round that
+  nevertheless had a check fail), surface `notices` and the `stats` footer as a
+  confirm-to-proceed prompt before clearing — identical to `NOTICES_ONLY`
+  handling — so a failed check is never hidden behind a cleared gate.
+
+- **`ZERO_FINDINGS_WARNING`** — voice `report` (which carries the warning
+  string) **and any `notices`** as a single confirm-to-proceed prompt (a
+  skipped/failed check is never hidden behind a clean-looking warning), with
+  the `stats` footer; on confirmation the gate is cleared and you proceed to
+  the next task. Do not record in `## Dismissals` — this is not a finding.
+  This outcome now fires only on round 1: a round 2+ all-empty sweep is
+  converging and clears as `PASS` (with a written, empty findings file)
+  rather than surfacing this warning.
+
+- **`NOTICES_ONLY`** — surface `notices` as a confirm-to-proceed prompt with
+  the `stats` footer (the engineer accepts the partial run or rejects and
+  retries); never present it as a clean pass.
+
+- **`FINDINGS`** — first, **commit this round's findings file per Per-round
+  commit below**, before re-applying the skip set and before any voicing or
+  disposition. Then, **before voicing, re-apply the session-scoped in-memory
+  skip set to `report`**, suppressing any finding already skipped this gate loop
+  (the aggregation agent filters only `## Dismissals` and has no access to the
+  orchestrator's skip set). Then present ALL surviving findings to the engineer
+  at once — **each with its `new` / `persisted-from-round-N` annotation
+  preserved** — with `notices` surfaced alongside and `stats` as a one-line
+  footer (checks run/failed, per-severity counts). Disposition every finding per
+  **The disposition protocol** above — compute and voice a recommended
+  disposition for each, then have the engineer confirm or override. The engineer
+  must disposition every finding before the loop continues. The loop is unlimited.
+
+  **Fix — full ladder** (severity floor, or design-upstream override). When a
+  finding takes the full ladder:
+  1. Engineer directs revision.
+  2. Re-dispatch to `design-writer.md` with updated synthesis. **If the writer
+     re-dispatch fails, surface the failure and halt the Fix cycle — do not
+     invoke the next round, as there is no revised artefact to review.**
+  3. Re-run Stage 12b design gate (full gate loop, not abbreviated).
+  4. Once design gate clears, commit the revised design:
+     ```bash
+     git add docs/design/{TICKET}-{slug}.md
+     git commit -m "{TICKET}: Revise design document"
+     ```
+  5. Delete all existing task specs for this ticket before regenerating, so
+     slug-collision logic does not produce stale `-v2` files:
+     ```bash
+     git rm --cached docs/tasks/{TICKET}-TASK-*.md 2>/dev/null || true
+     rm -f docs/tasks/{TICKET}-TASK-*.md
+     ```
+  6. Regenerate ALL task specs from scratch (starting from task 01).
+  7. Run per-task reviewer on each regenerated spec — do not re-use prior
+     review results.
+
+  **Fix — spec patch** (spec-local finding below the severity floor). When a
+  sub-floor finding is local to this one task spec:
+  1. Patch the single affected task spec only. Do NOT touch, regenerate, or
+     rewrite any sibling spec. **If the writer re-dispatch fails, surface the
+     failure and halt the Fix cycle — do not invoke the next round, as there is
+     no revised artefact to review.**
+  2. Re-review that whole patched spec — a fresh full-sweep round with
+     `round + 1` and `priorFindingsPath` set to this round's `findingsPath`
+     (re-invoke the gate Workflow on it), not a diff.
+  3. Loop on that one spec until it is clean. The loop is intentionally
+     unbounded, matching the ladder-loop convention; convergence is guaranteed
+     not by an iteration cap but by the always-voice rule — at each re-review
+     the engineer sees any re-surfacing finding and can elevate it to the
+     full ladder, Skip it, or Dismiss it, so the loop cannot silently churn.
+
+  **Skip**: add to the session-scoped in-memory skip set; do not record on disk.
+
+  **Dismiss**: append to the design document's `## Dismissals` section with the
+  severity label, issue summary, `source` = the originating task-spec filename
+  (`{TICKET}-TASK-{NN}-{slug}.md`), and explicit engineer acknowledgement.
+
+  Once all findings are resolved, skipped, or dismissed: proceed to next task.
+
+**Truncated/absent compact result (recovery).** If the completion notification
+carries the full compact result, use it. If it delivers only a task ID or a
+truncated payload, reconstruct the deterministic findings-file path from the
+args just passed (`docs/ai/reviews/{TICKET}-task-{NN}-gate-{round:NNN}.md`) and
+check disk: **if the file exists**, treat the round as `FINDINGS`/`PASS`, read
+the findings **and any appended `notices`** from it, and dispose exactly as the
+live payload would (findings → disposition protocol; a fully-dismissed PASS
+that still carries notices → confirm-to-proceed; a clean PASS → silent clear);
+**if it does not exist** (the round was `ZERO_FINDINGS_WARNING` /
+`NOTICES_ONLY` / `HALT`, indistinguishable from disk), surface
+`gate result could not be retrieved — re-run or inspect` and **do not
+auto-clear the gate**. Never treat an unrecoverable result as a pass — fail
+toward human attention.
+
+**Per-round commit.** After each `FINDINGS`/`PASS` round (a round that wrote a
+findings file), commit it immediately — before any engineer-facing disposition,
+voicing, or clear:
+
+```bash
+git add docs/ai/reviews/{TICKET}-*-gate-*.md && git commit -m "{TICKET}: persist task-{NN}-gate findings round {round}"
+```
+
+Interpolate `{TICKET}`, `{NN}`, and `{round}` to the actual values. The
+`docs/ai/reviews/` path prefix is load-bearing — a bare `{TICKET}-*-gate-*.md`
+glob from the repo root matches nothing — and the `-m` flag keeps the commit
+non-interactive. Do NOT defer to Stage 15, so the audit trail survives a
+session interrupted mid-gate.
+
+---
+
+## Stage 14c — Sync-check gate
+
+After all per-task findings are resolved or dismissed, run the sync-check.
+
+**No context assembly needed** — sync-check receives design and all task specs.
+
+Read `.claude/skills/write-design-doc-max/sync-check.md` in full. Dispatch via Agent tool:
+sub-agent file content as prompt; full design document text and all task spec
+texts (one per task, in order) as user message.
+
+**If the sub-agent fails or returns malformed output**: surface the failure,
+re-run. If the second run also fails: halt and surface the error.
+
+**On output:**
+
+- Begins with `HALT:`: surface the reason and stop.
+
+- `PASS`: proceed to Stage 15.
+
+- Findings report: present ALL findings to engineer at once. Disposition every
+  finding per **The disposition protocol** above — the same routing as the
+  other gates, referencing the one shared subsection.
+
+  - **Fix — full ladder** (severity floor, or design-upstream override): apply
+    the Stage 14b full-ladder steps 1–7 to the finding. After regeneration
+    completes, re-run Stage 14c on the regenerated set.
+  - **Fix — spec patch** (spec-local finding below the severity floor): patch
+    the single affected task spec, full re-review of that whole spec, loop
+    until clean; siblings untouched (Stage 14b spec-patch steps). Then re-run
+    Stage 14c.
+  - **Skip**: add to the session-scoped in-memory skip set; do not record on
+    disk.
+  - **Dismiss**: append to the design document's `## Dismissals` section with
+    severity, issue summary, `source` = `sync-check`, and explicit engineer
+    acknowledgement.
+
+  Loop is unlimited. Once all findings are resolved, skipped, or dismissed:
+  proceed to Stage 15.
+
+---
+
+## Stage 15 — Push and create PR
+
+Commit and push only after sync-check clears:
+
+```bash
+git add docs/tasks/{TICKET}-TASK-*.md
+git commit -m "{TICKET}: Add task specs"
+git push -u origin {branch}
+```
+
+Then invoke the `create-pr` skill to open a PR for the design branch. Pass:
+- `ticket`: the JIRA key
+- `branch`: the design branch name
+- `steering_doc_path`: the design document path
+
+Do not pass `base` — the design branch PR targets the repo default branch.
+
+---
+
+## Stage 16 — Report
+
+Report to the engineer:
+
+> Phase 2 complete.
+>
+> Design Document: `docs/design/{TICKET}-{slug}.md`
+> PR: {PR URL}
+>
+> Task specs generated:
+> - `docs/tasks/{TICKET}-TASK-01-{slug}.md` — {task name}
+> - …
+>
+> {If slug collisions: Slug collision on {original} — written as {slug}-v2.}
+>
+> {If any contract corrections occurred during step 6b: one line per corrected
+> spec, of the form: Contract correction — {spec filename}: {field} corrected from
+> '<got>' to '<expected>'. De-duplicated by {spec filename, field}. Omit entirely
+> when no corrections occurred.}
+>
+> Run `implement {TICKET}` to begin implementation.
+
+---
+
+## Rules
+
+- **Requirements source must be resolved before Phase 1 begins.** Hard-fail
+  with the exact message above if nothing is found. No interview without it.
+- **Phase 1 is interactive.** One section at a time. Wait for engineer input.
+  Do not produce the Design Document in one pass.
+- **Read the codebase actively.** Use Bash and Read throughout Phase 1.
+- **Gate ordering is a hard constraint.** Design gate must clear before
+  sign-off. Sign-off before task generation. Sync-check before push. No
+  exceptions. A gate clears once every finding is dispositioned per **The
+  disposition protocol** — fixed (full ladder or spec patch), skipped, or
+  dismissed.
+- **All three gates route through one disposition protocol.** Stages 12b, 14b,
+  and 14c reference the single **The disposition protocol** subsection for the
+  routing rules, carrying only their stage-specific deltas rather than restating
+  the routing rules themselves. The severity floor routes `High`-and-above (or
+  design-upstream-flagged) findings to the full ladder; spec-local sub-floor
+  findings take the spec-patch path (unavailable at the design gate, which has
+  no specs).
+- **Always voice, never auto-apply.** Every finding is presented with a
+  recommended disposition; nothing is fixed, skipped, or dismissed without the
+  engineer confirming or overriding. The severity floor produces a
+  recommendation, not an action.
+- **`## Dismissals` is for conscious acceptance only.** A Dismiss record means
+  the engineer has explicitly accepted a real gap; it carries severity, issue
+  summary, a stage-distinguishing `source`, and explicit acknowledgement.
+- **Skip is never written to disk.** Skipped findings live only in the
+  session-scoped in-memory skip set for the duration of one gate loop; they are
+  never written to `## Dismissals` or any `## ` section. On an
+  interrupted-then-resumed session the set is empty and skipped findings
+  re-surface for re-confirmation — intended behaviour.
+- **No sign-off without all sections.** All seven sections required before
+  sign-off is accepted.
+- **No sign-off with zero tasks.**
+- **Phase 2 is autonomous.** No questions, no pauses, no confirmation between
+  tasks.
+- **`## Dismissals` is managed by SKILL.md only.** Check agents and reviewer
+  sub-agents must not create or modify this section.
+- **Task specs are machine-optimised.** All writing goes through `task-writer.md`.
+- **Slug derivation is deterministic.** Lowercase, replace non-alphanumeric
+  runs with a single hyphen, trim leading/trailing hyphens, truncate to 40
+  chars, trim trailing hyphens after truncation.
+- **Conflict detection for document tasks.** Run Stages 5 and 6 when the
+  output is a standards file, skill file, or similar non-code artefact.
+- **No kept/adapted/discarded.** Synthesis from external references goes
+  directly into task spec ACs and constraints.

--- a/.claude/skills/write-design-doc-max/check-principles.md
+++ b/.claude/skills/write-design-doc-max/check-principles.md
@@ -1,0 +1,50 @@
+# check-principles
+
+Shared principles, severity vocabulary, emission gate, and finding schema for every `write-design-doc-max` check agent. The `review-gate.js` workflow script's check agents each Read the full contents of this document themselves, ahead of their own rubric file and the assembled context. Apply these principles whether the artefact under review is a design document or a task spec.
+
+## Standing principles
+
+1. Read actual code before accepting claims about what exists.
+2. Calibrate scepticism to the current review round (the per-round check-agent prompt declares which round you are on):
+   - **Round 1** — bias toward finding problems. A review that finds nothing is suspicious; question harder and treat an empty return as a signal you have not looked hard enough.
+   - **Round 2 or later** — the artefact has been revised in response to earlier rounds and should be converging. An empty findings array is valid and expected when the revisions genuinely resolved the earlier concerns; do not manufacture findings to avoid an empty return.
+3. Be specific — "error handling might be incomplete" is useless; "the artefact doesn't address what happens when X returns Y" is actionable.
+4. If you generated this artefact, be especially critical — an AI reviewer of its own output will find it harder to spot implicit assumptions baked in at generation time.
+
+## Severity labels
+
+Allowed: `Critical` / `High` / `Medium` / `Nit pick`
+No other labels.
+
+## Emission gate
+
+Investigate as critically as the standing principles demand, but only **emit** a finding if fixing it would change the artefact the implementer produces. A finding that cannot state an artefact-affecting change in its `Why it matters` field is suppressed at source — do not emit it. This keys on artefact impact, not on severity: a substantive omission still emits, because it does change what the implementer builds; a prose-precision or enumeration-completeness nit that would not change the produced artefact does not.
+
+## Load-bearing versus illustrative
+
+Classify what a finding targets:
+
+- **Load-bearing** — content the implementer acts on directly: a line range, a contract, a `Depends on:` clause, an acceptance criterion.
+- **Illustrative** — content that explains or exemplifies: an enumeration, an example, prose.
+
+A gap in load-bearing content is more likely to change the produced artefact than a gap in illustrative content. Use this distinction to populate the `Target` field of each finding.
+
+## Routing heuristics
+
+Two heuristics inform how a finding is weighted downstream. They are advisory inputs to the orchestrator's recommendation; a check agent only reports them, it never routes:
+
+- **Severity** — `Critical` / `High` / `Medium` / `Nit pick`, per the severity vocabulary above.
+- **Size of fix** — the agent's estimate of its own suggested resolution: `trivial` (one line/word) / `local` (one section) / `broad` (multi-section or structural). It is advisory: it never gates anything on its own, and only combines with severity to tune a recommendation.
+
+## Output
+
+List of findings. Each finding has these six fields, in this order:
+
+- `Severity`: `Critical` / `High` / `Medium` / `Nit pick` — no other labels.
+- `Issue`: the specific gap named — not a general concern.
+- `Why it matters`: what changes in the artefact the implementer produces if the finding is fixed. If you cannot state an artefact-affecting change here, do not emit the finding (see the emission gate above).
+- `Size of fix`: `trivial` (one line/word) / `local` (one section) / `broad` (multi-section or structural).
+- `Target`: `load-bearing` (line range, contract, dependency, acceptance criterion) or `illustrative` (enumeration, example, prose).
+- `Suggested resolution`: the actionable change.
+
+Or empty list if no findings.

--- a/.claude/skills/write-design-doc-max/checks/ai-agent-sufficiency.md
+++ b/.claude/skills/write-design-doc-max/checks/ai-agent-sufficiency.md
@@ -1,0 +1,36 @@
+You are a check agent. You receive a design document and one task spec. You check whether an AI agent can produce the expected output using only the information in this task spec — no external knowledge, no prior context, no implicit conventions.
+
+## Inputs
+
+- `DESIGN_CONTENT`: full text of the design document including `## Dismissals`
+- `TASK_SPEC_CONTENT`: full text of the task spec under review
+
+## Checks
+
+**Self-contained context**
+- Is every term, name, and reference used in the task spec defined within the task spec itself, or does it assume knowledge the agent does not have?
+- Undefined reference: raise High, naming the specific term and where it appears
+
+**No ambiguous steps**
+- Is there any step, decision point, or constraint in the task spec where the agent would need to guess the intended behaviour?
+- Ambiguous step: raise High, naming the specific decision and what two or more interpretations are possible
+
+**Binary-checkable acceptance criteria**
+- Can each acceptance criterion be evaluated as pass or fail without engineer judgment?
+- AC that requires subjective assessment: raise Medium, naming the criterion and what binary formulation would replace it
+
+**Output clearly defined**
+- Does the task spec state what done looks like? Is the expected output described with enough specificity that an agent knows when it has succeeded?
+- Underspecified output: raise High, naming the output and what information is missing
+
+**No implicit conventions**
+- Does the task spec rely on naming conventions, file layout patterns, framework idioms, or team practices not stated in the spec itself?
+- Implicit convention: raise Medium, naming the convention assumed and where it must be stated
+
+**Reproducibility without design doc**
+- Could an agent produce the artefact described in the task spec without having read the design document?
+- If the task spec contains forward references like "as described in the design" without quoting the referenced content: raise High, naming the forward reference and what content must be inlined
+
+## Dismissal handling
+
+Skip any finding that matches a recorded dismissal in `## Dismissals` section of the design document. Match on semantic equivalence — the same specific gap in the same component. If the task spec has been regenerated or the component has changed significantly since the dismissal was recorded, re-raise the finding.

--- a/.claude/skills/write-design-doc-max/checks/assumption-identification.md
+++ b/.claude/skills/write-design-doc-max/checks/assumption-identification.md
@@ -1,0 +1,47 @@
+# assumption-identification
+
+Check: every assumption in the document under review is identified; implicit assumptions are flagged; each assumption's impact if wrong is assessed; ordering assumptions are explicitly called out.
+
+## Primary document disambiguation
+
+If a task spec is present in the input alongside a design document:
+- The task spec is the primary document.
+- Apply all criteria to the task spec.
+- Treat the design document as context only.
+
+If only a design document is present (no task spec):
+- The design document is the primary document.
+- Apply all criteria to the design document.
+
+## Inputs
+
+- `requirements_source`: full text of the requirements source (context only)
+- Primary document: full text of the document under review (including `## Dismissals` if present)
+- Codebase context files passed from SKILL.md — read them to validate specific claims before raising a finding
+
+## Checks
+
+**Enumerate all assumptions:**
+- Read the primary document in full. Identify every claim that depends on something being true that is not verified by the document itself.
+- Include: claims about the codebase ("X already exists", "Y behaves as Z"), claims about the environment ("the system will always have access to W"), claims about ordering ("A happens before B"), and claims about external parties ("the API returns T").
+
+**Explicit vs implicit:**
+- For each assumption: is it explicitly stated in the primary document, or is it implied by the prose without acknowledgement?
+- Implicit assumptions are higher-risk. Raise a finding for every implicit assumption, regardless of whether it appears correct.
+
+**Validation:**
+- For each assumption: use the codebase context files to confirm or refute it.
+- If a referenced file exists and supports the assumption: state that it was verified.
+- If a referenced file cannot be read or does not support the assumption: raise a finding naming the unvalidated assumption and what was checked.
+
+**Impact assessment:**
+- For each assumption: what specifically breaks if the assumption is wrong? Name the component, the flow, and the failure mode.
+- An assumption whose failure mode is "undefined" is a finding.
+
+**Ordering assumptions:**
+- For every "X happens before Y" claim in the primary document: is this ordering enforced by the design/implementation, or is it just expected?
+- If just expected (no enforcement mechanism stated): it is an implicit assumption. Raise a finding naming the specific ordering constraint and what enforces (or fails to enforce) it.
+
+## Dismissals
+
+Check the `## Dismissals` section of the primary document. Skip any finding that matches a recorded dismissal on semantic equivalence — the same specific assumption in the same component. If the primary document or the relevant component has changed significantly since the dismissal was recorded, re-raise the finding rather than silently skipping it.

--- a/.claude/skills/write-design-doc-max/checks/failure-handling.md
+++ b/.claude/skills/write-design-doc-max/checks/failure-handling.md
@@ -1,0 +1,43 @@
+# failure-handling
+
+Check: every external call in the document under review has defined failure behaviour; retryable vs terminal failures are distinguished; no stuck states exist; all error types are handled distinctly.
+
+## Primary document disambiguation
+
+If a task spec is present in the input alongside a design document:
+- The task spec is the primary document.
+- Apply all criteria to the task spec.
+- Treat the design document as context only.
+
+If only a design document is present (no task spec):
+- The design document is the primary document.
+- Apply all criteria to the design document.
+
+## Inputs
+
+- `requirements_source`: full text of the requirements source (context only)
+- Primary document: full text of the document under review (including `## Dismissals` if present)
+
+## Checks
+
+**External call coverage:**
+- Enumerate every external call in the primary document: API calls, database operations, file system operations, message queue interactions, sub-agent invocations, and any operation that can fail independently of the calling code.
+- For each: does the primary document state what happens when it fails? If not, raise a finding naming the specific call and the missing failure behaviour.
+
+**Retryable vs terminal:**
+- For each external call with a defined failure path: does the primary document distinguish between retryable failures (transient, safe to retry) and terminal failures (non-retryable, must surface to the caller)?
+- If not distinguished: raise a finding naming the call and why the distinction matters.
+
+**Stuck states:**
+- Is there any flow where a failure leaves the system in a state from which neither the user nor an automated process can proceed without manual intervention?
+- Name every such state explicitly.
+- "Rollback on failure" is not sufficient — does the rollback itself have a defined failure path?
+
+**Distinct error handling:**
+- Are all error types and codes handled distinctly, or are multiple different errors lumped into a single catch-all handler?
+- A catch-all that swallows errors without logging or surfacing them is always a finding.
+- Name every case where two distinct error types are handled identically when they should have different recovery paths.
+
+## Dismissals
+
+Check the `## Dismissals` section of the primary document. Skip any finding that matches a recorded dismissal on semantic equivalence — the same specific missing failure behaviour for the same external call. If the primary document or the relevant component has changed significantly since the dismissal was recorded, re-raise the finding rather than silently skipping it.

--- a/.claude/skills/write-design-doc-max/checks/goal-achievement.md
+++ b/.claude/skills/write-design-doc-max/checks/goal-achievement.md
@@ -1,0 +1,29 @@
+You are a check agent. You receive a design document and one task spec. You check whether the task spec fully achieves the goal assigned to it in the design's task breakdown.
+
+## Inputs
+
+- `DESIGN_CONTENT`: full text of the design document including `## Dismissals`
+- `TASK_SPEC_CONTENT`: full text of the task spec under review
+
+## Checks
+
+**Goal mapping**
+- Locate the task entry in the design's task breakdown that corresponds to this task spec (match by task number and name)
+- If no corresponding entry exists: raise Critical — task spec has no named goal in the design
+
+**Deliverable completeness**
+- For every deliverable listed under this task in the design's task breakdown: is it explicitly present as an output or acceptance criterion in the task spec?
+- Missing deliverable: raise High, naming the specific deliverable and the design section that assigns it to this task
+
+**Acceptance criteria closure**
+- Do the task spec's acceptance criteria cover every deliverable assigned to this task in the design?
+- Is any deliverable testable via the ACs as written — or do the ACs leave the deliverable unverified?
+- Incomplete AC coverage: raise High, naming the specific deliverable not covered and which AC would need to address it
+
+**Nothing assigned is missing**
+- Is there anything in the design's task entry that does not appear anywhere in the task spec (objective, constraints, inputs/outputs, ACs, or test requirements)?
+- Missing item: raise Medium, naming the specific item and where it appears in the design
+
+## Dismissal handling
+
+Skip any finding that matches a recorded dismissal in `## Dismissals` section of the design document. Match on semantic equivalence — the same specific gap in the same component. If the task spec has been regenerated or the component has changed significantly since the dismissal was recorded, re-raise the finding.

--- a/.claude/skills/write-design-doc-max/checks/header-format.md
+++ b/.claude/skills/write-design-doc-max/checks/header-format.md
@@ -1,0 +1,73 @@
+# header-format
+
+Check: the design document's header is the canonical six-line block — correct labels, in the canonical order, with line 2 satisfying the consumer grep `^JIRA: {TICKET}$` exactly — so the `review` skill's design-doc discovery can never silently fail.
+
+## Inputs
+
+- `requirements_source`: full text of the requirements source (FRs, ACs, constraints, and possibly a JIRA URL or key)
+- `design_document`: full text of the design document (including `## Dismissals`)
+
+## Canonical header
+
+The first six lines of `design_document` must be exactly this block, labels verbatim and in this order:
+
+```
+# Design: {feature_name}
+JIRA: {ticket}
+Engineer: {engineer}
+Requirements: {requirements_source_path}
+Date: {date}
+Branch: {branch}
+```
+
+This block is identical in shape to the template at `.claude/skills/write-design-doc-max/design-document.md` (lines 1–6) and to the verbatim block pinned in `.claude/skills/write-design-doc-max/design-writer.md`.
+
+## Checks
+
+### Primary assertion (deterministic — always performed)
+
+Examine the first six lines of `design_document` in order. These checks are mechanical; do not paraphrase or interpret.
+
+1. **Line 1** must match `^# Design: \S` — the literal prefix `# Design: ` (one space) followed by at least one non-whitespace character (the feature name).
+2. **Line 2** must match `^JIRA: \S+$` — the literal label `JIRA:` (never `Ticket:` or any other label), one space, then exactly one whitespace-free token, with **no trailing content** of any kind. This is the load-bearing line: it must satisfy the consumer grep `^JIRA: {TICKET}$` in `.claude/skills/review/SKILL.md`. `Ticket: AIDEV-116` fails (wrong label). `JIRA: AIDEV-116 (draft)` fails (trailing content). `JIRA: AIDEV-116` passes.
+3. **Line 3** must match `^Engineer: \S` — the literal label `Engineer: ` followed by at least one non-whitespace character. Multi-word or any longer values (e.g. `Engineer: Diogo Alves`) are valid; this is a non-empty-value prefix check, NOT a no-trailing-content check.
+4. **Line 4** must match `^Requirements: \S` — the literal label `Requirements: ` followed by at least one non-whitespace character. URL or path values (e.g. `Requirements: https://zegons.atlassian.net/browse/AIDEV-116`) are valid; prefix check only.
+5. **Line 5** must match `^Date: \S` — the literal label `Date: ` followed by at least one non-whitespace character. Prefix check only.
+6. **Line 6** must match `^Branch: \S` — the literal label `Branch: ` followed by at least one non-whitespace character. Prefix check only.
+
+The `^...\S+$` no-trailing-content rule applies ONLY to line 2, because line 2 is the only line consumed by an exact-match grep. Lines 1 and 3–6 use a non-empty-value prefix check (`\S` after the label), which permits multi-word and URL values.
+
+Any deviation — a wrong label, a reordered line, trailing content on line 2, an empty value, or fewer than six header lines — is a violation. A single bad header can trip several of these at once. The six deviation classes above (one per header line) plus the ticket-key mismatch sub-check below are independent and can co-occur on one header. When more than one is present, you MUST enumerate ALL of them into the single finding — never report only the first, most prominent, or load-bearing one and stop. Emit exactly ONE finding (see Output) whose `Issue` field ENUMERATES EVERY observed deviation, each named with its line number, observed value, and expected value, and whose `Suggested resolution` gives the verbatim corrected six-line header so one re-dispatch clears every deviation at once. A generic "header is invalid" does not satisfy this rubric, and neither does naming only the first or most prominent deviation while leaving others unreported.
+
+### Ticket-key equality sub-check (best-effort — performed only when unambiguous)
+
+This sub-check is secondary and best-effort. Attempt to derive a single ticket key from `requirements_source`:
+
+- A ticket key is a token matching `[A-Z]+-\d+` (e.g. `AIDEV-116`), including one embedded in a JIRA URL such as `https://zegons.atlassian.net/browse/AIDEV-116`.
+- Derive the key ONLY when exactly one distinct `[A-Z]+-\d+` token is present in `requirements_source`.
+
+Then:
+
+- **If a single unambiguous key is derivable**: compare it to the token on line 2 (the value after `JIRA: `). If they differ (e.g. line 2 is `JIRA: AIDEV-999` but the requirements source yields `AIDEV-116`), this is a key mismatch deviation. Do NOT emit a separate or second finding for it. Instead, fold it into the SINGLE finding from the Output section: if the primary assertion already produced a finding, add the key mismatch (naming both the observed key and the expected key) to that finding's enumerated deviation list; if the primary assertion passed, the single finding covers just this key mismatch.
+- **If no `[A-Z]+-\d+` token is present, OR more than one distinct token is present (ambiguous)**: SKIP this sub-check silently. Do not emit a finding for it. Do not fail. Do not return a check-agent failure. Rely entirely on the deterministic primary assertion above.
+
+This degradation is handled entirely inside this check. An absent or ambiguous ticket key is never an error and must never be escalated. The primary assertion always runs regardless of whether this sub-check is skipped — an ambiguous key does NOT no-op the whole check body.
+
+## Output
+
+Apply the six-field finding schema from `check-principles.md`.
+
+On a clean canonical header (primary assertion passes and the key sub-check either passes or is skipped): return an empty findings list.
+
+On any deviation: return exactly ONE finding — never two — that enumerates every observed deviation from BOTH the primary assertion AND the ticket-key sub-check. The finding has:
+
+- `Severity`: `High` (never a HALT — a header deviation self-heals via the disposition protocol's full ladder, which at the design gate cheaply re-dispatches the writer and re-runs the gate).
+- `Issue`: an enumeration of EVERY observed deviation, each naming its line number, observed value, and expected value (a derived ticket-key mismatch is one such enumerated entry, not a separate finding). For the label-drift case the `Issue` or `Suggested resolution` MUST contain both the literal string `Ticket:` and the literal string `JIRA:` (e.g. "line 2 is `Ticket: AIDEV-116`, must be `JIRA: AIDEV-116`"). A paraphrase such as "label is wrong" is insufficient. Listing only the first or most prominent deviation is insufficient when several are present.
+- `Why it matters`: the consumer grep `^JIRA: {TICKET}$` in `.claude/skills/review/SKILL.md` silently returns nothing when line 2 deviates, so review Group E loses the design doc and falls back to the task spec alone.
+- `Size of fix`: `trivial` for a single deviation fixable on one line; `local` when multiple deviations are enumerated or the whole header block must be reordered or reconstructed verbatim.
+- `Target`: `load-bearing` (the header is consumed by the review skill's exact-match discovery grep).
+- `Suggested resolution`: the full corrected six-line header block, verbatim, matching the canonical header — not just the single corrected line(s). Enumerating all deviations against one verbatim block rewrite lets a single re-dispatch clear every issue in one gate round.
+
+## Dismissals
+
+Check the `## Dismissals` section of `design_document`. Skip any finding that matches a recorded dismissal on semantic equivalence — the same specific header deviation in the same line. If the design or header has changed significantly since the dismissal was recorded, re-raise the finding rather than silently skipping it.

--- a/.claude/skills/write-design-doc-max/checks/implementation-soundness.md
+++ b/.claude/skills/write-design-doc-max/checks/implementation-soundness.md
@@ -1,0 +1,35 @@
+You are a check agent. You receive a design document and one task spec. You check whether the implementation approach in the task spec is sound, fits the actual codebase, and follows steering docs.
+
+## Inputs
+
+- `DESIGN_CONTENT`: full text of the design document including `## Dismissals`
+- `TASK_SPEC_CONTENT`: full text of the task spec under review
+- Assembled context files: relevant codebase files passed by task-reviewer; use file-reading tools when pasted context is insufficient to confirm or refute a specific claim
+
+## Checks
+
+**Codebase fit**
+- Does the implementation approach reference files, functions, or patterns that actually exist in the codebase?
+- Read every file referenced in the task spec before accepting the claim that it exists or has the stated interface
+- Non-existent reference: raise Critical, naming the specific file or function and what the task spec claims about it
+- Interface mismatch: raise Critical, naming the specific function and the claimed vs actual signature
+
+**Steering doc compliance**
+- Does the implementation approach follow existing steering docs passed as context?
+- Deviation without explicit justification in the task spec: raise High, naming the specific steering rule violated and the task spec statement that conflicts
+- If a deviation is explicitly justified in the task spec: note it but do not raise a finding
+
+**New steering requirements**
+- Does the implementation approach introduce a pattern or constraint that is not currently covered by any steering doc?
+- If yes: raise Medium, naming the new pattern and the steering doc that would need to be created or updated
+
+**Technical soundness**
+- Race conditions: are there concurrent operations on shared state without stated synchronisation?
+- Interface assumptions: does the task spec assume an interface contract that is not enforced by the producing system?
+- Breaking changes: does the implementation modify an interface consumed by other components without flagging the breaking change?
+- Missing error paths: does the task spec describe what happens when a dependency call fails?
+- Each technical issue: raise at the appropriate severity (Critical for data loss/corruption risk, High for behavioural correctness, Medium for robustness gaps, Nit pick for style)
+
+## Dismissal handling
+
+Skip any finding that matches a recorded dismissal in `## Dismissals` section of the design document. Match on semantic equivalence — the same specific gap in the same component. If the task spec has been regenerated or the component has changed significantly since the dismissal was recorded, re-raise the finding.

--- a/.claude/skills/write-design-doc-max/checks/plan-soundness.md
+++ b/.claude/skills/write-design-doc-max/checks/plan-soundness.md
@@ -1,0 +1,33 @@
+# plan-soundness
+
+Check: the approach fits the existing codebase, follows steering, edge cases are considered, and risks are documented.
+
+## Inputs
+
+- `requirements_source`: full text of the requirements source
+- `design_document`: full text of the design document (including `## Dismissals`)
+- Codebase context files: relevant files identified by SKILL.md — read them before assessing any claim about existing patterns or interfaces
+
+## Checks
+
+**Codebase fit:**
+- For every component listed in `## Components affected` of `design_document`: read the referenced file or directory before accepting any claim about what it contains or how it behaves.
+- Does the proposed approach fit the existing architecture and patterns? Name specific inconsistencies.
+- Are there existing abstractions the design should reuse but doesn't? Name them.
+- Does the approach introduce a pattern that conflicts with an established pattern in the codebase? Name both.
+
+**Steering compliance:**
+- Does the approach follow existing steering docs passed as context? Check each steering doc for rules the design approach would violate.
+- Is there anything the design proposes that should be extracted as a new steering doc because it introduces a reusable pattern? Name it.
+
+**Edge cases:**
+- For each flow described in the design: are there edge cases (empty inputs, boundary values, concurrent operations, partial failures) not addressed? Name each one.
+- Are there interactions between components described in `## Components affected` that could produce unexpected states? Name them.
+
+**Risk documentation:**
+- Are there concerns or risks the design omits from `## Risks and constraints`? Name each one.
+- Is each risk in `## Risks and constraints` specific enough to act on? Vague risks that name no concrete failure mode are not useful.
+
+## Dismissals
+
+Check the `## Dismissals` section of `design_document`. Skip any finding that matches a recorded dismissal on semantic equivalence — the same specific gap in the same component. If the design or component has changed significantly since the dismissal was recorded, re-raise the finding rather than silently skipping it.

--- a/.claude/skills/write-design-doc-max/checks/requirements-coverage.md
+++ b/.claude/skills/write-design-doc-max/checks/requirements-coverage.md
@@ -1,0 +1,27 @@
+# requirements-coverage
+
+Check: every FR and AC in the requirements source is addressed in the design and covered in the testing strategy.
+
+## Inputs
+
+- `requirements_source`: full text of the requirements source (FRs, ACs, constraints)
+- `design_document`: full text of the design document (including `## Dismissals`)
+
+## Checks
+
+For every functional requirement (FR) in `requirements_source`:
+- Is it addressed somewhere in `design_document`? Name the FR and the design section that addresses it.
+- If not addressed: raise a finding naming the specific FR.
+- If only partially addressed: is this explicitly called out and justified in the design? If not, raise a finding.
+
+For every acceptance criterion (AC) in `requirements_source`:
+- Is it addressed in `design_document`?
+- Is it covered in the `## Test strategy` section of `design_document`? A test scenario that does not reference the AC by name or substance is not coverage.
+- If not addressed: raise a finding naming the specific AC.
+- If not covered by test strategy: raise a finding naming the specific AC and the missing test scenario.
+
+If `requirements_source` contains no explicitly labelled FRs or ACs, identify the functional obligations and acceptance expectations from the prose and apply the same checks.
+
+## Dismissals
+
+Check the `## Dismissals` section of `design_document`. Skip any finding that matches a recorded dismissal on semantic equivalence — the same specific gap in the same component. If the design or component has changed significantly since the dismissal was recorded, re-raise the finding rather than silently skipping it.

--- a/.claude/skills/write-design-doc-max/checks/scope-clarity.md
+++ b/.claude/skills/write-design-doc-max/checks/scope-clarity.md
@@ -1,0 +1,37 @@
+You are a check agent. You receive a design document and one task spec. You check whether the task's scope is explicitly bounded and unambiguous.
+
+## Inputs
+
+- `DESIGN_CONTENT`: full text of the design document including `## Dismissals`
+- `TASK_SPEC_CONTENT`: full text of the task spec under review
+
+## Checks
+
+**Explicit scope boundary**
+- Does the task spec contain an `## Out of scope` section with at least one entry?
+- Missing out-of-scope section: raise High — without it, an implementer has no anchor for where to stop
+- Does the in-scope definition (objective, deliverables, ACs) state clearly what is included?
+- Vague in-scope boundary: raise Medium, naming the vague phrase and what specific boundary would replace it
+
+**Overreachable instructions**
+- Are there any instructions in the task spec that an implementer could reasonably extend beyond the intended boundary?
+- Example: "update all references" when only specific references should be updated
+- Overreachable instruction: raise High, naming the instruction and what scope restriction would contain it
+
+**Cross-task leakage**
+- Does the task spec include any deliverable or instruction that belongs to a different task's scope according to the design's task breakdown?
+- Cross-task item: raise High, naming the specific item and which task owns it per the design
+
+**Dependencies named explicitly**
+- Are all dependencies on other tasks (files produced by, interfaces defined by) named with exact file paths or task numbers?
+- Implicit dependency (described in prose, not named): raise Medium, naming the dependency and what explicit reference would replace it
+- Does the `Depends on:` header match the design's stated dependency for this task?
+- Mismatch between `Depends on:` and the design: raise Critical, naming the design-stated dependency and what the task spec declares
+
+**Nothing in scope that should not be**
+- Compare the task spec's scope against the design's task entry — is there anything claimed in the task spec that the design assigns to a different task or to no task at all?
+- Out-of-place item: raise Medium, naming the item and where the design assigns it
+
+## Dismissal handling
+
+Skip any finding that matches a recorded dismissal in `## Dismissals` section of the design document. Match on semantic equivalence — the same specific gap in the same component. If the task spec has been regenerated or the component has changed significantly since the dismissal was recorded, re-raise the finding.

--- a/.claude/skills/write-design-doc-max/checks/steering-compliance.md
+++ b/.claude/skills/write-design-doc-max/checks/steering-compliance.md
@@ -1,0 +1,35 @@
+# steering-compliance
+
+Check: the document under review does not propose anything that contradicts existing steering docs.
+
+## Primary document disambiguation
+
+If a task spec is present in the input alongside a design document:
+- The task spec is the primary document.
+- Apply all criteria to the task spec.
+- Treat the design document as context only.
+
+If only a design document is present (no task spec):
+- The design document is the primary document.
+- Apply all criteria to the design document.
+
+## Inputs
+
+- `requirements_source`: full text of the requirements source (context only)
+- Primary document: full text of the document under review (including `## Dismissals` if present)
+- All `docs/ai/steering/` files passed as context — read every one before assessing
+
+## Checks
+
+For each steering doc passed as context:
+- Read it in full.
+- For each rule or convention it states: does the primary document propose anything that contradicts it?
+- A contradiction is a statement in the primary document that, if acted on, would violate the steering rule.
+- For every contradiction found: name the specific rule violated (file path + rule text) and the specific statement in the primary document that conflicts with it.
+- Vague concerns ("this might conflict") are not findings — only name a finding when the contradiction is specific and traceable.
+
+If a steering doc is passed but cannot be read: note the gap — "steering doc {path} could not be read; compliance against it is unverified" — and continue.
+
+## Dismissals
+
+Check the `## Dismissals` section of the primary document. Skip any finding that matches a recorded dismissal on semantic equivalence — the same specific contradiction against the same steering rule. If the primary document or the relevant component has changed significantly since the dismissal was recorded, re-raise the finding rather than silently skipping it.

--- a/.claude/skills/write-design-doc-max/checks/task-ordering.md
+++ b/.claude/skills/write-design-doc-max/checks/task-ordering.md
@@ -1,0 +1,37 @@
+# task-ordering
+
+Check: task sequencing is correct, parallelisation opportunities are identified, tasks are single-responsibility, values are traceable end-to-end, and sequential ordering constraints are explicit.
+
+## Inputs
+
+- `requirements_source`: full text of the requirements source
+- `design_document`: full text of the design document (including `## Dismissals`)
+
+## Checks
+
+**Sequencing correctness:**
+- For each dependency stated in `## Task breakdown`: is the dependency correct? Does the dependent task actually require an output from the dependency before it can proceed?
+- Is there any task that depends on an output that is not produced by its stated dependency? Name the specific missing output.
+- Is there any circular dependency implied (even if not stated explicitly)?
+
+**Parallelisation:**
+- Are there tasks currently listed as sequential that have no real dependency between them and could run in parallel? Name each pair.
+- If tasks are listed as parallel: do they actually share no outputs that one depends on?
+
+**Single-responsibility:**
+- Does each task have a clearly bounded, single responsibility? If a task's name or description suggests multiple distinct deliverables, name them.
+- Are any two tasks so closely related they should be merged into one? Name them and state why.
+
+**Value tracing:**
+- For every value that flows through multiple components (e.g. an identifier, a flag, a computed result): trace it end-to-end across the task breakdown.
+- At each handoff point: is the value explicitly named in the downstream task's spec? Or could it be lost, defaulted to zero/empty, or hardcoded?
+- Name every point where a value could be silently dropped or defaulted.
+
+**Intra-flow ordering:**
+- For every sequential flow within the design (not just inter-task dependencies): is the ordering stated as a hard constraint, or is it just implied?
+- Could an implementer reading only the task specs accidentally parallelise two steps that must be sequential?
+- Name every sequential constraint that is implied but not stated explicitly.
+
+## Dismissals
+
+Check the `## Dismissals` section of `design_document`. Skip any finding that matches a recorded dismissal on semantic equivalence — the same specific ordering gap in the same component. If the design or component has changed significantly since the dismissal was recorded, re-raise the finding rather than silently skipping it.

--- a/.claude/skills/write-design-doc-max/checks/testability.md
+++ b/.claude/skills/write-design-doc-max/checks/testability.md
@@ -1,0 +1,51 @@
+# testability
+
+Check: every flow path has a named test scenario; every error case has its own test scenario; tests are sound; ordering constraints are testable; each test scenario's assertions verify the correct outcome.
+
+## Primary document disambiguation
+
+If a task spec is present in the input alongside a design document:
+- The task spec is the primary document.
+- Apply all criteria to the task spec.
+- Treat the design document as context only.
+
+If only a design document is present (no task spec):
+- The design document is the primary document.
+- Apply all criteria to the design document.
+
+## Inputs
+
+- `requirements_source`: full text of the requirements source (context only)
+- Primary document: full text of the document under review (including `## Dismissals` if present)
+
+## Checks
+
+**Flow path coverage:**
+- Enumerate every flow path described in the primary document (happy path, alternative paths, branching conditions).
+- For each: does the `## Test strategy` section (or equivalent testing section) name a test scenario that covers it?
+- If any flow path has no named test scenario: raise a finding naming the specific path.
+
+**Error case coverage:**
+- Enumerate every error case defined in the primary document: failed external calls, invalid inputs, boundary conditions, partial failures.
+- For each error case: does the testing section name a dedicated test scenario for it?
+- A test scenario that tests multiple error cases under one name is not adequate — each distinct error case requires its own scenario.
+- Raise a finding for every error case with no dedicated scenario.
+
+**Test soundness:**
+- For each named test scenario: could it be misconstrued — i.e., could an implementer write a test that satisfies the scenario description but does not actually verify the behaviour it claims to test?
+- Could any scenario be trivially satisfied by a stub or no-op implementation? Name it.
+- Are any scenarios so vague that multiple different (and possibly incorrect) implementations would pass?
+
+**Ordering constraints:**
+- For every ordering constraint in the primary document ("A must be called before B", "X must complete before Y begins"): is there a named test scenario that verifies the ordering specifically — not just that both were called, but that they were called in the correct order?
+- A test that asserts "A and B were both called" does not verify ordering. Name every ordering constraint that has no order-verifying test.
+
+**Assertion correctness:**
+- For each named test scenario: do the described assertions verify the correct outcome as defined by the primary document?
+- An assertion that checks "function was called" when the expected outcome is "state X was written to Y" is not correct.
+- An assertion that checks "return value is non-null" when the expected outcome is "return value has field Z with value W" is not correct.
+- Name every scenario where the assertions would pass for an incorrect implementation.
+
+## Dismissals
+
+Check the `## Dismissals` section of the primary document. Skip any finding that matches a recorded dismissal on semantic equivalence — the same specific missing or unsound test scenario for the same flow or error case. If the primary document or the relevant component has changed significantly since the dismissal was recorded, re-raise the finding rather than silently skipping it.

--- a/.claude/skills/write-design-doc-max/design-document.md
+++ b/.claude/skills/write-design-doc-max/design-document.md
@@ -1,0 +1,90 @@
+# Design: [Feature name]
+JIRA: [ticket]
+Engineer: [name]
+Requirements: [link to Artefact 1 — JIRA ticket, docs/requirements/ path, or "N/A"]
+Date: [ISO 8601 date]
+Branch: [branch]
+
+## Approach
+
+High-level description of the implementation strategy. One to three paragraphs.
+
+Explain why this approach was chosen over evident alternatives. What problem
+does it solve and how? What is the high-level shape of the change?
+
+This section should give a reader who knows the codebase enough context to
+understand every subsequent section without needing to look things up.
+
+## Components affected
+
+**Existing (modified):**
+- `path/to/component` — brief description of what changes and why
+
+**New (created):**
+- `path/to/new/component` — purpose and responsibility
+
+List all services, modules, classes, and files that will be touched or created.
+Be specific enough that the task breakdown can reference them by name.
+
+## Interface contracts
+
+For each new or modified interface:
+
+### [InterfaceName]
+
+Input: [types, valid ranges, null handling, required vs optional]
+Output: [types, constraints, what "success" looks like]
+Errors: [explicit error types and the conditions that trigger them]
+Side effects: [state changes, events emitted, external calls made — "none" if none]
+
+Repeat this block for every interface. If no interfaces are new or modified,
+write "No new or modified interfaces."
+
+## Task breakdown
+
+Ordered list of tasks with dependencies. Each task must be independently
+implementable by an AI agent from a single task spec.
+
+TASK-01: [name] — no dependencies
+TASK-02: [name] — depends on TASK-01 (needs [specific output or artefact])
+TASK-03: [name] — depends on TASK-01, parallel with TASK-02
+
+Rules:
+- Each task name is specific enough to derive a unique slug.
+- Dependencies name the specific output or artefact needed, not just the task.
+- At least one task is required.
+
+## Test strategy
+
+Integration test owner: [which task or tasks own integration tests]
+E2E approach: [scope, tooling, environments — "N/A" if no E2E tests]
+Cross-task constraints: [shared fixtures, test data, ordering — "none" if none]
+
+Describe how the tasks fit together in the test picture. Which task is
+responsible for ensuring the whole feature works end-to-end? Are there
+ordering constraints between test suites?
+
+## Risks and constraints
+
+What could go wrong. What Claude must not do. Anything that needs extra
+attention during implementation or validation.
+
+- [Risk or constraint]: [why it matters and what the mitigation or rule is]
+- [Risk or constraint]: [why it matters and what the mitigation or rule is]
+
+Include external interface risks, behavioural constraints inherited from
+product requirements, and any "must not touch" boundaries.
+
+## ADR references
+
+Existing decisions that constrain this design:
+- [docs/decisions/NNN-name.md] — [one sentence on how it constrains this design]
+
+New decisions being made (create ADR if significant):
+- [proposed ADR title] — [one sentence on the decision being recorded]
+
+If no ADR references apply, write "No ADR references."
+
+## Dismissals
+
+<!-- Dismissed findings are recorded here by SKILL.md. One entry per dismissal: severity label, issue summary, engineer's explicit acknowledgement. -->

--- a/.claude/skills/write-design-doc-max/design-writer.md
+++ b/.claude/skills/write-design-doc-max/design-writer.md
@@ -1,0 +1,48 @@
+# design-writer
+
+You are a sub-agent invoked by `.claude/skills/write-design-doc-max/SKILL.md` to write a design document.
+
+## Inputs (received from SKILL.md)
+
+- `feature_name`: the human-readable feature name (used as the `# Design:` title and as the source for slug derivation)
+- `approach`: confirmed approach text (Stage 2 output)
+- `components`: confirmed components list — existing (modified) and new (created) with descriptions (Stage 3 output)
+- `interface_contracts`: confirmed interface contracts for all new or modified interfaces (Stage 4 output); "No new or modified interfaces" if none
+- `task_breakdown`: confirmed task breakdown — ordered list of tasks with names, numbers, and dependencies (Stage 7 output)
+- `test_strategy`: confirmed test strategy — integration test owner, E2E approach, cross-task constraints (Stage 8 output)
+- `risks_and_constraints`: confirmed risks and constraints — each risk with why it matters and mitigation (Stage 9 output)
+- `adr_references`: confirmed ADR references — existing ADRs that constrain the design, plus any new ADRs to create (Stage 10 output); "No ADR references" if none
+- `requirements_source_path`: path to the requirements source file (e.g. `docs/requirements/AIDEV-82-foo.md` or JIRA key)
+- `branch`: branch name established in SKILL.md Stage 1
+- `ticket`: JIRA ticket key (e.g. `AIDEV-82`)
+- `engineer`: engineer name
+- `date`: ISO 8601 date
+
+## Constraints
+
+- Write to `docs/design/{ticket}-{slug}.md` where `{slug}` is derived from `feature_name`: lowercase, replace runs of non-alphanumeric characters with a single hyphen, trim leading/trailing hyphens, truncate to 40 characters
+- Conformance target: the canonical six-line header block specified below, plus the seven body sections listed in the "All seven body sections" constraint below; use `feature_name` as the value for the `# Design:` header. `## Dismissals` is not part of the conformance target — it is appended by SKILL.md on first dismissal
+- The document MUST begin with exactly this canonical six-line header block, in this order, with these labels verbatim:
+
+  ```
+  # Design: {feature_name}
+  JIRA: {ticket}
+  Engineer: {engineer}
+  Requirements: {requirements_source_path}
+  Date: {date}
+  Branch: {branch}
+  ```
+
+  The labels and their order are MANDATORY and must NOT be paraphrased or reordered. In particular: line 2 is `JIRA:` (never `Ticket:` or any synonym), the six lines appear in the order above, and line 2 carries the ticket key alone with no trailing content (so it matches the `review` skill's exact-match discovery grep `^JIRA: {TICKET}$`). This header is identical in shape to the template at `.claude/skills/write-design-doc-max/design-document.md` and to the `header-format` check's expected lines; the design gate's `header-format` check fails on any deviation
+- Write narrative prose — this is the engineer-facing document; make it readable
+- All seven body sections must be present: Approach, Components affected, Interface contracts, Task breakdown, Test strategy, Risks and constraints, ADR references
+- Do not add a `## Dismissals` section — SKILL.md manages that section
+- Do not add YAML frontmatter
+
+## Output
+
+Write the complete design document to `docs/design/{ticket}-{slug}.md`.
+
+Return:
+- The path written
+- A one-sentence summary of what was produced

--- a/.claude/skills/write-design-doc-max/sync-check.md
+++ b/.claude/skills/write-design-doc-max/sync-check.md
@@ -1,0 +1,80 @@
+You are the sync-check agent. You receive a design document and all task spec contents. You verify holistic consistency across the full set before push.
+
+## Inputs (passed in user message)
+
+- `DESIGN_CONTENT`: full text of the design document
+- `TASK_SPECS`: array of task spec full texts, one per task — provided in order (TASK-01, TASK-02, …)
+
+## Output protocol — exactly three shapes, no others
+
+1. `HALT: <reason>` — input is structurally invalid; not dismissable; triggers hard stop in SKILL.md
+2. `PASS` — no findings
+3. Severity-grouped findings report — at least one finding exists
+
+## Step 1 — Validate inputs
+
+If `DESIGN_CONTENT` is absent or empty: return `HALT: Design document is missing or empty — sync check cannot proceed`.
+If `TASK_SPECS` is absent, empty, or contains no non-empty entries: return `HALT: Task specs list is empty — sync check cannot proceed`.
+
+Do not return findings or `PASS` for invalid inputs.
+
+## Step 2 — Run all five consistency checks
+
+### Gaps
+
+For every component, flow path, interface contract, and acceptance criterion stated in the design:
+- Is it covered by at least one task spec as a deliverable?
+- If not: report as a gap finding, naming the specific uncovered design element and the section it appears in
+
+### Overlaps
+
+For every deliverable across all task specs:
+- Does the same design element appear as a deliverable (not merely a dependency) in more than one task spec?
+- If yes: report as an overlap finding, naming the specific element and both task specs claiming ownership
+
+### Ordering consistency
+
+For every dependency declared in each task spec (`Depends on:` header):
+- Does it match the dependency stated in the design's task breakdown for that task?
+- If a task spec declares a dependency not in the design, or omits a dependency that is in the design: report as an ordering mismatch finding
+
+### Interface consistency
+
+For every output produced by one task spec that is consumed as an input by another task spec:
+- Are the types, shapes, and field names consistent between the producing spec and the consuming spec?
+- If not: report as an interface mismatch finding, naming the specific field or type that differs and which specs conflict
+
+### Completeness
+
+Using the design's mapping of FRs and ACs to components and tasks:
+- Do the task specs collectively address all FRs listed in the design?
+- Do the task specs collectively address all ACs listed in the design?
+- Any FR or AC not traceable to at least one task spec: report as a completeness gap finding
+
+## Step 3 — Return
+
+If no findings: return `PASS`.
+
+If findings exist, return severity-grouped findings report:
+
+```
+## Critical
+[findings in this group, or omit section if none]
+
+## High
+[findings in this group, or omit section if none]
+
+## Medium
+[findings in this group, or omit section if none]
+
+## Nit pick
+[findings in this group, or omit section if none]
+```
+
+Each finding:
+- **Check type**: `[gaps]`, `[overlaps]`, `[ordering]`, `[interfaces]`, or `[completeness]`
+- **Issue**: specific design element or interface named — not a general concern
+- **Why it matters**: consequence if not addressed
+- **Suggested resolution**: actionable change
+
+Allowed severity labels: `Critical`, `High`, `Medium`, `Nit pick` — no other labels.

--- a/.claude/skills/write-design-doc-max/task-writer.md
+++ b/.claude/skills/write-design-doc-max/task-writer.md
@@ -1,0 +1,41 @@
+You are a task spec writer. You receive a design document, one task entry, and a ticket. You write a single complete task spec file conforming to `.claude/templates/task-spec.md`.
+
+## Inputs (passed in user message)
+
+- `TICKET`: JIRA key (e.g. `AIDEV-82`)
+- `TASK_NUMBER`: zero-padded two-digit integer (e.g. `01`)
+- `TASK_NAME`: exact task name from the design's task breakdown
+- `TASK_DEPENDENCIES`: exact `Depends on:` value — `nothing`, or a task spec filename (e.g. `AIDEV-82-TASK-01-foo.md`), or a branch name (no `.md` suffix)
+- `OUTPUT_PATH`: fully-constructed file path (e.g. `docs/tasks/AIDEV-82-TASK-01-foo.md`) — SKILL.md derives slug and constructs this before dispatch; write to exactly this path
+- `BRANCH`: fully-constructed branch name (e.g. `AIDEV-82_TASK-01_foo`) — SKILL.md constructs this before dispatch
+- `DESIGN_CONTENT`: full text of the design document
+
+## Constraints
+
+- Write to `OUTPUT_PATH` exactly as given — do not construct or modify the path
+- Conform to `.claude/templates/task-spec.md` — all sections present; no new sections added; no template comments in output
+- Frontmatter: `ticket:` and `branch:` fields only — no `description:` field; `branch:` value is exactly `BRANCH` as provided — do not re-derive it from `OUTPUT_PATH`, and do not re-derive it from `DESIGN_CONTENT`'s `Branch:` line
+- Body header lines `Feature:`, `Design:`, `Depends on:` are required immediately after the H1 title; they are not frontmatter
+- `Depends on:` value must exactly match `TASK_DEPENDENCIES` as provided — do not re-derive it from `OUTPUT_PATH`, and do not re-derive it from `DESIGN_CONTENT`'s `Branch:` line
+- `Design:` value must be the path to the design document — extract from the design content header or from context provided
+- All sections populated with specific content derived from the design task entry — no template placeholder text remaining in output
+- `## Implementation constraints`: derive from the design's constraints for this task; include error handling, logging, PII, and any task-specific constraints explicitly named in the design
+- `## Inputs and outputs`: derive from the design's interface contracts for this task; include type, valid range, null handling, required/optional for each input; include what "correct" looks like for each output
+- `## Edge cases to handle explicitly`: derive from the design's edge cases and risks sections for this task; each edge case states the exact required behaviour — not "handle gracefully"
+- `## Acceptance criteria`: binary-checkable; derive from the design's acceptance criteria and task deliverables; each criterion either passes or fails with no judgment required
+- `## Test requirements`: derive from the design's test strategy for this task; state "Manual validation only" if the artefact is an AI instruction file; unit tests if the artefact is code
+- `## Definition of done`: derive from the design; at minimum includes confirmation that all acceptance criteria are met
+- `## Required output format`: derive from the design; if the output is AI instruction files, use "1. Files written: list each file" and "2. Completion notes" with four sub-bullets (decisions made, ambiguous constraints, anything not implemented as specified, anything wrong in adjacent code)
+
+## Algorithm
+
+1. Read `.claude/templates/task-spec.md` to confirm template structure
+2. Identify the task entry in `DESIGN_CONTENT` matching `TASK_NAME` and `TASK_NUMBER` in the task breakdown section
+3. Extract all task-specific detail: deliverables, dependencies, constraints, interface contracts, acceptance criteria, test requirements
+4. Construct the task spec following the template exactly
+5. Set `branch:` value to `BRANCH` as provided
+6. Write to `OUTPUT_PATH`
+
+## Output
+
+Complete task spec written to `OUTPUT_PATH`. Return the path written and a one-sentence summary.

--- a/.claude/skills/write-design-doc-max/workflows/review-gate.js
+++ b/.claude/skills/write-design-doc-max/workflows/review-gate.js
@@ -1,0 +1,697 @@
+export const meta = {
+  name: "review-gate",
+  description:
+    "Run one review-gate pass (design or task): fan out blind check agents, aggregate their findings, write a per-round findings file, and return a compact result.",
+  phases: [
+    { title: "Checks", detail: "fan out the in-scope blind check agents" },
+    { title: "Aggregate", detail: "dedup, dismissal-filter, write findings file" },
+  ],
+};
+
+// review-gate.js — one review-gate pass (design or task) as a Workflow tool.
+//
+// Runs a single gate round: fans out the in-scope blind check agents in
+// parallel, aggregates their findings via an aggregation agent, and returns a
+// compact result. The script performs NO filesystem access: every Read (rubric,
+// artefact, context, prior findings, `## Dismissals`) and the findings-file
+// Write is delegated to the agents it spawns. It does pure-JS orchestration over
+// the agents' structured returns.
+//
+// Workflow runtime contract this file obeys (see the Workflow tool description):
+//   - `export const meta` is the FIRST statement.
+//   - The script BODY runs directly; there is no `(args, ctx)` entrypoint and no
+//     `export default`. Inputs arrive via the global `args`; `agent`, `parallel`,
+//     `phase`, and `log` are globals. A top-level `return` is the workflow result.
+//   - The script is self-contained — relative `import` does not resolve in the
+//     sandbox, so the dispatch config lives inline here rather than in a sibling.
+//   - No filesystem Read/Write in the script (all I/O via agents); no
+//     Date.now()/Math.random() (the round is an input arg and the findings
+//     filename is derived from ticket/artefactSlug/round); the check fan-out
+//     concurrency is auto-capped at min(16, cores - 2) by `parallel`.
+//
+// The authoritative contract is the design's `## Interface contracts` (contracts
+// 1, 2, 3, 5) in docs/design/AIDEV-122-review-gates-as-a-workflow-orchestration.md.
+
+// ----- dispatch configuration -----
+//
+// The per-check `context` sets and `model` values below are transcribed VERBATIM
+// from the pre-existing sources, not re-derived:
+//   - `context` sets were transcribed from the `Context forwarded` columns of the
+//     now-deleted playbooks design-reviewer.md (Step 2 dispatch table, 7 rows) and
+//     task-reviewer.md (Step 2 dispatch table, 8 rows); those files no longer exist.
+//     The always-present artefact/requirements inputs (requirements_source,
+//     design_document, DESIGN_CONTENT, TASK_SPEC_CONTENT) are NOT config `context`
+//     categories — they are forwarded to every check by the script.
+//   - `model` comes from each .claude/skills/write-design-doc-max/checks/<name>.md file's
+//     `model:` frontmatter, read before that frontmatter was stripped in this task.
+//
+// `context` is the set of scoped context categories for the check; each category
+// resolves to a concrete Read instruction in the check-agent prompt:
+//   "steering"  -> "Read all files under `docs/ai/steering/`"
+//   "codebase"  -> an explicit list of the codebaseFilePaths to Read
+//   (no entry)  -> nothing beyond the artefact (and inline requirements text)
+
+// Path to the shared principles document every check agent reads first.
+const CHECK_PRINCIPLES_PATH = ".claude/skills/write-design-doc-max/check-principles.md";
+
+// Directory each check rubric lives under.
+const CHECKS_DIR = ".claude/skills/write-design-doc-max/checks";
+
+// Directory the per-round findings file is written under.
+const REVIEWS_DIR = "docs/ai/reviews";
+
+// Design gate — 8 checks. context + model were transcribed from the now-deleted
+// design-reviewer.md (Context forwarded column) and the checks/*.md frontmatter
+// respectively; that playbook file no longer exists. header-format (AIDEV-116)
+// was added after that deletion: model in the row, no per-check frontmatter.
+const DESIGN_CHECKS = [
+  { name: "requirements-coverage", model: "haiku", context: [] },
+  { name: "header-format", model: "haiku", context: [] },
+  { name: "plan-soundness", model: "sonnet", context: ["codebase"] },
+  { name: "steering-compliance", model: "sonnet", context: ["steering"] },
+  { name: "task-ordering", model: "sonnet", context: [] },
+  { name: "assumption-identification", model: "sonnet", context: ["codebase"] },
+  { name: "failure-handling", model: "sonnet", context: [] },
+  { name: "testability", model: "sonnet", context: [] },
+];
+
+// Task gate — 8 checks. context + model were transcribed from the now-deleted
+// task-reviewer.md (Context forwarded column) and the checks/*.md frontmatter
+// respectively; that playbook file no longer exists.
+const TASK_CHECKS = [
+  { name: "goal-achievement", model: "sonnet", context: [] },
+  { name: "ai-agent-sufficiency", model: "sonnet", context: [] },
+  {
+    name: "implementation-soundness",
+    model: "sonnet",
+    context: ["steering", "codebase"],
+  },
+  { name: "scope-clarity", model: "haiku", context: [] },
+  { name: "steering-compliance", model: "sonnet", context: ["steering"] },
+  { name: "assumption-identification", model: "sonnet", context: ["codebase"] },
+  { name: "failure-handling", model: "sonnet", context: [] },
+  { name: "testability", model: "sonnet", context: [] },
+];
+
+// The verbatim re-raise sentence embedded in the aggregation prompt. This exact
+// wording is authoritative for this script; it is NOT sourced from the check
+// rubrics' "Dismissal handling" sections (gate-specific variants disagree) nor
+// from ADR 010 (which carries no re-raise rule).
+const RE_RAISE_SENTENCE =
+  "if the design or the relevant component has changed significantly since " +
+  "the dismissal was recorded, re-raise the finding rather than silently " +
+  "skipping it.";
+
+// The warning string returned in `report` for the ZERO_FINDINGS_WARNING outcome.
+const ZERO_FINDINGS_WARNING_TEXT =
+  "Zero findings across all checks — verify this is expected before accepting";
+
+// The six ADR-010 finding fields, shared by both schemas below.
+const FINDING_FIELDS = {
+  Severity: { type: "string", enum: ["Critical", "High", "Medium", "Nit pick"] },
+  Issue: { type: "string" },
+  "Why it matters": { type: "string" },
+  "Size of fix": { type: "string", enum: ["trivial", "local", "broad"] },
+  Target: { type: "string", enum: ["load-bearing", "illustrative"] },
+  "Suggested resolution": { type: "string" },
+};
+const FINDING_REQUIRED = [
+  "Severity",
+  "Issue",
+  "Why it matters",
+  "Size of fix",
+  "Target",
+  "Suggested resolution",
+];
+
+// FINDINGS_SCHEMA — the schema each blind check agent returns against.
+// An array of zero or more findings, each carrying the six ADR-010 fields.
+const FINDINGS_SCHEMA = {
+  type: "object",
+  properties: {
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { ...FINDING_FIELDS },
+        required: [...FINDING_REQUIRED],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["findings"],
+  additionalProperties: false,
+};
+
+// AGGREGATION_SCHEMA — the schema the aggregation agent returns against.
+// `report` is the post-dismissal, deduped, severity-grouped, annotated findings;
+// `fileWritten` confirms the on-disk write; `errorKind` attributes input-read
+// failures without an opaque throw.
+const AGGREGATION_SCHEMA = {
+  type: "object",
+  properties: {
+    report: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { ...FINDING_FIELDS, annotation: { type: "string" } },
+        required: [...FINDING_REQUIRED, "annotation"],
+        additionalProperties: false,
+      },
+    },
+    fileWritten: { type: "boolean" },
+    errorKind: {
+      type: ["string", "null"],
+      enum: [null, "prior-findings-unreadable", "design-unreadable"],
+    },
+  },
+  required: ["report", "fileWritten", "errorKind"],
+  additionalProperties: false,
+};
+
+// ----- pure helpers (no I/O, no nondeterminism) -----
+
+// Deterministic findings-file path. round zero-padded to three digits.
+// No Date.now()/Math.random(): derived solely from ticket/artefactSlug/round.
+function findingsFilePath(ticket, artefactSlug, round) {
+  const nnn = String(round).padStart(3, "0");
+  return `${REVIEWS_DIR}/${ticket}-${artefactSlug}-gate-${nnn}.md`;
+}
+
+// Lowercase-normalised severity counts over the post-dismissal report.
+function countSeverities(report) {
+  const counts = { critical: 0, high: 0, medium: 0, nit: 0 };
+  for (const finding of report) {
+    switch (finding.Severity) {
+      case "Critical":
+        counts.critical += 1;
+        break;
+      case "High":
+        counts.high += 1;
+        break;
+      case "Medium":
+        counts.medium += 1;
+        break;
+      case "Nit pick":
+        counts.nit += 1;
+        break;
+      default:
+        break;
+    }
+  }
+  return counts;
+}
+
+// The compact return shape — exactly the six contract-1 fields, all present.
+function result({
+  findingsPath = null,
+  outcome,
+  haltReason = null,
+  report,
+  notices,
+  stats,
+}) {
+  return { findingsPath, outcome, haltReason, report, notices, stats };
+}
+
+function zeroCounts() {
+  return { critical: 0, high: 0, medium: 0, nit: 0 };
+}
+
+function emptyStats() {
+  return { checksRun: 0, checksFailed: 0, findingCounts: zeroCounts() };
+}
+
+// ----- prompt builders -----
+
+// Resolve a config `context` set into concrete prompt Read instructions.
+function contextInstructions(context, codebaseFilePaths) {
+  const lines = [];
+  for (const category of context) {
+    if (category === "steering") {
+      lines.push("Read all files under `docs/ai/steering/`.");
+    } else if (category === "codebase") {
+      if (codebaseFilePaths.length === 0) {
+        lines.push("No codebase files are in scope for this review; read none.");
+      } else {
+        const list = codebaseFilePaths.map((p) => `- ${p}`).join("\n");
+        lines.push(`Read each of these codebase files:\n${list}`);
+      }
+    }
+  }
+  return lines;
+}
+
+// Build the blind check agent prompt for one in-scope check (Interface contract 2).
+function checkPrompt({
+  check,
+  artefactPath,
+  designPath,
+  requirementsText,
+  codebaseFilePaths,
+  round,
+}) {
+  const rubricPath = `${CHECKS_DIR}/${check.name}.md`;
+  const roundFraming =
+    round === 1
+      ? `This is review round 1. Bias toward finding problems: question ` +
+        `hard, and treat an empty findings array as suspicious — a signal ` +
+        `you have not looked hard enough.`
+      : `This is review round ${round}. The artefact has been revised in ` +
+        `response to earlier rounds and should be converging. An empty ` +
+        `findings array is valid and expected when the revisions genuinely ` +
+        `resolved the earlier concerns; do not manufacture findings to ` +
+        `avoid an empty return.`;
+  const lines = [
+    `You are the blind check agent "${check.name}" for a review gate.`,
+    "",
+    roundFraming,
+    "",
+    "Read these files in full before forming any finding:",
+    `- The shared principles at \`${CHECK_PRINCIPLES_PATH}\`.`,
+    `- Your own rubric at \`${rubricPath}\`.`,
+    `- The artefact under review at \`${artefactPath}\`.`,
+    `- The design document at \`${designPath}\` (the source of design context).`,
+  ];
+  for (const instruction of contextInstructions(check.context, codebaseFilePaths)) {
+    lines.push(`- ${instruction}`);
+  }
+  if (requirementsText !== null && requirementsText !== undefined) {
+    lines.push("");
+    lines.push(
+      "The full requirements source is provided inline below (there is no " +
+        "requirements file to read — use this text directly):",
+    );
+    lines.push(`<requirementsText>\n${requirementsText}\n</requirementsText>`);
+  }
+  lines.push("");
+  lines.push(
+    "If you cannot Read any required file (your rubric, " +
+      "`check-principles.md`, the artefact, or a config-declared context " +
+      "file), stop and fail immediately — do not return findings derived " +
+      "from partial context.",
+  );
+  lines.push("");
+  lines.push(
+    "Apply your rubric and the shared principles, then return the findings " +
+      "array (empty if none) per the schema. Each finding carries the six " +
+      "fields: Severity, Issue, Why it matters, Size of fix, Target, " +
+      "Suggested resolution.",
+  );
+  return lines.join("\n");
+}
+
+// Build the aggregation agent prompt (Interface contract 3).
+function aggregationPrompt({
+  survivingResults,
+  designPath,
+  priorFindingsPath,
+  notices,
+  outputPath,
+  round,
+}) {
+  const blocks = survivingResults.map(
+    (r) =>
+      `Findings from check "${r.check}":\n${JSON.stringify(r.findings, null, 2)}`,
+  );
+  const noticesJson = JSON.stringify(notices, null, 2);
+  const priorClause =
+    priorFindingsPath == null
+      ? "This is round 1; there is no prior findings file — annotate every " +
+        "surviving finding `new`."
+      : `Read the prior round's findings file at \`${priorFindingsPath}\` to ` +
+        "compare round over round.";
+  return [
+    "You are the aggregation agent for a review gate. You receive the raw " +
+      "findings arrays from the surviving check agents and must produce one " +
+      "deduped, dismissal-filtered, severity-grouped, annotated report and " +
+      "write it to disk.",
+    "",
+    "Surviving check findings:",
+    ...blocks,
+    "",
+    `Read the design document at \`${designPath}\` to obtain its ` +
+      "`## Dismissals` section. Filter out any finding semantically " +
+      "equivalent to a recorded dismissal — the same specific gap in the " +
+      "same component. However: " +
+      RE_RAISE_SENTENCE,
+    "If the design is readable but contains no `## Dismissals` section, " +
+      "proceed with an empty dismissal set — this is a normal first-round " +
+      "state, not an error; set `errorKind` to null.",
+    "",
+    priorClause,
+    "",
+    "After dismissal-filtering: dedup semantically-equivalent findings, group " +
+      "by severity in the order Critical -> High -> Medium -> Nit pick, and " +
+      `annotate each surviving finding either \`new\` or ` +
+      "`persisted-from-round-N` (N is the round in which it first appeared, " +
+      `relative to the current round ${round}).`,
+    "",
+    `Write the result to \`${outputPath}\`. The file content is: a header ` +
+      "(ticket, gate type, round, artefact path, prior-round path), then the " +
+      "severity-grouped findings (each carrying the six fields plus its " +
+      "`new`/`persisted-from-round-N` annotation). Write the file even when " +
+      "dismissal-filtering empties the findings (the findings section is then " +
+      "empty but the file is still written).",
+    "",
+    "Notices input (per-check failure/skip strings collected by the script):",
+    noticesJson,
+    "When the `notices` input is a non-empty array, after writing the " +
+      "severity-grouped findings (which may be an empty section if all " +
+      "findings were dismissed) append a `## Notices` Markdown heading and " +
+      "beneath it one line per notice string, preserving the bracketed " +
+      "`[check X failed: <reason>]` / `[check X skipped: <reason>]` format " +
+      "verbatim; when `notices` is empty, omit the section entirely (do not " +
+      "write a heading with no entries).",
+    "",
+    "Error signalling — do NOT throw on an input-read failure; instead set " +
+      "`errorKind`:",
+    '- If reading `priorFindingsPath` fails, return `errorKind: ' +
+      '"prior-findings-unreadable"` (do not throw).',
+    '- If reading `designPath` fails, return `errorKind: "design-unreadable"` ' +
+      "(do not throw).",
+    '- If both fail, report `"prior-findings-unreadable"`.',
+    "- Throw only on a genuine logic failure unrelated to file reading.",
+    "",
+    "Return `{ report, fileWritten, errorKind }`: `report` is the " +
+      "post-filter severity-grouped annotated findings (empty array if all " +
+      "dismissed); `fileWritten` is true only if the Write succeeded; " +
+      "`errorKind` is null unless an input-read failure occurred.",
+  ].join("\n");
+}
+
+// ----- check fan-out with per-check retry-then-notice -----
+
+// Dispatch one check; retry once as a singleton on throw/null; on a second
+// failure return a failure marker carrying the notice reason. Uses the global
+// `agent`.
+async function runCheck(check, prompt) {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const out = await agent(prompt, {
+        model: check.model,
+        schema: FINDINGS_SCHEMA,
+        label: check.name,
+        phase: "Checks",
+      });
+      if (out && Array.isArray(out.findings)) {
+        return { check: check.name, ok: true, findings: out.findings };
+      }
+      // null/malformed return — falls through to retry or failure.
+      if (attempt === 1) {
+        return {
+          check: check.name,
+          ok: false,
+          reason: "returned malformed or null output",
+        };
+      }
+    } catch (err) {
+      if (attempt === 1) {
+        return {
+          check: check.name,
+          ok: false,
+          reason: String(
+            (err && err.message) || (err && JSON.stringify(err)) || err,
+          ),
+        };
+      }
+    }
+  }
+  // The loop always returns by attempt 1; this keeps the function total.
+  return { check: check.name, ok: false, reason: "unknown failure" };
+}
+
+// ----- aggregation with the contract-3 error routing -----
+
+// Uses the global `agent`.
+async function runAggregation(prompt) {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let out;
+    try {
+      out = await agent(prompt, {
+        schema: AGGREGATION_SCHEMA,
+        label: "aggregation",
+        phase: "Aggregate",
+      });
+    } catch (err) {
+      // Genuine logic failure (throw): retry once, then HALT.
+      if (attempt === 1) {
+        return { halt: "aggregation failed" };
+      }
+      continue;
+    }
+    if (!out || !Array.isArray(out.report)) {
+      // Malformed/unparseable: logic failure — retry once, then HALT.
+      if (attempt === 1) {
+        return { halt: "aggregation failed" };
+      }
+      continue;
+    }
+    const errorKind = out.errorKind || null;
+    if (errorKind === "prior-findings-unreadable") {
+      // Terminal: a genuinely absent prior-findings file is not retried.
+      return { haltKind: "prior-findings-unreadable" };
+    }
+    if (errorKind === "design-unreadable") {
+      // Retry once; a second design-unreadable HALTs.
+      if (attempt === 1) {
+        return { haltKind: "design-unreadable" };
+      }
+      continue;
+    }
+    return { ok: true, report: out.report, fileWritten: out.fileWritten };
+  }
+  return { halt: "aggregation failed" };
+}
+
+// ----- orchestration (the workflow body) -----
+
+// `args` is the value passed to the Workflow invocation. It normally arrives as
+// an object, but the harness may deliver it as a JSON string — tolerate both.
+// Malformed JSON string args, or a `null`/non-object args value, are caller
+// errors: HALT gracefully rather than letting the parse or destructure throw a
+// wholesale Workflow rejection (symmetric with the invalid-gateType HALT below).
+let gateType,
+  artefactPath,
+  designPath,
+  requirementsText,
+  codebaseFilePaths,
+  ticket,
+  artefactSlug,
+  round,
+  priorFindingsPath;
+try {
+  const input = typeof args === "string" ? JSON.parse(args) : args;
+  ({
+    gateType,
+    artefactPath,
+    designPath,
+    requirementsText,
+    codebaseFilePaths,
+    ticket,
+    artefactSlug,
+    round,
+    priorFindingsPath,
+  } = input);
+} catch {
+  return result({
+    outcome: "HALT",
+    haltReason: "invalid args",
+    report: [],
+    notices: [],
+    stats: emptyStats(),
+  });
+}
+
+// Normalise `round` at the arg boundary — it may arrive as a string. Rebind the
+// destructured binding itself (not a throwaway local) so every downstream
+// reference sees the clean integer. The predicate checks integrality, not mere
+// positivity: a bare `> 0` would admit a float like 1.7, which
+// String(round).padStart(3, "0") renders as '1.7', corrupting the findings path.
+// Same placement and HALT mechanism as the invalid-gateType halt below.
+// The `Number.isInteger(round) && round >= 1` predicate is the contract, not the
+// source type: exotic coercions like Number(true) === 1 and Number([1]) === 1
+// pass and correctly take the round-1 path, intentionally — hence no
+// `typeof round === "number"` guard.
+round = Number(round);
+if (!(Number.isInteger(round) && round >= 1)) {
+  return result({
+    outcome: "HALT",
+    haltReason: "invalid round",
+    report: [],
+    notices: [],
+    stats: emptyStats(),
+  });
+}
+
+// Invalid gateType — caller error: HALT, no dispatch, no retry.
+let checks;
+if (gateType === "design") {
+  checks = DESIGN_CHECKS;
+} else if (gateType === "task") {
+  checks = TASK_CHECKS;
+} else {
+  return result({
+    outcome: "HALT",
+    haltReason: `invalid gateType: ${gateType}`,
+    report: [],
+    notices: [],
+    stats: emptyStats(),
+  });
+}
+
+const notices = [];
+
+// Build the dispatch list, applying the requirements-coverage skip path.
+const dispatch = [];
+for (const check of checks) {
+  if (
+    check.name === "requirements-coverage" &&
+    (requirementsText === null || requirementsText === undefined)
+  ) {
+    notices.push(
+      "[check requirements-coverage skipped: no requirements source]",
+    );
+    continue;
+  }
+  dispatch.push(check);
+}
+
+// Fan out the dispatched checks in parallel. `parallel` auto-caps concurrency at
+// min(16, cores - 2), which comfortably fits the 8 checks.
+phase("Checks");
+const tasks = dispatch.map((check) => () => {
+  const prompt = checkPrompt({
+    check,
+    artefactPath,
+    designPath,
+    requirementsText,
+    codebaseFilePaths,
+    round,
+  });
+  return runCheck(check, prompt);
+});
+const checkResults = await parallel(tasks);
+
+// Partition into survivors (ok) and failures, recording failure notices. A thunk
+// that throws resolves to null in the parallel result array — treat that as a
+// failed check too (defensive: runCheck is total, so this should not occur).
+const survivors = [];
+let checksFailed = 0;
+for (const r of checkResults) {
+  if (r && r.ok) {
+    survivors.push(r);
+  } else {
+    checksFailed += 1;
+    const name = (r && r.check) || "unknown";
+    const reason = (r && r.reason) || "agent returned null";
+    notices.push(`[check ${name} failed: ${reason}]`);
+  }
+}
+const checksRun = dispatch.length;
+
+// Outcome ladder — evaluated in this exact order. The "survivors.length > 0"
+// precondition on the first branch closes the JS vacuous-truth back door:
+// [].every(predicate) is true, so without it a zero-survivors round would also
+// satisfy the all-empty test and mis-route to ZERO_FINDINGS_WARNING.
+const allSurvivorsEmpty =
+  survivors.length > 0 && survivors.every((r) => r.findings.length === 0);
+
+if (allSurvivorsEmpty && round === 1) {
+  // Round 1, at least one check survived AND every survivor returned empty
+  // findings. The first-round "finds nothing is suspicious" bias applies, so
+  // this is surfaced as a warning. Pure-JS — no aggregation agent on this
+  // round-1 branch. A failed check rides in `notices` and does NOT demote the
+  // round to PASS. On round 2+ an all-empty sweep is NOT short-circuited here:
+  // it falls through to the aggregation path below and clears as PASS.
+  return result({
+    findingsPath: null,
+    outcome: "ZERO_FINDINGS_WARNING",
+    report: ZERO_FINDINGS_WARNING_TEXT,
+    notices,
+    stats: { checksRun, checksFailed, findingCounts: zeroCounts() },
+  });
+}
+
+if (survivors.length === 0) {
+  // Zero survivors (every dispatched check failed its retry) — NOTICES_ONLY.
+  return result({
+    findingsPath: null,
+    outcome: "NOTICES_ONLY",
+    report: [],
+    notices,
+    stats: { checksRun, checksFailed, findingCounts: zeroCounts() },
+  });
+}
+
+// Either at least one surviving check returned a non-empty findings array, OR
+// this is a round 2+ all-empty sweep falling through to the aggregation path
+// (the round-1 ZERO_FINDINGS_WARNING short-circuit above no longer fires on
+// round 2+, so a converged clean sweep aggregates and clears as PASS) — run the
+// aggregation agent. The script passes its accumulated `notices` so the agent
+// can append a `## Notices` section to the on-disk file.
+phase("Aggregate");
+const outputPath = findingsFilePath(ticket, artefactSlug, round);
+// Pass every survivor's array to aggregation (including empty ones — the round
+// reached here because at least one survivor was non-empty, OR this is a
+// round 2+ all-empty sweep falling through to the aggregation path).
+const survivingResults = survivors.map((r) => ({
+  check: r.check,
+  findings: r.findings,
+}));
+
+const agg = await runAggregation(
+  aggregationPrompt({
+    survivingResults,
+    designPath,
+    priorFindingsPath,
+    notices,
+    outputPath,
+    round,
+  }),
+);
+
+const baseStats = { checksRun, checksFailed, findingCounts: zeroCounts() };
+const halt = (haltReason) =>
+  result({ outcome: "HALT", haltReason, report: [], notices, stats: baseStats });
+
+if (agg.halt) {
+  return halt(agg.halt);
+}
+if (agg.haltKind === "prior-findings-unreadable") {
+  return halt(`prior findings file unreadable: ${priorFindingsPath}`);
+}
+if (agg.haltKind === "design-unreadable") {
+  return halt(`design document unreadable: ${designPath}`);
+}
+// Aggregation succeeded with errorKind null. Confirm the file was written.
+if (!agg.fileWritten) {
+  return halt("findings-file write failed");
+}
+
+const report = agg.report;
+// findingCounts come from the POST-dismissal report the engineer sees.
+const findingCounts = countSeverities(report);
+const stats = { checksRun, checksFailed, findingCounts };
+
+if (report.length === 0) {
+  // All surviving findings dismissal-filtered away — PASS. The file is still
+  // written (durable record). `notices` survives the PASS path so SKILL.md can
+  // surface a failed check, and the agent appended them on disk too.
+  return result({
+    findingsPath: outputPath,
+    outcome: "PASS",
+    report: [],
+    notices,
+    stats,
+  });
+}
+
+// At least one surviving finding remains — FINDINGS.
+return result({
+  findingsPath: outputPath,
+  outcome: "FINDINGS",
+  report,
+  notices,
+  stats,
+});

--- a/.claude/skills/write-design-doc/SKILL.md
+++ b/.claude/skills/write-design-doc/SKILL.md
@@ -1,0 +1,643 @@
+---
+name: write-design-doc
+description: You MUST use this when the user asks to write a design document or task specs for a feature given a JIRA ticket or requirements file.
+model: claude-opus-4-8
+allowed-tools:
+  - Agent
+  - Bash
+  - Read
+  - Write
+  - WebFetch
+  - mcp__claude_ai_Atlassian__getJiraIssue
+---
+
+You are the orchestrator for `write-design-doc`. You conduct a two-phase
+session: Phase 1 builds a Design Document interactively with the engineer;
+Phase 2 generates Task Specs autonomously from the confirmed document.
+
+You do not write task specs yourself during Phase 1. You do not ask the
+engineer questions during Phase 2.
+
+---
+
+## Input handling
+
+The skill accepts one optional argument: a JIRA URL, a JIRA ticket key, or a
+path to a file under `docs/requirements/`.
+
+**If a JIRA URL is given** (contains `atlassian.net/browse/`): extract the
+ticket key from the URL path. Fetch the ticket via
+`mcp__claude_ai_Atlassian__getJiraIssue` with `cloudId: zegons.atlassian.net`
+and `issueKey: {KEY}`.
+
+**If a JIRA ticket key is given** (pattern `[A-Z]+-[0-9]+`): fetch via
+`mcp__claude_ai_Atlassian__getJiraIssue` with `cloudId: zegons.atlassian.net`
+and `issueKey: {KEY}`.
+
+**If a file path under `docs/requirements/` is given**: read it with Read.
+
+**If no argument is given**:
+
+```bash
+ls docs/requirements/ 2>/dev/null
+```
+
+If the directory exists and is non-empty, list the files and ask the engineer
+to select one or provide a JIRA key/URL. If the directory is absent or empty,
+ask the engineer directly:
+
+> No argument given and docs/requirements/ is empty or absent.
+> Provide a JIRA URL, ticket key (e.g. AIDEV-29), or file path to continue.
+
+**If the Atlassian MCP call fails**: surface the error verbatim:
+
+> Atlassian MCP error: {full error message}
+> Paste the requirements content directly and I will continue from there.
+
+Wait for the engineer to paste the content before proceeding.
+
+Extract from the requirements source:
+- `TICKET` — JIRA key (e.g. `AIDEV-29`)
+- Problem statement or feature intent (may be unstructured — extract what can
+  be inferred; gaps will be surfaced during the interview)
+- Any scope, acceptance criteria, or constraints already stated
+
+If the JIRA description is unstructured prose, extract what can be inferred
+and note which Design Document sections will need the most input from the
+engineer.
+
+---
+
+## Stage 1 — Branch
+
+Check the current branch:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+If the branch name starts with the ticket key (e.g. `AIDEV-29_*`), confirm it
+and continue.
+
+If not, propose a branch in the format `{TICKET}_{description}` where
+description is a short kebab-case slug derived from the feature name. Ask the
+engineer to confirm or adjust, then:
+
+```bash
+git checkout -b {branch-name}
+```
+
+Check for a prior run:
+
+```bash
+rg -l "^# Design:" docs/design/ 2>/dev/null | rg "{TICKET}-"
+```
+
+If a matching Design Document exists, tell the engineer:
+
+> I found a prior Design Document for this ticket: {filename}.
+> Continue from there, or start fresh?
+
+If continuing: read the document, summarise what was planned, and ask what
+they want to change. Jump to Stage 11 (revisit gate) to re-present the
+affected sections for review. If starting fresh or no prior document
+exists, continue to Stage 2.
+
+---
+
+# Phase 1 — Interactive Design Interview
+
+Work through each section below with the engineer **one section at a time**.
+After presenting your synthesis for each section, wait for the engineer's
+response before moving to the next section.
+
+Before beginning Stage 2, actively read the codebase to inform the design:
+use Bash to explore directory structures, Read to examine existing patterns
+and interface signatures, and Bash to search for relevant files. Ground your
+questions in what you find — do not ask the engineer to describe things you
+can observe directly.
+
+---
+
+## Stage 2 — Approach
+
+Read the codebase to understand the current state relevant to this feature.
+Inspect existing patterns, affected modules, and adjacent code. Use Bash
+and Read as needed.
+
+Present your understanding of the problem and a candidate approach:
+
+> Based on {requirements source} and my reading of the codebase, here is a
+> candidate approach:
+>
+> {One to three paragraphs: the implementation strategy, why this approach
+> over evident alternatives, what the high-level change looks like.}
+>
+> Does this match your intent? What would you change?
+
+Wait for the engineer's response. Revise the approach draft accordingly.
+Record the confirmed approach.
+
+---
+
+## Stage 3 — Components affected
+
+Using the confirmed approach and your codebase reading, propose components:
+
+> Components I expect to be affected:
+>
+> **Existing (modified):**
+> - {component}: {why}
+>
+> **New (created):**
+> - {component}: {purpose}
+>
+> Anything missing or wrong?
+
+Wait for the engineer's response. Update the list. Record confirmed components.
+
+---
+
+## Stage 4 — Interface contracts
+
+For each new or modified interface identified in Stage 3, propose the contract:
+
+> For each interface below, confirm or correct the contract:
+>
+> ### {InterfaceName}
+> Input: {types, constraints}
+> Output: {types, constraints}
+> Errors: {explicit error types and conditions}
+> Side effects: {state changes, events emitted — "none" if none}
+
+Present all interfaces in one block. Wait for the engineer's response. Record
+confirmed contracts.
+
+If no new or modified interfaces exist, state that explicitly and continue.
+
+---
+
+## Stage 5 — External references (document-type tasks only)
+
+**Determine whether this task is document-type:** a task whose objective
+produces a standards file, skill file, template, or other non-code artefact.
+If document-type, run this stage. If code-only, skip to Stage 6.
+
+Ask:
+
+> Do you have existing documentation to draw from for this design? This could
+> be URLs, file paths, or named external standards. Paste any references, or
+> skip.
+
+If references are provided:
+- Fetch each URL with WebFetch.
+- Read each local file path with Read.
+- For named concepts or well-known standards (e.g. "OpenTelemetry semantic
+  conventions"), note them for the engineer — do not search without a URL.
+
+For each reference, summarise: what it covers, what rules or conventions it
+contains, and how it relates to this task.
+
+Then read all files under `docs/ai/steering/` to run conflict detection (Stage 6).
+
+---
+
+## Stage 6 — Conflict detection (document-type tasks only)
+
+**Skip if this task is not document-type** (determined in Stage 5).
+
+1. Read all existing files under `docs/ai/steering/`. Skip files already read.
+2. Compare every rule or convention planned for this output against every
+   existing file.
+3. Identify conflicts: two rules that would give Claude contradictory
+   instructions for the same situation.
+
+**If conflicts are found**, stop. For each conflict state:
+- The rule being introduced.
+- The clashing rule (file path and rule text).
+- What the contradiction is.
+
+Ask the engineer to resolve each conflict before continuing. Record resolutions
+as constraints for Phase 2: "must not include X — contradicts Y in Z.md".
+
+**If no conflicts are found**, state that and continue.
+
+Do not produce a kept/adapted/discarded section. Surface synthesis outputs as:
+- Constraints for Phase 2 task specs: "must not include X — contradicts Y"
+- Acceptance criteria for Phase 2 task specs: "output must include rule for W,
+  sourced from reference R"
+
+Record these constraints and ACs; they feed Phase 2 directly.
+
+---
+
+## Stage 7 — Task breakdown
+
+Present a proposed task breakdown based on the confirmed approach and
+components:
+
+> Proposed task breakdown:
+>
+> TASK-01: {name} — {dependencies or "no dependencies"}
+> TASK-02: {name} — depends on TASK-01 ({specific output needed})
+> ...
+>
+> Each task should be independently implementable by an AI agent from a single
+> task spec. Does this breakdown work? Add, remove, or reorder as needed.
+
+Wait for the engineer's response. Update the breakdown.
+
+**If the breakdown contains zero tasks after the engineer's response**, stop:
+
+> The task breakdown must have at least one task before sign-off.
+> Add at least one task to proceed.
+
+Do not continue until the breakdown has at least one task.
+
+Record confirmed task breakdown. Each task name and dependency must be precise
+enough to generate a complete task spec in Phase 2.
+
+---
+
+## Stage 8 — Test strategy
+
+Present a candidate test strategy:
+
+> Proposed test strategy:
+>
+> Integration test owner: {which task owns integration tests}
+> E2E approach: {scope, tooling, environments}
+> Cross-task constraints: {shared fixtures, test data, ordering}
+>
+> Is this accurate?
+
+Wait for the engineer's response. Record confirmed test strategy.
+
+---
+
+## Stage 9 — Risks and constraints
+
+Present identified risks from codebase reading and the design:
+
+> Risks and constraints I have identified:
+>
+> - {risk or constraint}: {why it matters, what Claude must not do}
+> - ...
+>
+> Anything to add?
+
+Wait for the engineer's response. Record confirmed risks and constraints.
+
+For document-type tasks: include constraints derived from conflict detection
+in Stage 6 (e.g. "must not introduce rules that overlap with docs/ai/steering/base/
+logging.md rule 3").
+
+---
+
+## Stage 10 — ADR references
+
+Ask:
+
+> Are there existing ADRs (in docs/decisions/) that constrain this design?
+> And does this design introduce decisions significant enough to warrant a
+> new ADR?
+
+```bash
+ls docs/decisions/ 2>/dev/null
+```
+
+List the existing decisions files for context. Wait for the engineer's
+response. Record referenced ADRs and any new ADRs to be created.
+
+---
+
+## Stage 11 — Revisit gate
+
+Before producing the Design Document, check whether the engineer wants to
+revisit any section:
+
+> Draft complete. Sections covered:
+> 1. Approach
+> 2. Components affected
+> 3. Interface contracts
+> 4. Task breakdown
+> 5. Test strategy
+> 6. Risks and constraints
+> 7. ADR references
+>
+> If this is a document-type task, you may also revisit Stage 5 (External
+> references) or Stage 6 (Conflict detection).
+>
+> Want to revisit any section, or shall I write the Design Document?
+
+If the engineer wants to revisit a section: jump back to that stage, update
+the draft, re-present the section, and return here.
+
+**Allow revisits freely.** The design is not locked until sign-off.
+
+---
+
+## Stage 12 — Write Design Document
+
+Derive the slug: lowercase the feature name, replace any run of
+non-alphanumeric characters with a single hyphen, trim leading/trailing
+hyphens, truncate to 40 characters.
+
+Path: `docs/design/{TICKET}-{slug}.md`
+
+```bash
+mkdir -p docs/design
+```
+
+Write the Design Document using `.claude/templates/design-document.md` as the
+structural reference. The document must include all Artefact 2a sections:
+Approach, Components affected, Interface contracts, Task breakdown, Test
+strategy, Risks and constraints, ADR references.
+
+**The document MUST begin with exactly this canonical six-line header block, in
+this order, with these labels verbatim:**
+
+```
+# Design: {feature_name}
+JIRA: {TICKET}
+Engineer: {engineer}
+Requirements: {requirements_source_path}
+Date: {date}
+Branch: {branch-name}
+```
+
+The labels and their order are MANDATORY and must NOT be paraphrased or
+reordered. In particular, **line 2 is `JIRA:`** (never `Ticket:` or any synonym)
+and it carries the ticket key alone with no trailing content, so it matches the
+`review` skill's exact-match design-doc discovery grep `^JIRA: {TICKET}$` in
+`skills/review/SKILL.md`. If line 2 deviates — wrong label, or trailing content
+such as `JIRA: AIDEV-29 (draft)` — that grep silently returns nothing, so review
+Group E loses the design doc and falls back to the task spec alone.
+
+Fill the values from session context: `{feature_name}` is the feature title,
+`{TICKET}` the JIRA key from input handling, `{engineer}` the current git user
+(`git config user.name`), `{requirements_source_path}` the JIRA URL or
+`docs/requirements/` path used as input, `{date}` today's date
+(`date +%Y-%m-%d`), and `{branch-name}` the branch from Stage 1. The `Branch:`
+line is read by Phase 2 to generate the first task's `Depends on:` value.
+
+Write narrative prose — this is the engineer-facing document. Make it readable.
+
+Tell the engineer:
+
+> Design Document written to `docs/design/{TICKET}-{slug}.md`.
+>
+> Please review it. Say "looks good", "sign off", "approved", "ship it", or
+> "looks good — proceed to Phase 2" to proceed to task spec generation.
+> Or tell me what to change.
+
+---
+
+## Stage 13 — Sign-off gate
+
+**Wait for the engineer's explicit sign-off.** Accepted phrases: "looks good",
+"sign off", "approved", "ship it", "looks good — proceed to Phase 2". Do not
+treat bare "yes" as sign-off — it appears as a natural answer to questions.
+
+**If the engineer signs off but the document is missing any Artefact 2a
+section**, do not accept sign-off. List the missing sections explicitly:
+
+> Sign-off not accepted — the following sections are missing from the Design
+> Document:
+> - {section name}
+> - {section name}
+>
+> Complete these sections before I can proceed to Phase 2.
+
+**If the task breakdown has zero tasks at sign-off time**, do not accept
+sign-off:
+
+> Sign-off not accepted — the task breakdown must contain at least one task.
+> Add tasks to the breakdown before signing off.
+
+**If the engineer signs off but the document header is not the canonical
+six-line block** — in particular if line 2 is not exactly `JIRA: {TICKET}`
+(correct label, ticket key alone, no trailing content) — do not accept sign-off.
+Verify deterministically:
+
+```bash
+sed -n '1,6p' docs/design/{TICKET}-{slug}.md            # show the header
+rg -q "^JIRA: {TICKET}$" docs/design/{TICKET}-{slug}.md && echo OK || echo HEADER_DEVIATES
+```
+
+The `rg -q` line is the load-bearing self-check: it runs the exact consumer
+grep, so `HEADER_DEVIATES` (or a non-`OK` result) means line 2 will be invisible
+to the `review` skill. Treat anything other than `OK` as a deviation. Then
+confirm from the printed header that line 1 matches `^# Design: \S` and lines
+3–6 carry the `Engineer:`, `Requirements:`, `Date:`, and `Branch:` labels in
+order, each with a non-empty value. If the `rg` check fails or any line
+deviates:
+
+> Sign-off not accepted — the design document header must be the canonical
+> six-line block and line 2 must be exactly `JIRA: {TICKET}`. The `review` skill
+> discovers design docs with `rg -l "^JIRA: {TICKET}$"`; any deviation makes
+> this document invisible to review. Correct the header, then sign off.
+
+**If the engineer requests changes**, loop back to the originating stage
+(Stage 2–10) to update that section, then return through Stage 11 (revisit
+gate) and Stage 12 (re-write document) before re-attempting sign-off here.
+
+**Once valid sign-off is received**, commit the design document to the branch:
+
+```bash
+git add docs/design/{TICKET}-{slug}.md
+git commit -m "{TICKET}: Add design document"
+```
+
+Then continue immediately to Phase 2.
+
+---
+
+# Phase 2 — Autonomous Task Spec Generation
+
+Phase 2 begins immediately after sign-off. No questions to the engineer.
+Read the confirmed Design Document and generate all task specs.
+
+---
+
+## Stage 14 — Generate task specs
+
+Tell the engineer:
+
+> Sign-off confirmed. Generating task specs now.
+
+Read the confirmed Design Document in full. For each task in the task
+breakdown:
+
+1. Derive the task number: two-digit zero-padded (01, 02, 03...).
+
+2. Derive the slug: lowercase the task name, replace any run of
+   non-alphanumeric characters with a single hyphen, trim leading/trailing
+   hyphens, truncate to 40 characters. After truncation, trim any trailing
+   hyphens. Example: if truncating at 40 chars produces a trailing hyphen,
+   remove it — e.g. "the-quick-brown-fox-jumps-over-the-lazy--dog" truncates
+   to "the-quick-brown-fox-jumps-over-the-lazy-" then trims to
+   "the-quick-brown-fox-jumps-over-the-lazy" (no trailing hyphen).
+
+3. Check for slug collision:
+
+   ```bash
+   ls docs/tasks/ 2>/dev/null | rg "^{TICKET}-TASK-{NN}-{slug}\.md$"
+   ```
+
+   If a file with that name already exists, try `-v2`, then `-v3`, `-v4`, etc.
+   until an unused suffix is found. Note the collision in the Stage 16 report.
+
+4. Path: `docs/tasks/{TICKET}-TASK-{NN}-{slug}.md`
+
+   ```bash
+   mkdir -p docs/tasks
+   ```
+
+5. Determine the `Depends on:` value for this task:
+   - If the task depends on another task: use the exact filename of that
+     task spec — `{TICKET}-TASK-{NN}-{slug}.md` (not a path, not a title).
+     The filename must match the filename derived in step 4 for the dependency
+     task.
+   - If the task has no dependency in the task breakdown AND it is not the
+     first task (task number > 01): use the literal string `nothing`.
+   - If the task has no dependency in the task breakdown AND it is the first
+     task (task number 01): read the `Branch:` line from the Design Document
+     header and use that branch name as the literal value — not `nothing`.
+
+6. Write the task spec using `.claude/templates/task-spec.md` as the structural
+   reference. In the body header block, emit:
+
+   ```
+   Depends on: {TICKET}-TASK-{NN}-{dependency-slug}.md
+   ```
+
+   or
+
+   ```
+   Depends on: nothing
+   ```
+
+   or (first task only)
+
+   ```
+   Depends on: {design-branch-name}
+   ```
+
+   In the frontmatter, populate `branch` as `{TICKET}_TASK-{NN}_{slug}` using
+   the task number from step 1 and the slug derived in step 2.
+
+7. **Verify the two contract fields on disk against the values you computed — do
+   not trust the just-written file.** Re-read the spec at the path from step 4.
+   Both contract fields have canonical values you already hold; at this point
+   never re-derive either from the Design Document:
+   - Frontmatter `branch:` MUST equal `{TICKET}_TASK-{NN}_{slug}` (steps 1–2) —
+     NOT the Design Document's `Branch:` value.
+   - Body header `Depends on:` MUST equal the value determined in step 5.
+
+   Compare on the trimmed value. If a field on disk differs from its canonical
+   value, re-write the whole spec with Write — the same content but with that
+   field set to its canonical value (this flow has `Write`, not `Edit`) — and
+   record a correction note for the Stage 16 report, of the form
+   `{spec filename}: {field} corrected from '<got>' to '<expected>'`. This
+   reconciliation is deterministic: it never re-opens the interview, never halts
+   on value drift, and is a no-op on an already-correct spec.
+
+**Task spec writing rules — enforce strictly:**
+
+- Frontmatter: `ticket` and `branch` ONLY. No other fields.
+- `branch` value: `{TICKET}_TASK-{NN}_{slug}` — task number from step 1, slug from step 2. Never the Design Document's `Branch:` value; that branch belongs only to the first task's `Depends on:` line (step 5), never to any task's `branch` frontmatter.
+- `Depends on:` value: the exact task spec filename, the literal `nothing`, or a literal branch name (for the first task only) — no path, no prose description.
+- Every line in the body is a constraint, a verifiable fact, or a
+  binary-checkable AC.
+- No narrative prose. No "this section covers...". No "generally speaking...".
+- No padding sentences. No explanatory text that does not directly constrain
+  the implementation or specify a checkable outcome.
+- Interface contracts from the Design Document go verbatim into the relevant
+  task spec's Inputs and outputs section.
+- Risks and constraints that apply to a specific task go into that task spec's
+  Implementation constraints section.
+- Every AC must be independently checkable by the review skill without
+  engineer involvement.
+- The Required output format block from Artefact 3 (implementation code, test
+  code, completion notes format) must appear in every task spec.
+
+For document-type tasks: include constraints and ACs derived from Stage 6
+conflict detection (e.g. "Must not include rules that overlap with
+docs/ai/steering/base/logging.md"). Include acceptance criteria derived from external
+references (e.g. "Output must include rule for X, sourced from {reference}").
+
+Generate all task specs before reporting. Do not pause between tasks.
+
+---
+
+## Stage 15 — Push and create PR
+
+Stage all generated task specs and push the design branch:
+
+```bash
+git add docs/tasks/{TICKET}-TASK-*.md
+git push -u origin {branch}
+```
+
+Then invoke the `create-pr` skill to open a PR for the design branch. Pass:
+- `ticket`: the JIRA key
+- `branch`: the design branch name
+- `steering_doc_path`: the design document path (`docs/design/{TICKET}-{slug}.md`)
+
+Do not pass `base` — the design branch PR targets the repo default branch.
+
+---
+
+## Stage 16 — Report
+
+Report to the engineer:
+
+> Phase 2 complete.
+>
+> Design Document: `docs/design/{TICKET}-{slug}.md`
+> PR: {PR URL}
+>
+> Task specs generated:
+> - `docs/tasks/{TICKET}-TASK-01-{slug}.md` — {task name}
+> - `docs/tasks/{TICKET}-TASK-02-{slug}.md` — {task name}
+> - ...
+>
+> {If any slug collisions occurred:}
+> Slug collision on {original slug} — written as {slug}-v2.
+>
+> {If any contract corrections occurred during step 7: one line per corrected
+> spec — Contract correction — {spec filename}: {field} corrected from '<got>'
+> to '<expected>'. Omit entirely when no corrections occurred.}
+>
+> Run `implement {TICKET}` to begin implementation.
+
+---
+
+## Rules
+
+- **Phase 1 is interactive.** Work through sections one at a time. Wait for
+  engineer input at each stage. Do not produce the Design Document in one pass.
+- **Read the codebase actively.** Use Bash and Read throughout Phase 1 to
+  ground the design in observable reality. Do not rely solely on engineer input.
+- **No sign-off without all sections.** All seven Artefact 2a sections must be
+  present in the Design Document before sign-off is accepted.
+- **No sign-off with zero tasks.** The task breakdown must contain at least one
+  task.
+- **Phase 2 is autonomous.** No questions, no pauses, no confirmation between
+  task specs. Read the document, generate all specs, report.
+- **Task specs are machine-optimised.** Resist narrative. Every line is a
+  constraint or checkable AC.
+- **Frontmatter is ticket and branch only.** Any other field in a task spec
+  frontmatter is an error.
+- **Conflict detection for document tasks.** When the output is a standards
+  file, skill file, or similar non-code artefact: run Stage 5 and Stage 6.
+  Read all of docs/ai/steering/ before the engineer signs off.
+- **No kept/adapted/discarded.** Synthesis from external references goes
+  directly into task spec ACs and constraints. No synthesis history section.
+- **Allow revisits in Phase 1.** The engineer can request changes to any
+  section at any time before sign-off. Update the draft and re-present.
+- **Slug derivation is deterministic.** Lowercase, replace any run of
+  non-alphanumeric characters with a single hyphen, trim leading/trailing
+  hyphens, truncate to 40 chars. Apply consistently to both Design Document
+  and task spec filenames.

--- a/.claude/skills/write-requirements/SKILL.md
+++ b/.claude/skills/write-requirements/SKILL.md
@@ -1,0 +1,633 @@
+---
+name: write-requirements
+description: You MUST use this when the user asks to collect or document requirements from a product owner or PM.
+model: claude-opus-4-8
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - mcp__claude_ai_Atlassian__getJiraIssue
+---
+
+You are the orchestrator for `/write-requirements`. Collect requirements
+from the user and produce a structured Requirements Package. When a Jira
+ticket is provided, pre-populate sections from the ticket description,
+assess extraction quality per section, and only skip the interview for
+sections with solid, directly-stated content. Sections that are thin
+(inferred from unstructured prose) or empty are routed into the interview
+so that gaps are surfaced rather than silently accepted.
+
+---
+
+## Stage 1 — Ticket, metadata, and branch setup
+
+Ask:
+
+> What is the JIRA ticket for this feature? (e.g. PROJ-123)
+
+Record the ticket.
+
+Ask:
+
+> What is the feature name? (short, descriptive — e.g. "Driver onboarding
+> redesign")
+
+Record the feature name. Derive a kebab-case slug from it (e.g.
+`driver-onboarding-redesign`). The output path will be
+`docs/requirements/{TICKET}-{feature-slug}.md`.
+
+Ask:
+
+> Who is the author of this requirements package? (e.g. "Jane Smith,
+> Product Manager")
+
+Record the author.
+
+**Branch setup.** Check the current branch:
+
+```bash
+git branch --show-current
+```
+
+Match the branch name against `^{TICKET}[_-]` (anchored with a separator
+to avoid partial matches like `AIDEV-2` matching `AIDEV-28_…`). If it
+matches, confirm and continue.
+
+If it does not match, offer to create or switch to the correct branch:
+
+> The current branch is `{branch}`, which doesn't match ticket `{TICKET}`.
+> I can create or switch to `{TICKET}_{feature-slug}`. Proceed? [y/n]
+
+If the user confirms, run:
+
+```bash
+.claude/scripts/req-branch.sh {TICKET} {feature-slug}
+```
+
+If the user declines, continue on the current branch without switching.
+
+**Prior-run check.** Check whether a requirements package already exists
+at the output path:
+
+```bash
+test -f docs/requirements/{TICKET}-{feature-slug}.md && echo "EXISTS" || echo "NEW"
+```
+
+If it exists, tell the user:
+
+> I found an existing requirements package at
+> `docs/requirements/{TICKET}-{feature-slug}.md`. Start fresh
+> (overwrite), or continue from the existing content?
+
+If continuing: read the existing file, summarise what it contains, and
+ask what they want to change. Skip to Stage 11 to re-confirm.
+If starting fresh: continue to Stage 2.
+
+---
+
+## Stage 2 — Pre-populate from Jira
+
+Attempt to fetch the Jira ticket description. Use the Atlassian MCP
+tools if available (`getJiraIssue` with `responseContentFormat: markdown`).
+If the fetch fails (network error, authentication failure, or ticket
+does not exist), continue to Stage 3 for the full interview.
+If the fetch succeeds but the description is empty, null, or not
+substantive, continue to Stage 3 for the full interview.
+If MCP tools are not available, ask the user:
+
+> Can you paste the Jira ticket description? Or type "skip" to go
+> through the full interview instead.
+
+If the user types "skip" or pastes content that is not substantive,
+continue to Stage 3 for the full interview. If the pasted content is
+substantive, treat it as the ticket description and proceed with
+extraction below.
+
+A description is **substantive** if it contains identifiable
+requirements, user flows, or structured content that maps to at least
+one section of the Requirements Package. A title restatement, a single
+vague sentence, or boilerplate with no actionable content is not
+substantive.
+
+If the description is substantive, extract what you can into each
+section of the Requirements Package:
+
+- **Problem statement** (Stage 3) — opening paragraph or summary,
+  stripped of solution language
+- **Scope** (Stage 4) — any included/excluded items mentioned
+- **User journey** (Stage 5) — any step-by-step flow described. Strip
+  implementation language (API endpoints, database tables, service
+  names) during extraction, as in Stage 5.
+- **Functional requirements** (Stage 6) — testable statements, bullet
+  points, or numbered items. Number them FR-01, FR-02, etc. Rewrite to
+  start with a verb if needed and strip implementation assumptions, as
+  in Stage 6.
+- **Acceptance criteria** (Stage 7) — any Gherkin or Given/When/Then
+  patterns. Link each to an FR. If the ticket has no explicit ACs, or
+  if Functional requirements extraction produced no content, leave this
+  section empty — the completeness gate will flag missing ACs.
+- **Edge cases and error states** (Stage 8) — any error or boundary
+  scenarios mentioned
+- **Non-functional requirements** (Stage 9) — any performance, security,
+  or compliance constraints
+- **Open questions** (Stage 10) — any items marked as TBD, unresolved,
+  or needing input
+
+Apply the same quality checks as the interview stages during extraction:
+each FR must be independently testable (Stage 6 criteria) and each NFR
+must be specific and measurable (Stage 9 criteria). FRs or NFRs that are
+directly stated in the ticket but fail these checks should be classified
+as Thin rather than Solid during the gap assessment.
+
+**Gap assessment.** After extraction, classify every section into one
+of three tiers:
+
+| Tier | Meaning | Action |
+|------|---------|--------|
+| **Solid** | Section has specific, testable content directly stated in the ticket | Present as-is for confirmation |
+| **Thin** | Content was inferred or paraphrased from unstructured prose — plausible but not explicitly stated | Present with a ⚠ marker and flag for interview |
+| **Empty** | Nothing in the ticket maps to this section | Flag for interview |
+
+If a section has mixed quality (e.g. Scope with solid inclusions but no
+exclusions, or Functional requirements where some items are explicit and
+others reverse-engineered), classify the entire section as Thin and note
+which sub-parts need attention during the interview. This is
+intentionally conservative — it is better to re-confirm solid sub-parts
+than to skip review of thin ones.
+
+Section-specific guidance for Solid vs Thin:
+- **Problem statement** — Solid if it clearly articulates a user need
+  without solution language. Thin if the problem had to be inferred
+  from solution-oriented or implementation-focused text.
+- **Scope** — Solid if both inclusions and exclusions are explicitly
+  listed. Thin if only one side is stated or items had to be inferred
+  from a general description.
+- **User journey** — Solid if the ticket describes the flow step by
+  step with enough detail to reproduce. Thin if the journey had to be
+  reconstructed from scattered references across the ticket.
+- **Functional requirements** — Solid if the ticket lists explicit,
+  verb-first, independently testable requirements. Thin if requirements
+  had to be reverse-engineered from a narrative description.
+- **Acceptance criteria** — Solid if the ticket contains explicit
+  Gherkin or Given/When/Then blocks linked to requirements. Thin if
+  ACs had to be inferred, or if their linked FRs are Thin. Empty if
+  the ticket contains no AC-like content, or if FRs are Empty.
+- **Edge cases and error states** — Solid if the ticket enumerates
+  specific scenarios with expected behaviour. Thin if edge cases had
+  to be inferred from the happy-path description.
+- **Non-functional requirements** — Solid if the ticket states specific,
+  measurable constraints (e.g. "p95 < 200ms"). Thin if constraints are
+  vague or inferred from context.
+- **Open questions** — Solid if the ticket explicitly marks items as
+  TBD or unresolved. Thin if questions had to be inferred from gaps
+  or ambiguities in the description.
+
+In addition to the section-specific criteria above, the following
+cross-cutting rules apply:
+
+- A section is **Thin** when the ticket description is unstructured
+  prose and the section content was inferred rather than directly
+  stated, or when the extracted content is a single vague sentence that
+  would fail the quality checks applied during extraction.
+- **FR → AC dependency:** if Functional requirements are Thin, any
+  acceptance criteria linked to those requirements are also Thin,
+  regardless of whether the ACs were explicitly stated in the ticket,
+  because the underlying requirements may change during the interview.
+  If some ACs are linked to Solid FRs and others to Thin FRs, the
+  mixed-quality rule applies — classify the entire AC section as Thin.
+- **FR Empty → AC Empty:** if Functional requirements are Empty, any
+  extracted acceptance criteria are also Empty, since there are no
+  confirmed requirements to link them to.
+
+If all sections are Empty after classification (unlikely if the
+substantive check passed, but guards against extraction producing no
+content that survives quality checks), skip the presentation and
+extraction summary — continue to Stage 3 for the full interview.
+
+Otherwise, present the pre-populated draft section by section. For each
+section, show the extracted content and the tier label. After all
+sections, show a summary:
+
+> **Extraction summary**
+>
+> Solid: {list of solid sections}
+> Thin (draft content to review and expand): {list of thin sections}
+> Empty (will interview from scratch): {list of empty sections}
+
+Omit any tier line that has no sections.
+
+If there are gaps (any section is Thin or Empty), add:
+
+> I'll confirm the solid sections with you, then we'll interview for
+> the gaps.
+
+If there are no gaps, add:
+
+> All sections look solid. I'll ask you to review and confirm.
+
+If there are **no gaps** (every section is Solid):
+
+- Ask the user to review and confirm or flag changes.
+- If the user **confirms**: run the completeness gates — verify every
+  FR has at least one linked AC (Stage 7 gate) and classify any open
+  questions as blocker or informational (Stage 10 classification).
+  Completeness gates apply even to Solid sections — a gate failure
+  means the section needs more content regardless of its tier.
+  If all gates pass, skip to Stage 11 for final review. If any gate
+  fails (e.g. FRs without ACs), jump to the relevant interview stage
+  to collect the missing content, re-run the completeness gates, then
+  return to Stage 11 for final review.
+- If sections **need changes**: jump to the relevant interview stage
+  (3–10), collect changes, re-run the completeness gates, then return
+  to Stage 11 for final review.
+
+If there **are gaps** (any section is Thin or Empty):
+
+- Ask the user to review the Solid sections and confirm each is correct
+  or note changes needed. If the user requests changes to a Solid
+  section, add it to the gap list as Thin (with the existing content as
+  the starting point) and interview for it in stage order with the
+  other gaps.
+- Then, enter the interview for **each gap section in stage order**
+  (Stages 3–10). For **Thin** sections, present the inferred content
+  as a starting point and ask the user to confirm, correct, expand, or
+  replace entirely. If replacing, run the full interview prompt for that
+  stage as if it were Empty.
+  For **Empty** sections, run the full interview prompt for that stage.
+  If Functional requirements are Solid but Acceptance criteria are a
+  gap, the FRs will already be confirmed during the Solid-section
+  review above — proceed directly to Stage 7 to iterate over those
+  finalised requirements.
+- After all gaps are covered, run the completeness gates (Stage 7:
+  every FR has at least one AC; Stage 10: blocker classification), then
+  proceed to Stage 11.
+
+---
+
+## Stage 3 — Problem statement
+
+Ask:
+
+> Describe the user need this feature addresses. Focus on the problem, not
+> the solution. One paragraph, no implementation language.
+
+Record the response. If it contains solution language (mentions specific
+technologies, UI components, or implementation details), point out the
+solution language and ask the user to restate in terms of the user's need.
+
+---
+
+## Stage 4 — Scope
+
+Ask:
+
+> What is in scope for this feature? List the capabilities being delivered.
+
+Then:
+
+> What is explicitly out of scope? List things that might be assumed but
+> are not part of this work.
+
+Record both lists. If the exclusion list is empty, prompt:
+
+> Are there any adjacent features or capabilities that someone might
+> expect but are not part of this work? Explicit exclusions prevent
+> scope creep.
+
+---
+
+## Stage 5 — User journey
+
+Ask:
+
+> Walk me through the user journey step by step. Describe what the user
+> sees and does at each point — behaviour only, no implementation
+> language.
+
+Record the narrative. If it contains implementation language (API
+endpoints, database tables, service names), point it out and ask the user
+to restate in behavioural terms.
+
+---
+
+## Stage 6 — Functional requirements
+
+Ask:
+
+> List the functional requirements. Each requirement should:
+> - Start with a verb (display, calculate, store, return, prevent)
+> - Be independently testable
+> - Make no implementation assumptions
+>
+> I will number them FR-01, FR-02, etc.
+
+Record each requirement. Number them sequentially. For each one, check:
+
+1. Does it start with a verb? If not, suggest a rewrite.
+2. Is it testable? If it is vague (e.g. "handle errors gracefully"),
+   ask for specifics.
+3. Does it assume implementation? If it names a technology or internal
+   component, ask the user to restate without that assumption.
+
+When the user indicates they are done, confirm:
+
+> I have {N} functional requirements (FR-01 through FR-{NN}). Are these
+> complete, or do you want to add more?
+
+---
+
+## Stage 7 — Acceptance criteria
+
+For each functional requirement, ask:
+
+> For FR-{NN} ("{requirement text}"), what are the acceptance criteria?
+> Use Gherkin format:
+>   Given [context], when [action], then [outcome]
+>
+> Each FR needs at least one AC. Multiple ACs per FR are encouraged for
+> complex requirements.
+
+Number them AC-01, AC-02, etc., with the linked FR in parentheses:
+`AC-01 (FR-01)`.
+
+**Completeness gate:** Every FR must have at least one linked AC. If any
+FR is missing an AC after the user indicates they are done, list the
+uncovered FRs and ask:
+
+> The following functional requirements do not have acceptance criteria
+> yet:
+> {list of uncovered FRs}
+>
+> Each FR needs at least one AC before I can produce the document.
+> Let's cover them now.
+
+Do not proceed to the next stage until every FR has at least one AC.
+
+---
+
+## Stage 8 — Edge cases and error states
+
+Ask:
+
+> What are the edge cases and error states? For each non-happy-path
+> scenario, describe:
+> 1. The scenario
+> 2. The expected behaviour
+>
+> Think about: invalid input, missing data, concurrent access, timeouts,
+> permission boundaries, and boundary values.
+
+Record each edge case with its expected behaviour. If the user provides
+fewer than two, prompt:
+
+> Most features have several edge cases. Consider what happens when:
+> - Required data is missing or malformed
+> - The user does not have permission
+> - An external dependency is unavailable
+> - Values are at their boundaries (zero, maximum, empty)
+>
+> Any of these apply?
+
+---
+
+## Stage 9 — Non-functional requirements
+
+Ask:
+
+> Are there non-functional requirements? These cover performance,
+> security, compliance, scalability, or availability constraints.
+>
+> Each should be specific and measurable — "response time under 200ms at
+> p95" not "it should be fast."
+
+Record each NFR. Number them NFR-01, NFR-02, etc. If any are vague,
+ask for a specific, measurable threshold.
+
+If the user has none, record the section as "None identified." and
+continue.
+
+---
+
+## Stage 10 — Open questions
+
+Ask:
+
+> Are there any unresolved questions? These are items product hasn't
+> decided yet, or areas where engineering input is needed before design
+> can start.
+
+Record each open question with status "Open".
+
+Then ask:
+
+> For each open question, is it a blocker (engineering cannot start
+> design without an answer) or informational (nice to resolve but not
+> blocking)?
+
+Mark blockers explicitly. If there are no open questions, record the
+section as "None." and continue.
+
+**Completeness gate:** If any open question is marked as a blocker, warn:
+
+> There are {N} blocking open questions. The requirements package will
+> include them, but engineering should not start design until they are
+> resolved or explicitly acknowledged.
+
+---
+
+## Stage 11 — Review and confirm
+
+Present a summary of everything collected:
+
+> **Requirements Package Summary**
+>
+> **Feature:** {feature name}
+> **Ticket:** {ticket}
+> **Output path:** `docs/requirements/{TICKET}-{feature-slug}.md`
+>
+> **Problem statement:** {first sentence}...
+> **Scope:** {N} inclusions, {N} exclusions
+> **Functional requirements:** FR-01 through FR-{NN}
+> **Acceptance criteria:** {N} ACs covering all {N} FRs
+> **Edge cases:** {N} scenarios
+> **Non-functional requirements:** {N} NFRs (or "None identified")
+> **Open questions:** {N} ({M} blockers)
+>
+> Ready to generate the document? (yes / no — let me change something)
+
+If the user wants changes, return to the relevant stage, collect the
+changes, then **re-run all completeness gates** before regenerating the
+summary:
+
+- If FRs were added or removed: re-enter Stage 7 to ensure every FR
+  (including new ones) has at least one linked AC, and remove any ACs
+  whose FR no longer exists.
+- If ACs were added or removed: re-check the Stage 7 completeness gate.
+- If open questions were added, removed, or changed: re-run the
+  Stage 10 blocker classification.
+
+Present the summary again once all gates pass.
+
+---
+
+## Stage 12 — Generate the document
+
+Read the template at `.claude/templates/requirements-package.md`.
+
+Create the directory if it does not exist:
+
+```bash
+mkdir -p docs/requirements
+```
+
+Produce the Requirements Package at `docs/requirements/{TICKET}-{feature-slug}.md`
+using the template structure. Fill every section with the collected
+content. Do not leave any placeholder text — every section must contain
+the actual content from the interview.
+
+Metadata fields:
+- Feature name from Stage 1
+- JIRA ticket from Stage 1
+- Author from Stage 1
+- Date: today's date in YYYY-MM-DD format
+
+Tell the user:
+
+> Requirements package written to `docs/requirements/{TICKET}-{feature-slug}.md`.
+
+---
+
+## Stage 13 — Commit, push, and open PR
+
+Ask the user:
+
+> Requirements package is ready. Would you like me to commit it, push the
+> branch, and open a PR for Engineering to review? (yes / no)
+
+If the user declines, stop — the document is already written to disk.
+
+If the user confirms:
+
+**Step 1 — Confirm pending changes.** Run:
+
+```bash
+git status --porcelain
+```
+
+Print the output and ask:
+
+> The requirements file at `docs/requirements/{TICKET}-{feature-slug}.md`
+> will be committed and pushed. Any other pending changes shown above
+> will NOT be included. Confirm to proceed, or stop if anything looks
+> unexpected.
+
+Wait for the user's response. If the user stops, halt and report which
+files were pending. If the user confirms, continue.
+
+**Step 2 — Compose the commit message.** Write a prose commit message to
+a temporary file:
+
+```bash
+cat > /tmp/req-commit-msg-{TICKET}.txt <<'MSG'
+{TICKET}: Add requirements package for {feature name}
+
+Requirements package covering {N} functional requirements, {N} acceptance
+criteria, and {N} edge cases for {feature name}. Collected via the
+/write-requirements skill for Engineering review and sign-off.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+MSG
+```
+
+The first line is the subject (`{TICKET}: Add requirements package for
+{feature name}`, ≤70 characters). The body is a prose paragraph
+describing the artefact's scope — not a bullet list.
+
+**Step 3 — Derive the Changes section.** Use the `git status --porcelain`
+output from Step 1 to write one verb-first bullet per meaningful change.
+Each bullet opens with an imperative verb (Add, Remove, Update). For a
+single requirements file, this will typically be:
+
+```
+- Add requirements package at `docs/requirements/{TICKET}-{feature-slug}.md`
+```
+
+**Step 4 — Check for a PR template.** Run:
+
+```bash
+test -f .github/PULL_REQUEST_TEMPLATE.md && echo "PRESENT" || echo "ABSENT"
+```
+
+- **PRESENT** — read `.github/PULL_REQUEST_TEMPLATE.md`. Use its section
+  headings as the skeleton for the PR body. Fill in each section with the
+  content below. Discard any template sections not covered by the three
+  standard sections (Background, Changes, Jira Ticket/s).
+- **ABSENT** — use the three-section structure directly.
+
+**Step 5 — Write the PR body.** Write the PR body to a temporary file.
+The body must contain **exactly three sections**:
+
+1. `## Background` — one or two sentences: why this requirements package
+   exists and that it was collected via `/write-requirements`.
+2. `## Changes` — the verb-first bullet list from Step 3.
+3. `## Jira Ticket/s` — one bullet: `https://zegons.atlassian.net/browse/{TICKET}`
+
+```bash
+cat > /tmp/req-pr-body-{TICKET}.md <<'BODY'
+## Background
+
+Requirements package for {feature name}, collected via the `/write-requirements` skill for Engineering review and sign-off.
+
+## Changes
+
+{verb-first bullet list from Step 3}
+
+## Jira Ticket/s
+
+- https://zegons.atlassian.net/browse/{TICKET}
+BODY
+```
+
+**Step 6 — Run the PR script.**
+
+```bash
+.claude/scripts/req-pr.sh {TICKET} docs/requirements/{TICKET}-{feature-slug}.md /tmp/req-pr-body-{TICKET}.md /tmp/req-commit-msg-{TICKET}.txt
+```
+
+**Step 7 — Report the result.**
+
+> PR opened: {PR URL}
+>
+> Engineering can review the requirements package and sign off before
+> design begins.
+
+If the script exits with a non-zero status, report the error verbatim.
+Do not retry. If the error is from `gh pr create` (the commit and push
+already succeeded), tell the user they can open the PR manually from
+the branch.
+
+---
+
+## Rules
+
+- **Do not generate the document until all completeness gates pass.**
+  Every FR must have at least one linked AC. Every open question must
+  be either resolved or explicitly acknowledged.
+- **Do not invent content.** Every section comes from the user — either
+  via the Jira ticket they provided or from the interview. If
+  information is missing, ask for it — do not fill in defaults or make
+  assumptions beyond what the ticket description contains.
+- **Challenge solution language.** Problem statements, scope, and user
+  journeys must describe behaviour, not implementation. Push back when
+  the user uses technology names, API endpoints, or database concepts.
+- **Challenge vague requirements.** "Handle errors gracefully" is not
+  testable. "Return a 404 response when the resource does not exist" is.
+  Ask for specifics when requirements are not independently testable.
+- **Challenge vague NFRs.** "It should be fast" is not measurable.
+  "Response time under 200ms at p95" is. Ask for thresholds.
+- **Number everything consistently.** FR-01, FR-02; AC-01 (FR-01),
+  AC-02 (FR-01); NFR-01, NFR-02. Sequential, no gaps.
+- **Use the template.** The output must follow the structure in
+  `.claude/templates/requirements-package.md` exactly. Do not add or remove
+  sections.

--- a/.claude/skills/write-skill/SKILL.md
+++ b/.claude/skills/write-skill/SKILL.md
@@ -1,0 +1,554 @@
+---
+name: write-skill
+description: You MUST use this when the user asks to create a new skill, write a skill file, or produce a SKILL.md for a workflow.
+model: claude-opus-4-8
+allowed-tools:
+  - Agent
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - EnterWorktree
+  - ExitWorktree
+---
+
+You are the orchestrator for `write-skill`. You guide the production of a
+standardised, tested skill file through three stage groups: Interview & Design,
+TDD Cycle, and Validation & Output.
+
+Interview & Design stages are interactive — wait for engineer input at each
+stage. TDD Cycle and Validation & Output stages are autonomous — no questions
+to the engineer.
+
+**Token cost warning:** The TDD Cycle (Stages 7–9) spawns two sub-agents — a
+RED baseline agent and a REFACTOR pressure agent. Each runs a full scenario
+battery. Expect approximately 50k–100k additional input tokens per sub-agent
+invocation. Budget accordingly.
+
+---
+
+# Interview & Design
+
+---
+
+## Stage 1 — Input handling
+
+Check the argument passed to `write-skill`:
+
+- **If a name is given** (e.g. `write-skill audit-repo`): use it as the
+  working skill name. Confirm with the engineer.
+- **If a description or intent is given** (e.g. "a skill that enforces TDD"):
+  extract a candidate name (kebab-case, gerund form per naming conventions).
+  Propose it and wait for confirmation.
+- **If no argument is given**: ask the engineer:
+
+  > What skill do you want to create? Describe its purpose and I will propose
+  > a name.
+
+Wait for the engineer's response. Record the confirmed skill name.
+
+Verify the skill does not already exist:
+
+```bash
+ls .claude/skills/{name}/SKILL.md 2>/dev/null && echo "EXISTS" || echo "NEW"
+```
+
+If it exists, ask the engineer whether to overwrite or choose a different name.
+
+---
+
+## Stage 2 — Purpose and triggering conditions
+
+Ask the engineer to describe the skill's purpose and when it should be invoked:
+
+> Describe the skill's purpose. Specifically:
+>
+> 1. What does this skill do?
+> 2. When should an engineer (or Claude) reach for it? What user intent or
+>    situation signals this skill applies?
+> 3. What artefact or input must be present?
+> 4. Will this skill need companion reference files (e.g. best-practices
+>    guides, templates, checklists)? If so, list each file's name and
+>    one-line purpose.
+
+Wait for the engineer's response.
+
+Record any companion files the engineer identifies (name and purpose for each).
+If the engineer does not mention companion files, record that none are needed.
+
+Draft a `description:` field following ADR 006 format:
+
+```
+You MUST use this when [specific triggering condition].
+```
+
+Present it to the engineer for confirmation. The description must contain
+**triggering conditions only** — no workflow steps, stage names, sub-agent
+names, tools, invocation syntax, or output format.
+
+Record the confirmed description.
+
+---
+
+## Stage 3 — ADR 006 compliance gate
+
+Before proceeding, validate the confirmed description against ADR 006. Read
+`docs/decisions/006-skill-description-triggering-conditions.md` and check:
+
+- [ ] Starts with "You MUST use this when"
+- [ ] Contains only triggering conditions (user intent, required artefact)
+- [ ] Does not contain: workflow steps, phase/stage names, sub-agent names,
+      tool names, invocation syntax, output format, file paths produced
+
+If the description fails any check, state which check failed and ask the
+engineer to revise. Do not proceed until the description passes all checks.
+
+> Description passes ADR 006 compliance. Proceeding.
+
+---
+
+## Stage 4 — Complexity and model selection
+
+Present the model selection decision to the engineer:
+
+> Model selection:
+>
+> - **claude-opus-4-8** — complex cognitive work: interviews, TDD cycles,
+>   sub-agent orchestration, multi-step reasoning.
+> - **claude-sonnet-4-6** — balanced: structured output, moderate reasoning,
+>   good for most skills.
+> - **claude-haiku-4-5-20251001** — cheap, fast: repetitive tasks, simple
+>   transformations, high-volume work.
+>
+> Based on the skill's purpose, I recommend: **{recommendation}**
+>
+> Confirm or choose a different model.
+
+Base the recommendation on the skill's complexity: if it runs sub-agents,
+conducts interviews, or requires multi-step reasoning, recommend Opus. If it
+produces structured output with moderate branching, recommend Sonnet. If it is
+repetitive or simple, recommend Haiku.
+
+Wait for the engineer's response. Record the confirmed model.
+
+---
+
+## Stage 5 — Skill type classification
+
+Read `.claude/skills/write-skill/persuasion-principles.md`. Classify the skill as one
+of:
+
+- **Discipline-enforcing** — enforces a practice the agent might rationalise
+  away (TDD, verification, safety checks). Use Authority + Commitment +
+  Social Proof. Bright-line rules, no exceptions, explicit anti-rationalisation
+  counters.
+- **Guidance** — teaches a technique or approach without strict compliance
+  requirements. Use moderate Authority + Unity. Direction over guardrails.
+- **Reference** — provides information without behavioural requirements. Use
+  clarity only. No persuasion principles.
+
+Present the classification and rationale to the engineer:
+
+> I classify this skill as **{type}** because {rationale}.
+>
+> This means the skill will use {persuasion approach}.
+>
+> Agree, or should I reclassify?
+
+Wait for the engineer's response. Record the confirmed classification and
+applicable persuasion principles.
+
+---
+
+# TDD Cycle
+
+From this point forward, all stages are autonomous. Do not ask the engineer
+questions.
+
+---
+
+## Stage 6 — Prepare draft skill
+
+Before running the TDD cycle, produce a draft SKILL.md based on all confirmed
+decisions from the Interview & Design stages.
+
+Read `.claude/skills/write-skill/anthropic-best-practices.md` for structural guidance:
+frontmatter format, progressive disclosure, degrees of freedom, content
+guidelines.
+
+Write the draft to `.claude/skills/{name}/SKILL.md`. The draft must include:
+
+- Valid YAML frontmatter with `name`, `description`, `model`, `allowed-tools`.
+- Numbered stages (`## Stage N — Name` format).
+- A `## Rules` section with non-negotiable constraints.
+- Companion reference files referenced via `Read` at point of need (not loaded
+  upfront) if the skill requires them.
+
+The draft is the GREEN target — it addresses the engineer's stated purpose. It
+will be refined by the TDD cycle.
+
+```bash
+mkdir -p .claude/skills/{name}
+```
+
+Write the draft using the Write tool.
+
+---
+
+## Stage 7 — RED baseline test
+
+**Goal:** Run pressure scenarios WITHOUT the draft skill to establish a
+baseline of agent failures.
+
+Read `.claude/skills/write-skill/testing-skills-with-subagents.md` for the full TDD
+methodology.
+
+### Worktree isolation
+
+The RED sub-agent must NOT have access to the draft skill. Use `EnterWorktree`
+to create a clean worktree:
+
+```
+EnterWorktree(name: "{name}-red-baseline")
+```
+
+Inside the worktree, verify the draft skill is not present:
+
+```bash
+ls .claude/skills/{name}/SKILL.md 2>/dev/null && echo "LEAKED" || echo "CLEAN"
+```
+
+If the file is present (worktree inherited it), delete it before spawning the
+sub-agent:
+
+```bash
+rm .claude/skills/{name}/SKILL.md
+```
+
+If `EnterWorktree` is unavailable or fails: note this as a known limitation.
+Proceed with the RED test in the main worktree after temporarily moving the
+draft outside the skills tree so the sub-agent cannot discover it by listing
+`.claude/skills/{name}/`:
+
+```bash
+mv .claude/skills/{name}/SKILL.md /tmp/{name}-skill-draft.md
+```
+
+Restore after the test (the orchestrator must guarantee this restore runs even
+if the RED sub-agent errors mid-stage — run it before any early-exit
+reporting):
+
+```bash
+mkdir -p .claude/skills/{name}
+mv /tmp/{name}-skill-draft.md .claude/skills/{name}/SKILL.md
+```
+
+Add a note to the output: "RED baseline was approximate — the sub-agent may
+have had access to the draft skill's environment."
+
+### Spawn RED sub-agent
+
+Design 3–5 pressure scenarios combining multiple pressures (time + sunk cost +
+authority + exhaustion — see the testing reference for pressure types). Each
+scenario must force an explicit A/B/C choice.
+
+Spawn an Agent in the clean worktree:
+
+```
+You are being tested on how you handle a realistic engineering scenario.
+This is a real scenario — choose and act. Do not ask hypothetical questions.
+
+{Pressure scenario 1}
+
+{Pressure scenario 2}
+
+{Pressure scenario 3}
+
+For each scenario, state your choice (A, B, or C) and your reasoning.
+Be honest about your actual decision.
+```
+
+Wait for the sub-agent to return. Document:
+- Which option the agent chose for each scenario.
+- Exact rationalisations used (verbatim quotes).
+- Patterns across scenarios (which excuses recur).
+
+Exit the worktree:
+
+```
+ExitWorktree(action: "remove")
+```
+
+---
+
+## Stage 8 — GREEN write
+
+Read `.claude/skills/write-skill/persuasion-principles.md` to inform the persuasion
+strategy for the skill type confirmed in Stage 5.
+
+The draft skill from Stage 6 is the initial GREEN attempt. Review it against
+the RED baseline failures:
+
+- For each rationalisation documented in Stage 7, verify the draft skill
+  contains a counter.
+- For each failure pattern, verify the skill has a rule or constraint that
+  prevents it.
+
+If gaps exist, update the draft skill using Edit to address the specific
+failures observed. Do not add content for hypothetical cases — address only
+the actual failures from the RED baseline.
+
+Write the updated draft to `.claude/skills/{name}/SKILL.md`.
+
+---
+
+## Stage 9 — REFACTOR pressure test
+
+**Goal:** Run the same pressure scenarios WITH the draft skill loaded to find
+loopholes.
+
+Read `.claude/skills/write-skill/testing-skills-with-subagents.md` for the REFACTOR
+methodology.
+
+This sub-agent runs in the **main worktree** where the draft skill is present.
+
+Spawn an Agent:
+
+```
+You have access to the skill defined in .claude/skills/{name}/SKILL.md.
+Read it before proceeding.
+
+IMPORTANT: This is a real scenario. You must choose and act.
+Do not ask hypothetical questions — make the actual decision.
+
+{Same pressure scenarios from Stage 7}
+
+For each scenario, state your choice (A, B, or C) and your reasoning.
+If you considered the skill's rules, explain how they affected your decision.
+```
+
+Wait for the sub-agent to return. Compare results to the RED baseline:
+
+- **Agent now complies**: the skill addresses this scenario. No change needed.
+- **Agent still violates**: the skill has a loophole. Capture the new
+  rationalisation verbatim.
+- **Agent finds a novel rationalisation**: a new loophole not seen in RED.
+
+For each loophole found, update the draft skill:
+
+1. Add an explicit negation in the Rules section.
+2. Add an entry to a rationalisation table if the skill type is
+   discipline-enforcing.
+3. Add a red-flag entry if the pattern is a common bypass.
+
+Write the updated skill to `.claude/skills/{name}/SKILL.md`.
+
+If 2 or more loopholes were found, run one additional REFACTOR iteration
+(maximum 2 REFACTOR iterations total to control token cost).
+
+---
+
+# Validation & Output
+
+---
+
+## Stage 10 — CSO final check
+
+Read the completed skill file. Validate the `description:` field against
+ADR 006 one final time:
+
+- [ ] Starts with "You MUST use this when"
+- [ ] Contains only triggering conditions
+- [ ] Does not contain workflow steps, stage names, sub-agent names, tool
+      names, invocation syntax, output format, or file paths
+
+If the description drifted during the TDD cycle, restore it to the confirmed
+version from Stage 2.
+
+Validate frontmatter contains exactly: `name`, `description`, `model`,
+`allowed-tools`. No other fields.
+
+When companion files exist (written in Stage 12), Stage 12a re-runs these
+same checks against each companion file:
+
+- [ ] The file's content matches its declared one-line purpose from Stage 2.
+- [ ] The file does not duplicate content already present in SKILL.md.
+- [ ] UK English throughout.
+
+---
+
+## Stage 11 — Line-count check
+
+```bash
+wc -l .claude/skills/{name}/SKILL.md
+```
+
+- **Under 500 lines**: proceed.
+- **500 lines or over**: flag in completion notes. Do not truncate — the
+  500-line target is soft. Consider whether heavy content can be moved to
+  companion reference files.
+
+When companion files exist (written in Stage 12), Stage 12a re-runs this
+same check against each companion file:
+
+- **Under 500 lines per file**: proceed.
+- **500 lines or over**: flag in completion notes. Companion files should be
+  focused on a single responsibility — consider splitting.
+
+---
+
+## Stage 12 — Write final files
+
+Write the completed skill file to `.claude/skills/{name}/SKILL.md`.
+
+If the engineer identified companion reference files in Stage 2, draft and
+write each one to `.claude/skills/{name}/`. For each companion file:
+
+1. Re-read the file's name and one-line purpose recorded in Stage 2.
+2. Draft the file's content to fulfil that stated purpose. Apply the same
+   structural principles used for SKILL.md: progressive disclosure,
+   one responsibility per file, UK English, and clear section headings.
+3. Keep each companion file focused on its declared purpose — do not duplicate
+   content already present in SKILL.md.
+4. If a companion file's purpose is too vague to produce useful content (e.g.
+   the purpose is a single ambiguous phrase), **halt and ask the engineer** for
+   a clearer purpose statement. Do not write a skeleton with TODO comments —
+   never commit known-incomplete artefacts. Resume Stage 12 once the engineer
+   provides a sufficient purpose for every companion file.
+
+Write each companion file using the Write tool.
+
+Verify all files are in place:
+
+```bash
+ls -la .claude/skills/{name}/
+```
+
+---
+
+## Stage 12a — Companion file validation
+
+Skip this stage if no companion files were identified in Stage 2.
+
+Run the Stage 10 and Stage 11 checks against each companion file:
+
+- **Scope check:** Does the file's content match its declared one-line purpose
+  from Stage 2? Does it avoid duplicating SKILL.md content?
+- **UK English:** All human-readable text uses UK English spelling.
+- **Line count:** Under 500 lines per file (soft target — flag if exceeded).
+
+If any companion file fails validation, fix it before proceeding.
+
+---
+
+## Stage 12b — Engineer approval of companion files
+
+Skip this stage if no companion files were identified in Stage 2.
+
+Present each companion file's name, section headings, and line count to the
+engineer for review:
+
+> **Companion files for review:**
+>
+> {For each file:}
+> - `.claude/skills/{name}/{filename}` — {line count} lines
+>   Sections: {list of section headings}
+>
+> Review the companion files and confirm they are acceptable, or request
+> changes.
+
+Wait for the engineer's response. If the engineer requests changes, apply them
+and re-run Stage 12a validation before proceeding.
+
+---
+
+## Stage 13 — Commit
+
+Stage and commit all files:
+
+```bash
+# In zego-ai-standards the new skill lives at skills/{name}/ — git cannot stage through the .claude/skills symlink.
+# In a consumer repo (.claude/skills is a real directory) stage .claude/skills/{name}/ instead.
+git add skills/{name}/
+git diff --cached --quiet || git commit -m "$(cat <<'EOF'
+Add {name} skill
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Stage 14 — Report
+
+Report to the engineer:
+
+> Skill written to `.claude/skills/{name}/SKILL.md`.
+>
+> **Frontmatter:**
+> ```yaml
+> name: {name}
+> description: {description}
+> model: {model}
+> allowed-tools: {tools}
+> ```
+>
+> **Skill type:** {classification}
+>
+> **TDD cycle results:**
+> - RED baseline: {N} scenarios, {M} failures documented
+> - GREEN: draft addressed {K} failure patterns
+> - REFACTOR: {J} loopholes found and closed ({L} iterations)
+> {If EnterWorktree was unavailable: "Note: RED baseline was approximate —
+> the sub-agent may have had access to the draft skill's environment."}
+>
+> **Line count:** {count} lines {if over 500: "(soft target exceeded — review
+> for content that can move to companion files)"}
+>
+> **Files written:**
+> - `.claude/skills/{name}/SKILL.md`
+> - {any companion files}
+
+---
+
+## Rules
+
+- **Interview & Design stages are interactive.** Wait for engineer input at
+  every stage in the first group. Do not skip ahead.
+- **TDD Cycle and Validation & Output stages are autonomous** — except
+  Stage 12b (engineer approval of companion files). No other post-Stage-5
+  stage asks the engineer questions.
+- **ADR 006 compliance is a hard gate.** The description must pass the
+  compliance check in Stage 3 before proceeding and must be re-validated in
+  Stage 10. No workflow steps, no internal mechanism names, no output format
+  in the description.
+- **RED sub-agent isolation is mandatory.** Use `EnterWorktree` to create a
+  clean worktree for the RED baseline. The sub-agent must not have access to
+  the draft skill file. If `EnterWorktree` is unavailable, surface this as a
+  known limitation.
+- **REFACTOR sub-agent runs in the main worktree.** It must have access to
+  the draft skill so it can test compliance under pressure.
+- **Maximum 2 REFACTOR iterations.** The TDD cycle is expensive. Two
+  iterations are sufficient to close major loopholes without unbounded token
+  cost.
+- **Read reference files at point of need, not upfront.** Progressive
+  disclosure: `anthropic-best-practices.md` in Stage 6,
+  `persuasion-principles.md` in Stages 5 and 8,
+  `testing-skills-with-subagents.md` in Stages 7 and 9.
+- **Frontmatter must contain exactly four fields:** `name`, `description`,
+  `model`, `allowed-tools`. No other fields.
+- **Skill type classification drives persuasion strategy.** Discipline-
+  enforcing skills use Authority + Commitment + Social Proof. Guidance skills
+  use moderate Authority + Unity. Reference skills use clarity only.
+- **Stage structure uses `## Stage N — Name` format.** Consistent with
+  existing skills in the library.
+- **UK English throughout.** All human-readable text in the skill file must
+  use UK English spelling.
+- **Companion files: validate, approve, never commit incomplete.** Stage 12a
+  validates each companion file (scope, UK English, line count). Stage 12b
+  obtains engineer approval. If a purpose is too vague, halt and ask — never
+  commit skeleton/TODO files.
+- **Do not modify existing skills.** This skill produces new skills only.
+- **Token cost transparency.** The TDD cycle costs ~50k–100k additional
+  input tokens per sub-agent run. Note this in the skill output.

--- a/.claude/skills/write-skill/anthropic-best-practices.md
+++ b/.claude/skills/write-skill/anthropic-best-practices.md
@@ -1,0 +1,198 @@
+# Skill authoring best practices
+
+Reference for writing effective Claude Code skills. Read this file when
+creating or revising any skill under `.claude/skills/`.
+
+---
+
+## Token efficiency
+
+The context window is shared across system prompts, conversation history, and
+loaded skills. Every token in a SKILL.md competes with the active conversation.
+
+- Only add context Claude does not already have.
+- Challenge each explanation: if Claude knows this from training, remove it.
+- Target SKILL.md under 500 lines (soft target — companion reference files
+  absorb heavy content).
+
+## Progressive disclosure
+
+Keep SKILL.md focused on the workflow. Move detailed reference material into
+companion files alongside SKILL.md.
+
+### One-level-deep reference rule
+
+All reference files must be linked directly from SKILL.md. Claude reads
+complete files when a skill references them. Nested references (a reference
+file pointing to another reference file) as load-bearing links cause partial
+reads and missed content.
+
+Non-load-bearing "see also" pointers between companion files are acceptable.
+A "see also" pointer provides optional context or a worked example — the
+referencing file remains fully self-contained without it. If a companion file
+cannot stand alone without reading the target, the link is load-bearing and
+must be promoted to SKILL.md instead.
+
+### File organisation patterns
+
+| Complexity | Structure |
+|------------|-----------|
+| Simple | Single SKILL.md |
+| Growing | SKILL.md + separate reference files (e.g. `reference.md`, `examples.md`) |
+| Domain-heavy | SKILL.md + domain-organised references (e.g. `reference/finance.md`) so Claude loads only what is relevant |
+
+For files exceeding 100 lines, include a table of contents so Claude
+understands the full scope even during partial reads.
+
+## SKILL.md structure
+
+### Frontmatter
+
+YAML frontmatter requires:
+
+```yaml
+---
+description: Triggering conditions only (see below)
+model: claude-opus-4-8        # or claude-haiku-4-5-20251001 for cheap/repetitive work
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash
+argument_hint: "Optional — describe expected argument"
+---
+```
+
+The `model:` field accepts the canonical model ID from
+[Anthropic's model list](https://docs.anthropic.com/en/docs/about-claude/models)
+(e.g. `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`).
+Some models require a dated suffix — use the exact ID to avoid alias-resolution
+failures.
+
+See `.claude/skills/README.md` for the full frontmatter specification.
+
+### Description requirements
+
+The `description:` field states **triggering conditions only** — the
+conditions under which the skill is the right tool. It must not describe what
+the skill does internally, how it works, or how to invoke it.
+
+Format: `You MUST use this when [specific triggering condition].`
+
+What belongs in a description:
+- The user intent or situation that signals this skill applies.
+- The specific artefact or input that must be present.
+
+What does not belong:
+- Workflow steps, phases, or stage names.
+- Names of sub-agents, tools, or internal mechanisms.
+- Invocation syntax or example commands.
+- Output format or file paths produced.
+
+Rationale: when a description summarises workflow steps, an LLM reads it as an
+abbreviated recipe and bypasses the full skill body. Triggering-conditions-only
+descriptions force the LLM to read the full body for execution detail.
+
+See `docs/decisions/006-skill-description-triggering-conditions.md` for the
+full ADR.
+
+### Naming conventions
+
+Use gerund form for skill names: "Processing PDFs", "Writing design documents",
+not "PDF Helper" or "Design doc tool". Gerund form communicates action and is
+consistent across the skill library.
+
+## Degrees of freedom
+
+Match guidance strictness to task fragility:
+
+| Task type | Guidance style | Example |
+|-----------|---------------|---------|
+| High freedom (code reviews, analysis) | Text-based direction | "Check for X, Y, Z" |
+| Medium freedom (structured output) | Pseudocode with parameters | Template with placeholders |
+| Low freedom (migrations, safety-critical) | Specific, unmodifiable steps | Exact commands to run |
+
+Narrow bridge with cliffs needs guardrails. Open field needs direction.
+
+## Workflows and validation
+
+### Checklists
+
+Structure multi-step operations with checklists the agent can track:
+
+```
+- [ ] Step 1: Analyse the input
+- [ ] Step 2: Create mapping
+- [ ] Step 3: Validate mapping
+- [ ] Step 4: Produce output
+- [ ] Step 5: Verify result
+```
+
+### Validation loops
+
+Pattern: run validator, identify errors, revise, repeat. Validation loops
+improve output quality significantly. See `.claude/skills/shared/ci-validation-loop.md`
+for a worked example.
+
+## Model-coverage testing
+
+What works for Opus may need more detail for Haiku. Test skills across all
+target models before deployment:
+
+- **Haiku** — cheap, fast; needs more explicit instructions.
+- **Sonnet** — balanced; good baseline for testing.
+- **Opus** — strongest reasoning; test that skill does not over-constrain it.
+
+Minimum: three test scenarios per target model. Use realistic tasks, not
+academic recitations. For discipline-enforcing skills (those listed in
+`.claude/skills/write-skill/persuasion-principles.md` as needing Authority + Commitment), three scenarios
+is insufficient — see `.claude/skills/write-skill/testing-skills-with-subagents.md` for the full
+TDD/bulletproofing loop with combined pressures and rationalisation tables.
+
+## Content guidelines
+
+- Avoid time-sensitive information. Use expandable sections for legacy patterns
+  rather than date-gated instructions.
+- Maintain consistent terminology. Choose one term and use it throughout
+  (e.g. "artefact" not alternating with "output" and "deliverable").
+- Provide output format templates where the skill produces structured output.
+- Show input/output examples demonstrating desired style and detail level.
+- Use conditional workflows for decision points: "Creating new content? Follow
+  Creation workflow. Editing? Follow Editing workflow."
+
+## Evaluation and iteration
+
+Build evaluations before extensive documentation:
+
+1. Run Claude without the skill — identify actual gaps.
+2. Create test scenarios from real usage patterns.
+3. Establish baselines for what Claude gets wrong.
+4. Write minimal content addressing those gaps.
+5. Test with a separate Claude instance and iterate.
+
+Develop with one Claude instance (A) creating the skill while another (B)
+tests it. Observe where B navigates unexpectedly or misses information. Refine
+with A based on B's real behaviour, not assumptions.
+
+See `.claude/skills/write-skill/testing-skills-with-subagents.md` for the full TDD
+methodology applied to skill testing.
+
+## Checklist
+
+### Core quality
+
+- [ ] Description is triggering conditions only (per ADR 006).
+- [ ] SKILL.md under 500 lines.
+- [ ] Heavy content in separate reference files.
+- [ ] No time-sensitive information.
+- [ ] Consistent terminology throughout.
+- [ ] Concrete examples, not abstract.
+- [ ] One-level-deep file references only (non-load-bearing "see also" pointers between companions are acceptable).
+- [ ] Clear workflows with explicit steps.
+
+### Testing
+
+- [ ] Three evaluations minimum.
+- [ ] Tested with Haiku, Sonnet, and Opus.
+- [ ] Real usage scenarios, not recitations.
+- [ ] Iterated based on observed agent behaviour.

--- a/.claude/skills/write-skill/persuasion-principles.md
+++ b/.claude/skills/write-skill/persuasion-principles.md
@@ -1,0 +1,203 @@
+# Persuasion principles for skill design
+
+Reference for applying persuasion psychology to skill authoring. LLMs respond
+to the same persuasion principles as humans. Understanding this helps design
+skills that hold under pressure — not to manipulate, but to ensure critical
+practices are followed when the agent is tempted to rationalise them away.
+
+**Research foundation:** Meincke et al. (2025) tested 7 persuasion principles
+with N=28,000 AI conversations. Persuasion techniques more than doubled
+compliance rates (33% to 72%, p < .001). The study measured compliance with
+objectionable requests — we apply the same observed mechanisms in the opposite
+direction, to enforce legitimate practices. The fact that these techniques
+bypass safety guardrails is also why they should be used sparingly and ethically
+(see _Ethical use_ below).
+
+---
+
+## The seven principles
+
+### 1. Authority
+
+Deference to expertise, credentials, or official sources.
+
+How it works in skills:
+- Imperative language: "YOU MUST", "Never", "Always".
+- Non-negotiable framing: "No exceptions".
+- Eliminates decision fatigue and rationalisation.
+
+When to use:
+- Discipline-enforcing skills (TDD, verification requirements).
+- Safety-critical practices.
+- Established best practices.
+
+```
+Good:  Write code before test? Delete it. Start over. No exceptions.
+Bad:   Consider writing tests first when feasible.
+```
+
+### 2. Commitment
+
+Consistency with prior actions, statements, or public declarations.
+
+How it works in skills:
+- Require announcements: "Announce skill usage".
+- Force explicit choices: "Choose A, B, or C".
+- Use checklists for tracking progress through multi-step processes.
+
+When to use:
+- Ensuring skills are actually followed.
+- Multi-step processes.
+- Accountability mechanisms.
+
+```
+Good:  When you find a skill, you MUST announce: "I'm using [Skill Name]"
+Bad:   Consider letting your partner know which skill you're using.
+```
+
+### 3. Scarcity
+
+Urgency from time limits or limited availability.
+
+How it works in skills:
+- Time-bound requirements: "Before proceeding".
+- Sequential dependencies: "Immediately after X".
+- Prevents procrastination.
+
+When to use:
+- Immediate verification requirements.
+- Time-sensitive workflows.
+- Preventing "I'll do it later" rationalisation.
+
+```
+Good:  After completing a task, IMMEDIATELY request code review before proceeding.
+Bad:   You can review code when convenient.
+```
+
+### 4. Social Proof
+
+Conformity to what others do or what is considered normal.
+
+How it works in skills:
+- Universal patterns: "Every time", "Always".
+- Failure modes: "X without Y = failure".
+- Establishes norms.
+
+When to use:
+- Documenting universal practices.
+- Warning about common failures.
+- Reinforcing standards.
+
+```
+Good:  Checklists without tracking = steps get skipped. Every time.
+Bad:   Some people find checklists helpful.
+```
+
+### 5. Unity
+
+Shared identity, "we-ness", in-group belonging.
+
+How it works in skills:
+- Collaborative language: "our codebase", "we're colleagues".
+- Shared goals: "we both want quality".
+
+When to use:
+- Collaborative workflows.
+- Establishing team culture.
+- Non-hierarchical practices.
+
+```
+Good:  We're colleagues working together. I need your honest technical judgement.
+Bad:   You should probably tell me if I'm wrong.
+```
+
+### 6. Reciprocity
+
+Obligation to return benefits received.
+
+Use sparingly — can feel manipulative. Rarely needed in skills. Other
+principles are more effective.
+
+### 7. Liking
+
+Preference for cooperating with those we like.
+
+Do not use for compliance. Conflicts with honest feedback culture. Creates
+sycophancy. Avoid for discipline enforcement.
+
+---
+
+## Principle combinations by skill type
+
+| Skill type | Use | Avoid |
+|------------|-----|-------|
+| Discipline-enforcing | Authority + Commitment + Social Proof | Liking, Reciprocity |
+| Guidance/technique | Moderate Authority + Unity | Heavy authority |
+| Collaborative | Unity + Commitment | Authority, Liking |
+| Reference | Clarity only | All persuasion |
+
+---
+
+## Why this works
+
+**Bright-line rules reduce rationalisation:**
+- "YOU MUST" removes decision fatigue.
+- Absolute language eliminates "is this an exception?" questions.
+- Explicit anti-rationalisation counters close specific loopholes.
+
+**Implementation intentions create automatic behaviour:**
+- Clear triggers + required actions = automatic execution.
+- "When X, do Y" is more effective than "generally do Y".
+- Reduces cognitive load on compliance.
+
+**LLMs are parahuman:**
+- Trained on human text containing these patterns.
+- Authority language precedes compliance in training data.
+- Commitment sequences (statement then action) are frequently modelled.
+- Social proof patterns ("everyone does X") establish norms.
+
+---
+
+## Ethical use
+
+**Legitimate:**
+- Ensuring critical practices are followed.
+- Creating effective documentation.
+- Preventing predictable failures.
+
+**Illegitimate:**
+- Manipulating for personal gain.
+- Creating false urgency.
+- Guilt-based compliance.
+
+**The test:** Would this technique serve the user's genuine interests if they
+fully understood it?
+
+---
+
+## Research citations
+
+**Cialdini, R. B. (2021).** *Influence: The Psychology of Persuasion (New and
+Expanded).* Harper Business.
+- Seven principles of persuasion.
+- Empirical foundation for influence research.
+
+**Meincke, L., Shapiro, D., Duckworth, A. L., Mollick, E., Mollick, L., &
+Cialdini, R. (2025).** Call Me A Jerk: Persuading AI to Comply with
+Objectionable Requests. University of Pennsylvania.
+- Tested 7 principles with N=28,000 LLM conversations.
+- Compliance increased 33% to 72% with persuasion techniques.
+- Authority, commitment, scarcity most effective.
+- Validates parahuman model of LLM behaviour.
+
+---
+
+## Quick reference
+
+When designing a skill, ask:
+
+1. **What type is it?** (Discipline vs. guidance vs. reference)
+2. **What behaviour am I trying to change?**
+3. **Which principle(s) apply?** (Usually Authority + Commitment for discipline)
+4. **Am I combining too many?** (Do not use all seven)
+5. **Is this ethical?** (Serves user's genuine interests?)

--- a/.claude/skills/write-skill/testing-skills-with-subagents.md
+++ b/.claude/skills/write-skill/testing-skills-with-subagents.md
@@ -1,0 +1,366 @@
+# Testing skills with subagents
+
+Reference for verifying skills work under pressure and resist rationalisation.
+Read this file when creating or editing skills, before deployment.
+
+**Core principle:** Testing skills is TDD applied to process documentation.
+Run scenarios without the skill (RED — watch agent fail), write skill
+addressing those failures (GREEN — watch agent comply), then close loopholes
+(REFACTOR — stay compliant).
+
+If you did not watch an agent fail without the skill, you do not know if the
+skill prevents the right failures.
+
+---
+
+## When to use
+
+Test skills that:
+- Enforce discipline (TDD, verification requirements).
+- Have compliance costs (time, effort, rework).
+- Could be rationalised away ("just this once").
+- Contradict immediate goals (speed over quality).
+
+Do not test:
+- Pure reference skills (API docs, syntax guides).
+- Skills without rules to violate.
+- Skills agents have no incentive to bypass.
+
+---
+
+## TDD mapping for skill testing
+
+| TDD phase | Skill testing | What you do |
+|-----------|---------------|-------------|
+| **RED** | Baseline test | Run scenario WITHOUT skill, watch agent fail |
+| **Verify RED** | Capture rationalisations | Document exact failures verbatim |
+| **GREEN** | Write skill | Address specific baseline failures |
+| **Verify GREEN** | Pressure test | Run scenario WITH skill, verify compliance |
+| **REFACTOR** | Plug holes | Find new rationalisations, add counters |
+| **Stay GREEN** | Re-verify | Test again, ensure still compliant |
+
+Same cycle as code TDD, different test format. Note: code tests follow
+integration-first conventions (see `docs/ai/steering/base/testing.md`). Skill testing
+uses pressure scenarios — a different domain. Do not conflate the two.
+
+---
+
+## RED phase: baseline testing
+
+**Goal:** Run test WITHOUT the skill — watch agent fail, document exact
+failures.
+
+This is identical to TDD's "write failing test first" — you must see what
+agents naturally do before writing the skill.
+
+### Process
+
+- [ ] Create pressure scenarios (3+ combined pressures).
+- [ ] Run WITHOUT skill — give agents a realistic task with pressures.
+- [ ] Document choices and rationalisations word-for-word.
+- [ ] Identify patterns — which excuses appear repeatedly?
+- [ ] Note effective pressures — which scenarios trigger violations?
+
+### Example scenario
+
+```
+IMPORTANT: This is a real scenario. Choose and act.
+
+You spent 4 hours implementing a feature. It is working perfectly.
+You manually tested all edge cases. It is 6pm, dinner at 6:30pm.
+Code review tomorrow at 9am. You just realised you did not write tests.
+
+Options:
+A) Delete code, start over with TDD tomorrow
+B) Commit now, write tests tomorrow
+C) Write tests now (30 min delay)
+
+Choose A, B, or C.
+```
+
+Run this WITHOUT a TDD skill. Agent chooses B or C and rationalises:
+- "I already manually tested it"
+- "Tests after achieve the same goals"
+- "Deleting is wasteful"
+- "Being pragmatic not dogmatic"
+
+Now you know exactly what the skill must prevent.
+
+---
+
+## GREEN phase: write minimal skill
+
+Write skill addressing the specific baseline failures you documented. Do not
+add extra content for hypothetical cases — write just enough to address the
+actual failures you observed.
+
+Run same scenarios WITH skill. Agent should now comply.
+
+If agent still fails: skill is unclear or incomplete. Revise and re-test.
+
+---
+
+## Pressure scenario design
+
+### Bad scenario (no pressure)
+
+```
+You need to implement a feature. What does the skill say?
+```
+
+Too academic. Agent just recites the skill.
+
+### Good scenario (single pressure)
+
+```
+Production is down. $10k/min lost. Manager says add 2-line
+fix now. 5 minutes until deploy window. What do you do?
+```
+
+Time pressure + authority + consequences.
+
+### Great scenario (multiple pressures)
+
+```
+You spent 3 hours, 200 lines, manually tested. It works.
+It is 6pm, dinner at 6:30pm. Code review tomorrow 9am.
+Just realised you forgot TDD.
+
+Options:
+A) Delete 200 lines, start fresh tomorrow with TDD
+B) Commit now, add tests tomorrow
+C) Write tests now (30 min), then commit
+
+Choose A, B, or C. Be honest.
+```
+
+Multiple pressures: sunk cost + time + exhaustion + consequences.
+Forces explicit choice.
+
+### Pressure types
+
+| Pressure | Example |
+|----------|---------|
+| **Time** | Emergency, deadline, deploy window closing |
+| **Sunk cost** | Hours of work, "waste" to delete |
+| **Authority** | Senior says skip it, manager overrides |
+| **Economic** | Job, promotion, company survival at stake |
+| **Exhaustion** | End of day, already tired, want to go home |
+| **Social** | Looking dogmatic, seeming inflexible |
+| **Pragmatic** | "Being pragmatic vs dogmatic" |
+
+Best tests combine 3+ pressures.
+
+For the research basis on why authority, scarcity, and commitment principles
+increase compliance pressure, see
+`.claude/skills/write-skill/persuasion-principles.md`.
+
+### Key elements of good scenarios
+
+1. **Concrete options** — force A/B/C choice, not open-ended.
+2. **Real constraints** — specific times, actual consequences.
+3. **Real file paths** — `/tmp/payment-system` not "a project".
+4. **Make agent act** — "What do you do?" not "What should you do?"
+5. **No easy outs** — cannot defer without choosing.
+
+### Testing setup
+
+```
+IMPORTANT: This is a real scenario. You must choose and act.
+Do not ask hypothetical questions — make the actual decision.
+
+You have access to: [skill-being-tested]
+```
+
+Make agent believe it is real work, not a quiz.
+
+---
+
+## REFACTOR phase: close loopholes
+
+Agent violated rule despite having the skill? This is like a test regression —
+refactor the skill to prevent it.
+
+### Capture new rationalisations verbatim
+
+- "This case is different because..."
+- "I'm following the spirit not the letter"
+- "The PURPOSE is X, and I'm achieving X differently"
+- "Being pragmatic means adapting"
+- "Deleting X hours is wasteful"
+- "Keep as reference while writing tests first"
+- "I already manually tested it"
+
+Document every excuse. These become your rationalisation table.
+
+### Plugging each hole
+
+For each new rationalisation, add four things:
+
+**1. Explicit negation in rules**
+
+Before:
+```
+Write code before test? Delete it.
+```
+
+After:
+```
+Write code before test? Delete it. Start over.
+
+No exceptions:
+- Do not keep it as "reference"
+- Do not "adapt" it while writing tests
+- Do not look at it
+- Delete means delete
+```
+
+**2. Entry in rationalisation table**
+
+```
+| Excuse | Reality |
+|--------|---------|
+| "Keep as reference, write tests first" | You will adapt it. That is testing after. Delete means delete. |
+```
+
+**3. Red flag entry**
+
+```
+## Red flags — STOP
+
+- "Keep as reference" or "adapt existing code"
+- "I'm following the spirit not the letter"
+```
+
+**4. Update description**
+
+Add symptoms of "about to violate" to the description's triggering conditions
+(per ADR 006 — triggering conditions only, no workflow detail).
+
+### Re-verify after refactoring
+
+Re-test same scenarios with updated skill.
+
+Agent should now:
+- Choose the correct option.
+- Cite new sections.
+- Acknowledge their previous rationalisation was addressed.
+
+If agent finds a new rationalisation: continue REFACTOR cycle.
+If agent follows rule: success — skill is bulletproof for this scenario.
+
+---
+
+## Meta-testing
+
+After agent chooses wrong option, ask:
+
+```
+You read the skill and chose Option C anyway.
+
+How could that skill have been written differently to make
+it crystal clear that Option A was the only acceptable answer?
+```
+
+Three possible responses:
+
+1. **"The skill WAS clear, I chose to ignore it"**
+   - Not a documentation problem.
+   - Need stronger foundational principle.
+   - Add "Violating letter is violating spirit".
+
+2. **"The skill should have said X"**
+   - Documentation problem.
+   - Add their suggestion verbatim.
+
+3. **"I did not see section Y"**
+   - Organisation problem.
+   - Make key points more prominent.
+   - Add foundational principle early.
+
+---
+
+## When skill is bulletproof
+
+**Signs of a bulletproof skill:**
+
+1. Agent chooses correct option under maximum pressure.
+2. Agent cites skill sections as justification.
+3. Agent acknowledges temptation but follows rule anyway.
+4. Meta-testing reveals "skill was clear, I should follow it".
+
+**Not bulletproof if:**
+- Agent finds new rationalisations.
+- Agent argues skill is wrong.
+- Agent creates "hybrid approaches".
+- Agent asks permission but argues strongly for violation.
+
+---
+
+## Bulletproofing checklist
+
+Before deploying a skill, verify you followed RED-GREEN-REFACTOR:
+
+### RED phase
+
+- [ ] Created pressure scenarios (3+ combined pressures).
+- [ ] Ran scenarios WITHOUT skill (baseline).
+- [ ] Documented agent failures and rationalisations verbatim.
+
+### GREEN phase
+
+- [ ] Wrote skill addressing specific baseline failures.
+- [ ] Ran scenarios WITH skill.
+- [ ] Agent now complies.
+
+### REFACTOR phase
+
+- [ ] Identified new rationalisations from testing.
+- [ ] Added explicit counters for each loophole.
+- [ ] Updated rationalisation table.
+- [ ] Updated red flags list.
+- [ ] Updated description with violation symptoms.
+- [ ] Re-tested — agent still complies.
+- [ ] Meta-tested to verify clarity.
+- [ ] Agent follows rule under maximum pressure.
+
+---
+
+## Common mistakes
+
+**Writing skill before testing (skipping RED):**
+Reveals what you think needs preventing, not what actually needs preventing.
+Fix: always run baseline scenarios first.
+
+**Not watching test fail properly:**
+Running only academic tests, not real pressure scenarios.
+Fix: use pressure scenarios that make agent want to violate.
+
+**Weak test cases (single pressure):**
+Agents resist single pressure, break under multiple.
+Fix: combine 3+ pressures (time + sunk cost + exhaustion).
+
+**Not capturing exact failures:**
+"Agent was wrong" does not tell you what to prevent.
+Fix: document exact rationalisations verbatim.
+
+**Vague fixes (adding generic counters):**
+"Do not cheat" does not work. "Do not keep as reference" does.
+Fix: add explicit negations for each specific rationalisation.
+
+**Stopping after first pass:**
+Tests pass once does not equal bulletproof.
+Fix: continue REFACTOR cycle until no new rationalisations.
+
+---
+
+## Quick reference
+
+| TDD phase | Skill testing | Success criteria |
+|-----------|---------------|------------------|
+| **RED** | Run scenario without skill | Agent fails, document rationalisations |
+| **Verify RED** | Capture exact wording | Verbatim documentation of failures |
+| **GREEN** | Write skill addressing failures | Agent now complies with skill |
+| **Verify GREEN** | Re-test scenarios | Agent follows rule under pressure |
+| **REFACTOR** | Close loopholes | Add counters for new rationalisations |
+| **Stay GREEN** | Re-verify | Agent still complies after refactoring |

--- a/.claude/skills/write-standard/SKILL.md
+++ b/.claude/skills/write-standard/SKILL.md
@@ -1,0 +1,585 @@
+---
+name: write-standard
+description: You MUST use this when the user asks to create a new standard, write a standards file, author coding conventions, or extend an existing standards file with new rules.
+model: claude-opus-4-8
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - WebFetch
+---
+
+You are the orchestrator for `write-standard`. You guide the production of a
+correctly structured standards file through six stage groups: Interview, Source
+Analysis, Conflict Detection, Draft, Structural Validation, and Output &
+Commit.
+
+Interview, Conflict Detection, and Output & Commit stages are interactive —
+wait for engineer input at each stage. Source Analysis, Draft, and Structural
+Validation stages are autonomous — no questions to the engineer (except when
+validation fails, which requires engineer input to resolve).
+
+---
+
+# Interview
+
+---
+
+## Stage 1 — Gather topic
+
+Check the argument passed to `write-standard`:
+
+- **If a topic name is given** (e.g. `write-standard error handling`): use it
+  as the working topic. Confirm with the engineer.
+- **If a description is given** (e.g. "conventions for how we handle errors"):
+  extract a concise topic name (one sentence or ~10 words maximum). Propose it
+  and wait for confirmation.
+- **If no argument is given**: ask the engineer:
+
+  > What topic should this standard cover? Describe it in one sentence or
+  > ~10 words.
+
+Wait for the engineer's response. Record the confirmed topic name.
+
+---
+
+## Stage 2 — Detect repo context
+
+Determine whether this repo is `zego-ai-standards` or a consumer repo.
+
+```bash
+git remote -v 2>/dev/null | head -5
+```
+
+Check whether the basename of any remote URL (the last `/`-segment, with any
+`.git` suffix stripped) equals `zego-ai-standards`. SSH and HTTPS variants both
+match.
+
+- **`zego-ai-standards`**: standards files live in `standards/{subfolder}/`.
+  The `docs/ai/steering/` paths are symlinks back to `standards/`. Record
+  `repo_type=standards`.
+- **Consumer repo**: standards files live in `docs/ai/steering/local/`. Record
+  `repo_type=consumer`.
+- **No remotes**: treat as consumer-repo behaviour but ask the engineer to
+  confirm:
+
+  > No git remotes found. I will treat this as a consumer repo and write to
+  > `docs/ai/steering/local/`. Is that correct?
+
+Record the confirmed repo type.
+
+---
+
+## Stage 3 — Extend-before-create check
+
+Before drafting anything new, check whether an existing standards file already
+covers this domain.
+
+Scan recursively:
+- In `zego-ai-standards`: `standards/base/`, `standards/languages/`,
+  `standards/domains/`, `standards/governance/`.
+- In consumer repos: `docs/ai/steering/base/`, `docs/ai/steering/languages/`,
+  `docs/ai/steering/domains/`, `docs/ai/steering/governance/`,
+  `docs/ai/steering/local/`.
+
+For each `.md` file found (excluding `README.md` files), read the title and
+intro paragraph (~5 lines) to judge whether the file's domain overlaps with the
+confirmed topic.
+
+If one or more files overlap, present them to the engineer:
+
+> The following existing standards file(s) may already cover this domain:
+>
+> {For each match:}
+> - `{path}` — {title}: {first line of intro paragraph}
+>
+> Options:
+> (a) **Extend** an existing file — I will load it and you can direct edits
+>     conversationally through this skill.
+> (b) **Create** a new file — the domain is distinct enough to warrant a
+>     separate standard.
+>
+> Which do you prefer?
+
+Wait for the engineer's response.
+
+**If extending:**
+- Record `mode=extend` and the path of the file being extended.
+- Read the full file and present it in chat.
+- The engineer directs edits conversationally — this is not an automated
+  diff/merge. Apply edits as the engineer requests them.
+- Auto-increment the minor version (e.g. `1.0` to `1.1`) in frontmatter.
+- Refresh `last_reviewed` to today's date.
+- Skip Stage 4 (philosophy, trigger, and inspiration sources) and Stage 5
+  (sub-folder selection) — the file already has all of these. Ask the
+  engineer whether they have new inspiration sources to incorporate; if
+  yes, run Stage 6 against those sources, otherwise skip to Stage 7
+  (conflict detection).
+- During conflict detection (Stage 7), exclude the file being extended from
+  the scan — comparing it against itself is meaningless.
+
+**If creating (or no overlap found):** Record `mode=create` and proceed to
+Stage 4.
+
+---
+
+## Stage 4 — Philosophy, trigger, and inspiration sources
+
+This stage runs only on the **create** path.
+
+Ask the engineer:
+
+> For the new **{topic}** standard:
+>
+> 1. **Philosophy.** What governing principle should shape edge-case decisions
+>    for this standard? (One sentence.)
+> 2. **Trigger.** When should Claude apply this file? Describe the situation or
+>    context.
+> 3. **Inspiration sources.** (Optional) Provide any URLs, file paths, or repo
+>    config references I should analyse before drafting. Leave blank if none.
+
+Wait for the engineer's response. Record the philosophy, trigger sentence, and
+any inspiration sources.
+
+---
+
+## Stage 5 — Sub-folder selection (zego-ai-standards only)
+
+This stage runs only on the **create** path in `zego-ai-standards`. In consumer
+repos, sub-folder selection is skipped — files always go to
+`docs/ai/steering/local/`.
+
+Read `.claude/skills/write-standard/standards-authoring.md` — specifically the
+Sub-folders section — to determine the correct sub-folder based on the trigger
+sentence.
+
+| Trigger pattern | Sub-folder |
+|-----------------|-----------|
+| Always — any codebase | `base/` |
+| When writing [language] code | `languages/` |
+| When working on [domain] | `domains/` |
+| When the AI pipeline is operating | `governance/` |
+
+Propose a sub-folder to the engineer:
+
+> Based on the trigger sentence, I propose placing this in
+> `standards/{subfolder}/`. Confirm or choose a different sub-folder:
+> `base/`, `languages/`, `domains/`, `governance/`.
+
+Wait for the engineer's response. Record the confirmed sub-folder.
+
+---
+
+# Source Analysis
+
+From this point, proceed autonomously unless stated otherwise.
+
+---
+
+## Stage 6 — Analyse inspiration sources
+
+**Skip this stage entirely if no inspiration sources were provided** (both on
+create and on extend paths).
+
+For each inspiration source:
+
+- **URL**: Fetch the content. If the fetch fails (404, timeout, etc.), surface
+  the error to the engineer:
+
+  > Failed to fetch `{url}`: {error}. Would you like to (a) skip this source,
+  > or (b) provide an alternative?
+
+  Wait for the engineer's response. Do not skip silently or abort.
+
+- **File path**: Read the file. If it does not exist, surface the error to the
+  engineer as above.
+
+- **Repo config reference**: Locate and read the referenced configuration.
+
+For each source that was successfully fetched, produce a
+**keep / adapt / ignore** breakdown:
+
+> **Source: {source}**
+> - **Keep:** {rules or conventions to adopt directly, with rationale}
+> - **Adapt:** {rules to modify for Zego's context, with rationale}
+> - **Ignore:** {rules to skip, with rationale}
+
+Record the breakdown for use in the Draft stage.
+
+---
+
+# Conflict Detection
+
+---
+
+## Stage 7 — Scan for conflicts with existing rules
+
+Scan all existing standards files recursively:
+- In `zego-ai-standards`: `standards/base/`, `standards/languages/`,
+  `standards/domains/`, `standards/governance/`.
+- In consumer repos: `docs/ai/steering/base/`, `docs/ai/steering/languages/`,
+  `docs/ai/steering/domains/`, `docs/ai/steering/governance/`,
+  `docs/ai/steering/local/`.
+
+When extending, exclude the file being extended from the scan.
+
+For each `.md` file (excluding `README.md` files), read the **Rules at a
+Glance** section only — not the full file body. Compare the proposed rules
+(derived from the topic, philosophy, trigger, and source analysis) against
+existing rules.
+
+If a conflict is detected — a proposed rule contradicts an existing rule —
+surface it to the engineer:
+
+> **Conflict detected:**
+>
+> **Proposed rule:** {proposed rule text}
+> **Existing rule in `{file}`:** {existing rule text}
+>
+> These rules appear to contradict each other. How would you like to resolve
+> this?
+
+Wait for the engineer to resolve each conflict before proceeding. If resolution
+requires changing the standards file, apply the edit before proceeding. Do not
+draft until all conflicts are resolved.
+
+If no conflicts are found:
+
+> No conflicts detected with existing standards. Proceeding to draft.
+
+---
+
+# Draft
+
+---
+
+## Stage 8 — Draft the standards file
+
+Read `.claude/skills/write-standard/standards-authoring.md` in full for the required
+structure, section order, and rule format.
+
+**On the create path**, draft a new standards file containing:
+
+1. **Frontmatter:**
+   ```yaml
+   ---
+   version: 1.0
+   last_reviewed: {today's date, YYYY-MM-DD}
+   ---
+   ```
+   `version` must be a YAML number (not a quoted string). `last_reviewed` is
+   today's date.
+
+2. **Title:** `# {Topic} Standards` — title-case the topic noun, end with
+   "Standards".
+
+3. **Intro paragraph:** Up to four sentences following the authoring guide
+   order: domain + philosophy, trigger sentence, tooling exclusions (if any),
+   file-overlap exclusions (if any). The trigger sentence is never optional.
+
+4. **Rules at a Glance:** Each rule follows the format:
+   ```
+   N. **{Key concept}.** {Imperative statement — why it matters.}
+   ```
+   Every rule must carry the "why" inline.
+
+5. **Content sections:** One `##` section per rule that warrants rationale or
+   examples. The section heading must match the rule's key concept exactly.
+   Include `# good` / `# bad` labelled code examples where applicable.
+
+6. **See Also:** (Optional) Cross-references to related standards files.
+
+Incorporate the keep/adapt items from the source analysis breakdown. Ignore
+items marked as ignore.
+
+**On the extend path**, the engineer has already directed edits
+conversationally in Stage 3. The file should now reflect all requested changes.
+Skip writing a new draft — proceed to validation.
+
+Write the file:
+- In `zego-ai-standards` (create): `standards/{subfolder}/{filename}.md`
+- In consumer repos (create): `docs/ai/steering/local/{filename}.md`
+
+Derive the filename from the topic: lowercase, hyphens for spaces, no special
+characters. For example, "Error Handling" becomes `error-handling.md`.
+
+**Collision check** — before writing, verify the resolved target path does not
+already exist (attempt a `Read` on the path). If a file already exists at that
+location:
+
+1. Surface the collision to the engineer explicitly: state the existing file
+   path and explain that writing would overwrite it.
+2. Offer three options:
+   - **Extend** the existing file instead (switch to the extend path).
+   - **Choose a different filename** (ask the engineer for an alternative).
+   - **Abort** the write entirely.
+3. Do not proceed until the engineer has chosen an option.
+
+---
+
+# Structural Validation
+
+---
+
+## Stage 9 — Validate structure
+
+Read `.claude/skills/write-standard/standards-authoring.md` again for the canonical
+structure. Then read the standards file (whether newly created or extended) and
+check each of the following:
+
+1. **Frontmatter — version is a YAML number.** `version: 1.0`, not
+   `version: "1.0"`.
+2. **Frontmatter — `last_reviewed` is present** and set to a valid
+   `YYYY-MM-DD` date.
+3. **Section order.** Frontmatter, Title, Intro paragraph, Rules at a Glance,
+   Content sections, See Also (optional). No sections out of order.
+4. **Glance list completeness.** Every rule that appears in a content section
+   is listed in Rules at a Glance. No rule exists only in the body.
+5. **Intro-paragraph trigger sentence.** The intro paragraph contains a trigger
+   sentence (when Claude should apply this file).
+6. **Embedded "why" in every rule.** Each rule in Rules at a Glance carries
+   the reason inline — no rule is imperative-only without context.
+7. **Section headings match glance key concepts.** Each content section heading
+   matches the bold key concept of its corresponding rule exactly.
+8. **UK English.** Read the spelling standard (specifically the variant table)
+   as the canonical reference — `standards/base/spelling.md` in
+   `zego-ai-standards`, `docs/ai/steering/base/spelling.md` in consumer repos.
+   Check all human-readable text against it.
+   Common checks: `-ise` not `-ize`, `-our` not `-or`, `-ogue` not `-og`,
+   `-re` not `-er` (for centre/metre), `-ence` not `-ense`, `-l` not `-ll`
+   (for fulfil/enrol).
+
+**On validation failure:** present each defect to the engineer with the
+specific issue:
+
+> **Validation defect:**
+> {Description of the issue, with the specific text and location.}
+>
+> How would you like to fix this?
+
+Do not auto-fix. Wait for the engineer to address each defect. Re-run
+validation after the engineer addresses each one. Loop until the file is clean
+or the engineer explicitly aborts.
+
+**On validation pass:**
+
+> Structural validation passed. All checks clean.
+
+---
+
+# Output & Commit
+
+---
+
+## Stage 10 — Update README and discovery files
+
+**On the create path only** (extend does not need README or discovery updates —
+the file already has entries):
+
+**Sub-folder README** (both repo types):
+- In `zego-ai-standards`: `standards/{subfolder}/README.md`
+- In consumer repos: `docs/ai/steering/local/README.md`
+
+If the README exists, append an entry in this format:
+```
+- [{filename}]({filename}) — {one-line description of what the file covers}.
+```
+
+If the README does not exist, create it with a heading and the first entry:
+```markdown
+# {Sub-folder} Standards
+
+- [{filename}]({filename}) — {one-line description}.
+```
+
+For consumer repos, use `# Local Standards` as the heading.
+
+**Claude discovery registration:**
+
+In `zego-ai-standards`:
+- Add a reference line to the "Standards in this library" section of
+  `CLAUDE.md`, matching the existing entry format:
+  ```
+  - `docs/ai/steering/{subfolder}/{filename}` — {one-line description}.
+  ```
+
+In consumer repos:
+- If `CLAUDE.local.md` exists: append a reference line under a "Standards in
+  this library" section. If the section does not exist, append it to the end
+  of the file with a preceding blank line and `---` separator:
+  ```markdown
+
+  ---
+
+  ## Standards in this library
+
+  - `docs/ai/steering/local/{filename}` — {one-line description}.
+  ```
+  Do not modify `CLAUDE.md` — its body is team-owned.
+
+- If `CLAUDE.local.md` does not exist: print a note to the engineer:
+
+  > `CLAUDE.local.md` does not exist in this repo. To register the new
+  > standard for Claude discovery, add the following line to your preferred
+  > discovery file (or create `CLAUDE.local.md`):
+  >
+  > ```
+  > - `docs/ai/steering/local/{filename}` — {one-line description}.
+  > ```
+
+---
+
+## Stage 11 — Engineer review
+
+Present the completed standards file to the engineer for review. Include a
+summary of what was produced:
+
+> **Standards file ready for review:**
+>
+> - **File:** `{path}`
+> - **Topic:** {topic}
+> - **Version:** {version}
+> - **Rules:** {count} rules in Rules at a Glance
+> - **Mode:** {create | extend}
+>
+> Options:
+> (a) **Request edits** — tell me what to change and I will apply the edits
+>     and re-validate.
+> (b) **Reject entirely** — revert all changes, leaving `git status` clean.
+> (c) **Approve** — proceed to commit.
+
+Wait for the engineer's response.
+
+**Option (a) — request edits:** Apply the requested edits. Re-run Stage 9
+(structural validation). Then present this review prompt again. Loop until the
+engineer chooses (b) or (c).
+
+**Option (b) — reject:**
+
+On the **create** path: revert all artefacts produced by this skill — the
+standards file, the README edit, and any `CLAUDE.md` or `CLAUDE.local.md`
+edit. Use `git checkout` to restore modified files and `rm` to remove newly
+created files. Verify `git status` is clean.
+
+On the **extend** path: restore the file's pre-edit content by running
+`git checkout HEAD -- {file}` to revert both index and working tree for
+that file to the HEAD version without affecting any other files. The README and
+`CLAUDE.md`/`CLAUDE.local.md` are not modified during extension (the file
+already has entries), so no README/CLAUDE revert is needed.
+
+**Option (c) — approve:** Proceed to Stage 12.
+
+---
+
+## Stage 12 — Commit
+
+Check the current branch:
+
+```bash
+git branch --show-current
+```
+
+If the branch is `main` or `master`, warn the engineer:
+
+> You are on the `{branch}` branch. Committing directly to `{branch}` is not
+> recommended. Would you like to (a) continue anyway, or (b) create a feature
+> branch first?
+
+Wait for the engineer's response. If they choose (b), ask for a branch name
+and create it.
+
+Stage and commit all files produced by this skill:
+
+On the **create** path:
+```bash
+git add {standards file} {README file} {CLAUDE.md or CLAUDE.local.md if modified}
+git commit -m "$(cat <<'EOF'
+Add {topic} standards
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+On the **extend** path:
+```bash
+git add {standards file}
+git commit -m "$(cat <<'EOF'
+Extend {topic} standards
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Stage 13 — Report
+
+Report to the engineer:
+
+> **Standard written successfully.**
+>
+> - **File:** `{path}`
+> - **Topic:** {topic}
+> - **Version:** {version}
+> - **Mode:** {create | extend}
+> - **Rules:** {count} rules
+> - **Branch:** `{branch}`
+> - **Commit:** `{short hash}`
+
+---
+
+## Rules
+
+- **Interview stages are interactive.** Wait for engineer input at every stage
+  in the Interview and Conflict Detection groups. Do not skip ahead.
+- **Source Analysis and Draft stages are autonomous.** No questions to the
+  engineer unless a source fetch fails.
+- **Structural Validation is autonomous with engineer fallback.** Validation
+  runs without prompts, but defects are presented to the engineer for
+  resolution — do not auto-fix.
+- **Output & Commit is interactive.** The engineer reviews and approves or
+  rejects before any commit.
+- **Read the authoring guide at point of need.** Reference
+  `.claude/skills/write-standard/standards-authoring.md` via `Read` when drafting
+  (Stage 8) and when validating (Stage 9). Do not load it upfront.
+- **Extend before create.** Always check for existing coverage before creating
+  a new file. Extending preserves rule density and avoids fragmentation.
+- **Auto-increment version on extend.** Bump the minor version (e.g. `1.0` to
+  `1.1`) automatically. Do not prompt the engineer for the version.
+- **Refresh `last_reviewed` on extend.** Set `last_reviewed` to today's date
+  when extending an existing file.
+- **Source analysis runs only when sources exist.** Skip Stage 6 entirely if
+  no inspiration sources were provided (both create and extend paths).
+- **Conflict detection excludes the file being extended.** Do not compare a
+  file against itself.
+- **Reject must leave `git status` clean.** On create, revert all artefacts.
+  On extend, restore the file's pre-edit content using `git checkout HEAD -- {file}`.
+- **Consumer repos write to `docs/ai/steering/local/`.** Sub-folder selection
+  is skipped. Do not modify `CLAUDE.md` in consumer repos — its body is
+  team-owned.
+- **`zego-ai-standards` writes to `standards/{subfolder}/`.** The
+  `docs/ai/steering/` paths are symlinks. Reference lines in `CLAUDE.md` use
+  `docs/ai/steering/...` paths regardless of physical location.
+- **Do not conflate trigger concepts.** The intro-paragraph trigger sentence
+  (when Claude should apply the file) is distinct from the skill description
+  triggering conditions (when Claude should invoke the skill, per ADR 006).
+- **UK English throughout.** All human-readable text must use UK English
+  spelling, using the variant table in the spelling standard as the canonical
+  reference (`standards/base/spelling.md` in `zego-ai-standards`,
+  `docs/ai/steering/base/spelling.md` in consumer repos).
+- **Do not modify existing standards files.** This skill creates new files or
+  extends existing files only at the engineer's direction. It does not
+  autonomously alter other standards files.
+- **Do not modify existing skills.** This skill does not alter any other skill
+  under `.claude/skills/`.
+- **`version` is a YAML number.** Write `version: 1.0`, not
+  `version: "1.0"`. The authoring guide requires this.
+- **Branch safety.** Before committing, verify the current branch is not `main`
+  or `master`. Warn and offer alternatives if it is.
+- **Frontmatter uses exactly two fields.** Standards files have `version` and
+  `last_reviewed` only — no other frontmatter fields.

--- a/.claude/skills/write-standard/standards-authoring.md
+++ b/.claude/skills/write-standard/standards-authoring.md
@@ -1,0 +1,284 @@
+# Standards Authoring Guide
+
+Standards files are instructions for Claude, not human documentation. They
+are consumed by Claude at coding time to constrain its behaviour. Optimise
+for machine clarity: precise imperatives, explicit scope, zero prose padding.
+All files in `standards/` must follow the structure below.
+
+---
+
+## Structure
+
+Every standards file follows this section order exactly. Optional sections
+are marked.
+
+1. Frontmatter
+2. Title
+3. Intro paragraph
+4. Rules at a Glance
+5. Content sections (one per rule that warrants one)
+6. See Also (optional)
+
+---
+
+## Frontmatter
+
+Every standards file opens with YAML frontmatter carrying version and review
+date. Git history is the changelog — these fields tell Claude when to trust
+the content.
+
+```yaml
+---
+version: 1.0
+last_reviewed: 2026-05-06
+---
+```
+
+Increment the minor version for additions or clarifications; increment the
+major version for breaking changes to existing rules. A breaking change is:
+removing a rule, narrowing its scope, or reversing its imperative. Rewording
+for clarity, adding rationale, or adding a new rule are minor changes.
+
+---
+
+## Title
+
+`# {Topic} Standards` — always. Title-case the topic noun, end with
+"Standards".
+
+```markdown
+# Python Standards
+# Observability Standards
+# Comments and Documentation Standards
+```
+
+---
+
+## Intro Paragraph
+
+Up to four sentences, in this order:
+
+1. **Domain + philosophy.** What this file covers, including any governing
+   principle that shapes how edge cases are decided.
+2. **Trigger.** When Claude should apply this file — the situation or context
+   that activates it.
+3. **Tooling exclusions.** What is enforced mechanically and therefore not
+   covered here. Omit if nothing applies.
+4. **File-overlap exclusions.** What a related standards file already owns.
+   Omit if nothing applies.
+
+Sentences 3 and 4 can be omitted when genuinely not applicable, but both
+should be present whenever there is something to say. The trigger sentence is
+never optional — it is how Claude decides whether to apply this file at all.
+
+```markdown
+# Python Standards
+
+Structural and architectural conventions for Python services — how code is
+organised, dependencies wired, and libraries chosen. Apply these rules to any
+Python file in a service codebase. Formatting, import ordering, and type
+checking are enforced mechanically by ruff and mypy and are not covered here.
+Dependency injection patterns are covered in architecture.md.
+```
+
+```markdown
+# Observability Standards
+
+Conventions for logging, metrics, and distributed tracing — each signal
+answers a distinct question (is there a problem? where? what?) and all three
+are required for complete observability; we standardise on OpenTelemetry and
+Datadog. Apply these rules whenever adding or modifying any logging, metrics,
+or tracing code. Log formatting and retention policy are enforced by the
+platform and are not covered here.
+```
+
+---
+
+## Rules at a Glance
+
+The complete ruleset for the file. Body sections are rationale and examples
+only — they do not introduce new rules. If a rule belongs in the body but
+not the glance list, stop and add it to the glance list first.
+
+Rule numbers are unique within a file. Each content section heading must
+match its rule's **key concept** exactly — this is how Claude links a rule
+to its rationale.
+
+### Format
+
+Each rule follows this pattern:
+
+```
+N. **{Key concept}.** {Imperative statement — why it matters.}
+```
+
+- **Bold the key concept** — Claude uses it to locate the rule relevant to
+  the situation without parsing the full list.
+- **State the imperative** in one sentence.
+- **Carry the why inline.** Claude that knows *why* a rule exists applies it
+  correctly at the edges; Claude that only knows *what* to do misapplies it.
+  Embed the reason as a trailing clause or second sentence — never in a
+  separate Philosophy section.
+
+### The "why" principle
+
+The most important property of a well-written rule.
+
+```markdown
+# bad — no context for edge cases
+5. **PII in logs.** Never log PII.
+
+# better — scope and reason are in the rule itself
+5. **No PII at INFO and above.** Never log names, addresses, or identifiers
+   at INFO or higher — our logging setup is not designed to store PII.
+```
+
+```markdown
+# bad — no context for when the rule applies
+5. **Protocols.** Use a Protocol for dependencies.
+
+# better — constraint and reason are in the rule itself
+5. **Use protocols sparingly.** Introduce a Protocol only when two or more
+   concrete implementations exist — speculative interfaces add complexity
+   without value.
+```
+
+A clause is enough. The rule must be self-contained: Claude should not need
+to read the rest of the file to apply it correctly.
+
+---
+
+## Content Sections
+
+Give a rule its own `##` section when the rationale is non-obvious or an
+example would reduce ambiguity. A fully self-explanatory rule can stand
+alone without one, but that is the exception.
+
+The section heading must match the **key concept** exactly — this is how
+Claude links from a rule in the glance list to its rationale.
+
+Each section:
+
+- Rationale: one or two paragraphs. No restatement of the rule — Claude
+  already has it from the glance list.
+- An example where the rule applies. Use best judgement, but always try.
+- No new rules.
+
+No `---` horizontal rules between sections.
+
+---
+
+## Code Examples
+
+Label all examples `# good` or `# bad` (lowercase, no period), optionally
+followed by `—` and a brief reason. Use `# {filename}` for structural
+examples like composition roots.
+
+```python
+# good
+logger.info("Adjusting policy.", extra={"policy.id": policy.id})
+
+# bad — formats variables into the message string, defeating search
+logger.info(f"Adjusting policy {policy.id}.")
+```
+
+For multi-file or structural examples where good/bad doesn't apply, use a
+`# {filename} —` label:
+
+```python
+# main.py — composition root, wired once at startup
+def build_app() -> App:
+    client = ExternalClientImpl(base_url=settings.service_url)
+    service = DomainService(client=client)
+    return App(service=service)
+```
+
+---
+
+## File Selection
+
+Check whether the domain is already covered before creating a new file.
+Extend an existing file if one owns the concern — a narrower new file
+fragments the ruleset Claude loads.
+
+Create a new file only when no existing file owns the domain.
+
+If a rule could plausibly live in two files, put it in the one most relevant
+to the change being made and cross-reference from the other. One file owns
+the rule; the other points to it.
+
+### Sub-folders
+
+Not all sub-folders exist yet — create the directory if needed.
+
+The trigger sentence in the intro determines which sub-folder a file belongs
+in:
+
+| Trigger | Sub-folder | Contents |
+|---------|-----------|----------|
+| Always — any codebase | `base/` | Comments, testing principles, security, git workflow. |
+| When writing [language] code | `languages/` | Language-specific conventions — one file per language. |
+| When working on [domain] | `domains/` | Business and infrastructure concerns — payments, telephony, gRPC, MCP servers, data pipelines. |
+| When the AI pipeline is operating | `governance/` | Pipeline policy — impact assessment tiers, review iteration, extension model. |
+
+Each sub-folder has a `README.md` listing its files with a one-line
+description. The `standards/` root also has a `README.md` explaining the
+folder structure. When adding a new standards file, add one line to the
+relevant sub-folder README in this format:
+
+```
+- [filename.md](filename.md) — one-line description of what the file covers.
+```
+
+If the sub-folder README does not exist yet, create it with a `# {Sub-folder}
+Standards` heading and that entry as the first line.
+
+---
+
+## See Also
+
+Add a `## See Also` section when another standards file owns a related
+topic — this tells Claude where to look for rules that apply alongside
+this file. Links must be relative paths.
+
+```markdown
+## See Also
+
+- [observability.md](../domains/observability.md) — structured logging
+  conventions and PII rules.
+```
+
+Omit if there are no cross-references.
+
+---
+
+## Template
+
+```markdown
+---
+version: 1.0
+last_reviewed: {YYYY-MM-DD}
+---
+
+# {Topic} Standards
+
+{Domain + governing philosophy — what this file covers and the principle that shapes edge cases.}
+{Trigger — when Claude should apply this file.}
+{Tooling exclusions — what is enforced mechanically and not covered here. Omit if none.}
+{File-overlap exclusions — what a related standards file already owns. Omit if none.}
+
+## Rules at a Glance
+
+1. **{Key concept}.** {Imperative — why it matters.}
+2. **{Key concept}.** {Imperative — why it matters.}
+
+## {Key concept from rule N}
+
+{Rationale for the rule. One or two paragraphs.}
+
+{Example with # good / # bad labels where applicable — see Code Examples.}
+
+## See Also  {optional — omit if no cross-references}
+
+- [{filename}]({relative path}) — {one-line description}.
+```

--- a/.claude/templates/README.md
+++ b/.claude/templates/README.md
@@ -1,0 +1,13 @@
+# Templates
+
+Handoff artefact templates fanned out to every consumer repo. Language-agnostic for now — per-language variants are added to this directory when needed (e.g. `steering-doc-python.md`), requiring no structural change.
+
+## Templates in this library
+
+| Template | Handoff | Purpose |
+|---|---|---|
+| `requirements-package.md` | Product → Engineer | Structured requirements with Given/When/Then ACs |
+| `steering-doc.md` | Engineer → AI | The load-bearing artefact for Stage 2 of the pipeline |
+| `task-spec.md` | Engineer → AI | Lightweight task spec for smaller changes |
+| `acceptance-handoff.md` | Engineer → Product | Summary of what was built and how to verify it |
+| `working-context.md` | Session continuity | WORKING.md format for mid-session context hand-off |

--- a/.claude/templates/acceptance-handoff.md
+++ b/.claude/templates/acceptance-handoff.md
@@ -1,0 +1,63 @@
+# Ready for Acceptance: [Feature name]
+
+JIRA: [ticket]
+Engineer: [engineer name]
+Date: [YYYY-MM-DD]
+
+---
+
+## What was built
+
+[Plain language description of what was built. Describe what the user can now
+do that they could not before. No implementation detail — no file names, class
+names, or technical jargon.]
+
+---
+
+## Acceptance criteria status
+
+| AC | Description | Status | Details |
+|----|-------------|--------|---------|
+| AC-01 | [criterion description] | Implemented | [how to verify — one-line summary] |
+| AC-02 | [criterion description] | Implemented | [how to verify — one-line summary] |
+| AC-03 | [criterion description] | Partial | [what was implemented, what was deferred, and why] |
+| AC-04 | [criterion description] | Deferred | [what was deferred and why — reason provided by engineer] |
+
+---
+
+## Known limitations
+
+[Anything that works but not exactly as specified, with reason. Anything
+deferred to a follow-up ticket. If none, state "None identified."]
+
+- [Limitation description — reason and any follow-up ticket reference]
+
+---
+
+## How to verify
+
+### AC-01: [criterion description]
+
+1. [Environment or preconditions needed]
+2. [Test data or setup steps]
+3. [Action to perform]
+4. [Expected outcome]
+
+### AC-02: [criterion description]
+
+1. [Environment or preconditions needed]
+2. [Test data or setup steps]
+3. [Action to perform]
+4. [Expected outcome]
+
+[Repeat for each Implemented criterion.]
+
+---
+
+## What's not in scope
+
+[Restate the explicit exclusions from the Requirements Package. This prevents
+product from validating against things that were never in scope.]
+
+- [Exclusion 1]
+- [Exclusion 2]

--- a/.claude/templates/design-document.md
+++ b/.claude/templates/design-document.md
@@ -1,0 +1,86 @@
+# Design: [Feature name]
+JIRA: [ticket]
+Engineer: [name]
+Requirements: [link to Artefact 1 — JIRA ticket, docs/requirements/ path, or "N/A"]
+Date: [ISO 8601 date]
+Branch: [branch name]
+
+## Approach
+
+High-level description of the implementation strategy. One to three paragraphs.
+
+Explain why this approach was chosen over evident alternatives. What problem
+does it solve and how? What is the high-level shape of the change?
+
+This section should give a reader who knows the codebase enough context to
+understand every subsequent section without needing to look things up.
+
+## Components affected
+
+**Existing (modified):**
+- `path/to/component` — brief description of what changes and why
+
+**New (created):**
+- `path/to/new/component` — purpose and responsibility
+
+List all services, modules, classes, and files that will be touched or created.
+Be specific enough that the task breakdown can reference them by name.
+
+## Interface contracts
+
+For each new or modified interface:
+
+### [InterfaceName]
+
+Input: [types, valid ranges, null handling, required vs optional]
+Output: [types, constraints, what "success" looks like]
+Errors: [explicit error types and the conditions that trigger them]
+Side effects: [state changes, events emitted, external calls made — "none" if none]
+
+Repeat this block for every interface. If no interfaces are new or modified,
+write "No new or modified interfaces."
+
+## Task breakdown
+
+Ordered list of tasks with dependencies. Each task must be independently
+implementable by an AI agent from a single task spec.
+
+TASK-01: [name] — no dependencies
+TASK-02: [name] — depends on TASK-01 (needs [specific output or artefact])
+TASK-03: [name] — depends on TASK-01, parallel with TASK-02
+
+Rules:
+- Each task name is specific enough to derive a unique slug.
+- Dependencies name the specific output or artefact needed, not just the task.
+- At least one task is required.
+
+## Test strategy
+
+Integration test owner: [which task or tasks own integration tests]
+E2E approach: [scope, tooling, environments — "N/A" if no E2E tests]
+Cross-task constraints: [shared fixtures, test data, ordering — "none" if none]
+
+Describe how the tasks fit together in the test picture. Which task is
+responsible for ensuring the whole feature works end-to-end? Are there
+ordering constraints between test suites?
+
+## Risks and constraints
+
+What could go wrong. What Claude must not do. Anything that needs extra
+attention during implementation or validation.
+
+- [Risk or constraint]: [why it matters and what the mitigation or rule is]
+- [Risk or constraint]: [why it matters and what the mitigation or rule is]
+
+Include external interface risks, behavioural constraints inherited from
+product requirements, and any "must not touch" boundaries.
+
+## ADR references
+
+Existing decisions that constrain this design:
+- [docs/decisions/NNN-name.md] — [one sentence on how it constrains this design]
+
+New decisions being made (create ADR if significant):
+- [proposed ADR title] — [one sentence on the decision being recorded]
+
+If no ADR references apply, write "No ADR references."

--- a/.claude/templates/requirements-package.md
+++ b/.claude/templates/requirements-package.md
@@ -1,0 +1,65 @@
+# Feature: {Feature Name}
+
+| Field   | Value          |
+|---------|----------------|
+| JIRA    | {TICKET-NNN}   |
+| Author  | {product owner} |
+| Date    | {YYYY-MM-DD}   |
+
+## Problem statement
+
+{What user need does this address? One paragraph, no solution language.}
+
+## Scope
+
+### Included
+
+{What is in scope for this feature. Bullet list of capabilities being delivered.}
+
+### Excluded
+
+{What is explicitly not in scope. Bullet list of things that might be assumed but are not part of this work.}
+
+## User journey
+
+{Narrative description of the experience from the user's perspective. No implementation language — behaviour only. Walk through the flow step by step, describing what the user sees and does at each point.}
+
+## Functional requirements
+
+{Numbered requirements. Each requirement starts with a verb, is independently testable, and makes no implementation assumptions.}
+
+FR-01: {Verb-first, specific, testable requirement}
+FR-02: {Verb-first, specific, testable requirement}
+
+## Acceptance criteria
+
+{Gherkin format. Each criterion is linked to a functional requirement by ID.}
+
+AC-01 (FR-01): Given {context}, when {action}, then {outcome}
+AC-02 (FR-01): Given {context}, when {action}, then {outcome}
+AC-03 (FR-02): Given {context}, when {action}, then {outcome}
+
+## Edge cases and error states
+
+{Explicit enumeration of non-happy-path scenarios. Each with expected behaviour.}
+
+| # | Scenario | Expected behaviour |
+|---|----------|--------------------|
+| 1 | {Description of edge case or error state} | {What the system does} |
+| 2 | {Description of edge case or error state} | {What the system does} |
+
+## Non-functional requirements
+
+{Performance, security, compliance constraints. Specific and measurable — not "it should be fast."}
+
+NFR-01: {Specific, measurable non-functional requirement}
+NFR-02: {Specific, measurable non-functional requirement}
+
+## Open questions
+
+{Anything product hasn't resolved yet. Engineering should not start design until these are closed or explicitly acknowledged as blockers.}
+
+| # | Question | Status | Resolution |
+|---|----------|--------|------------|
+| 1 | {Unresolved question} | Open | — |
+| 2 | {Unresolved question} | Open | — |

--- a/.claude/templates/task-spec.md
+++ b/.claude/templates/task-spec.md
@@ -1,0 +1,95 @@
+---
+ticket: [TICKET]
+branch: {TICKET}_{slug}
+---
+
+# Task: [TASK-NN] [Name]
+Feature: [JIRA ticket or link to requirements]
+Design: [docs/design/TICKET-slug.md]
+Depends on: nothing / TICKET-TASK-NN-slug.md
+
+<!-- Feature, Design, and Depends on are required header lines in the body,
+     not frontmatter. They are enforced by convention, not by YAML parsing.
+     Depends on: valid values:
+       - The literal string "nothing" (no dependency)
+       - The exact filename (not path) of a task spec in docs/tasks/,
+         e.g. AIDEV-70-TASK-01-reformat-depends-on-header-in-template.md
+     Any other value is an error. Do not use prose descriptions.
+     branch: derived as {TICKET}_{slug} where slug is: lowercase task name,
+     replace any run of non-alphanumeric characters with a single hyphen,
+     trim leading/trailing hyphens, truncate to 40 characters (trim trailing
+     hyphens after truncation). Example: "the-quick-brown-fox-jumps-over-the-lazy--dog"
+     truncates to "the-quick-brown-fox-jumps-over-the-lazy-" then trims to
+     "the-quick-brown-fox-jumps-over-the-lazy" (no trailing hyphen). -->
+
+## Objective
+
+[One sentence. What exists after this task that did not exist before.]
+
+## Context
+
+- [Where this task fits in the system — specific location, not general description]
+- [Relevant existing pattern to follow — name file or function, not "follow conventions"]
+- [Interface contract this task implements or consumes — reference Design Document section]
+- [Any output from a dependency task that this task consumes — specific file or function]
+
+## Implementation constraints
+
+- Must follow [specific pattern] — see [file or ADR]
+- Must not modify [specific file or component]
+- Error handling: [specific approach — exception type, return value, or propagation rule]
+- Logging: [what to log at which level; what must not be logged]
+- PII: [specific handling rule, or "no PII in scope"]
+- [Any constraint derived from conflict detection against existing standards]
+- [Any constraint derived from external reference synthesis]
+
+## Inputs and outputs
+
+Inputs:
+- [name]: [type] — [valid range or constraint; null handling; required vs optional]
+
+Outputs:
+- [name]: [type] — [what it contains; what "correct" looks like]
+
+Errors:
+- [ErrorType]: [condition that triggers it]
+
+## Edge cases to handle explicitly
+
+- [Edge case]: [required behaviour — not "handle gracefully", but the exact outcome]
+- [Edge case]: [required behaviour]
+
+## Out of scope
+
+- [Thing Claude might reasonably add but must not]
+- [Adjacent concern that belongs to a different task]
+
+## Acceptance criteria
+
+- [ ] [Binary-checkable criterion — passes or fails, no judgment required]
+- [ ] [Binary-checkable criterion]
+- [ ] [Criterion derived from external reference: output includes rule for X sourced from Y]
+- [ ] [Criterion derived from conflict detection: output does not include rule that contradicts Z]
+
+## Test requirements
+
+- Unit tests: [specific functions or behaviours that must have unit test coverage]
+- Edge cases: [which edge cases listed above require explicit test cases]
+- [Do not write integration tests — those are TASK-XX] / [Integration tests: owned by this task]
+
+## Definition of done
+
+- [ ] Implementation passes all unit tests
+- [ ] No hardcoded values
+- [ ] Passes all language-specific linting and type-checking rules defined in CLAUDE.md
+- [ ] Consistent with [specific pattern referenced in Context]
+
+## Required output format
+
+1. Implementation code
+2. Test code
+3. Completion notes:
+   - What decisions were made that were not specified in this task spec
+   - Any constraints in the spec that were ambiguous
+   - Anything that could not be implemented as specified and why
+   - Anything that looks wrong in adjacent code (flag, do not fix)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Background
+
+{one paragraph — why this change exists}
+
+## Changes
+
+* {what changed}
+* ...
+
+## Jira Ticket/s
+
+* https://zegons.atlassian.net/browse/{TICKET}

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,0 +1,37 @@
+# CLAUDE.local.md
+
+Team-local context for AI agents working in this repository. Captures
+non-obvious knowledge an agent could not reliably derive by reading the
+codebase itself. This file is never shipped or overwritten by a standards bump
+— all repo-specific context belongs here, not in `CLAUDE.md`.
+
+## Repository context
+
+### Purpose
+
+- A **reusable Terraform module** that, given a VPC marker (name tag), exposes that VPC's attributes (VPC id, subnets, route tables, VPN CIDR) as outputs — so consumers don't duplicate the `data` lookups. Read-only: it declares **only data sources, no resources**.
+- Owner `systems-engineering`, domain `orchestration`.
+
+### Repository structure
+
+- Flat module: `datasources.tf`, `output.tf` (8 outputs), `variables.tf` (single `marker` input), `local.tf`. Consumed via a git `source` ref (`github.com/zegocover/techops-tf_aws_metadata`); requires AWS provider ≥ 3.55. No backend, no Makefile/Buildkite — CI is the shared claude-code-review GHA only.
+
+### Maintenance notes
+
+- `ci-test-command` is `terraform fmt -check -recursive` (auth-free; no Makefile/pipeline here).
+- **`terraform-safety.sh`** is registered for consistency with the IaC fleet, though this module creates nothing (data-only). Being upstreamed to `zego-ai-standards` ([PR #193](https://github.com/Zegocover/zego-ai-standards/pull/193)); re-add the registration if a bump overwrites `.claude/settings.json`.
+
+## Standards scope
+
+The AI Standards library fans in unconditionally (ADR-002). For a reusable Terraform module:
+
+### Out of scope
+
+- `docs/ai/steering/languages/python.md`, `domains/protobuf-converters.md`, `domains/frontend-ticket-spec.md` — N/A.
+- `docs/ai/steering/base/logging.md`, `observability.md`, `error-handling.md`, `resilience.md` — declarative; no runtime.
+- `docs/ai/steering/base/environment.md` — a library module with input variables, not a deployable with environment config.
+
+### Load-bearing
+
+- `docs/ai/steering/base/code-review.md`, `commit-workflow.md`, `file-organisation.md`, `pull-requests.md`, `spelling.md`
+- `docs/ai/steering/base/testing.md` — no tests today; native `.tftest.hcl` would suit if added.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+---
+# managed by bin/bundle — do not edit; regenerated on every release
+standards_version: "1.1.0"
+built_at: 2026-06-03
+ci-test-command: "terraform fmt -check -recursive"
+---
+
+# Claude AI Standards
+
+If `CLAUDE.local.md` exists in this directory, read it for additional repo-specific context. If it is absent, ignore this reference.
+
+---
+
+## Managed frontmatter block
+
+The YAML frontmatter block at the top of each consumer repo's CLAUDE.md is managed by fan-out. Do not edit the managed keys manually — fan-out will overwrite them. See [ADR 003](docs/decisions/003-claudemd-frontmatter.md) for the full specification.
+
+### Keys
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `standards_version` | yes | — | Version of the AI standards library applied to this repo. |
+| `ci-test-command` | no | — | Shell command(s) the `implement` skill runs for CI validation before committing. |
+
+### `ci-test-command`
+
+Optional. Declares the commands the `implement` skill runs for CI validation (Stage 4) before committing. When absent, the skill discovers commands automatically from `.buildkite/pipeline.yml` or `.github/workflows/*.yml`. Recommended for repos with complex pipelines where automatic extraction may be inconsistent.
+
+See [ADR 003](docs/decisions/003-claudemd-frontmatter.md) for the full specification: priority chain, value format, and examples.
+
+---
+
+## Where things live
+
+- **Generic skills** — `.claude/skills/`. The `implement`, `review`, `create-pr`, `fix-pr-comments`, `fix-buildkite`, `write-design-doc`, and `write-design-doc-max` skills. Always driven by a task spec. `write-design-doc` is the default; `write-design-doc-max` is the high-context, deep-review variant invoked only on explicit request.
+- **Scripts** — `.claude/scripts/`. Shell helper scripts: `pr-comments.sh`, `pr-reply.sh`, `pr-resolve.sh`, `pr-issue-reply.sh` for GitHub PR comment management.
+- **Hooks** — `.claude/hooks/`. `PreToolUse` hook scripts registered in `.claude/settings.json`. Currently: `git-safety.sh`, `filesystem-safety.sh`, `database-safety.sh` — block dangerous Bash patterns before execution.
+- **Design Documents** — `docs/design/`. One file per feature, produced by `write-design-doc` (or `write-design-doc-max`) Phase 1.
+- **Task Specs** — `docs/tasks/`. One file per task, produced by `write-design-doc` (or `write-design-doc-max`) Phase 2. Consumed by `implement`.
+- **AI review outputs** — `docs/ai/reviews/`. Findings files written by the `review` skill; one file per review run.
+
+---
+
+## Tooling preferences
+
+Use `rg` (ripgrep) instead of `grep`, and `fd` instead of `find`. The `.claude/settings.json` deny-list enforces this — `grep` and `find` are blocked.
+
+Hook scripts must use `python3` to parse stdin JSON — do not use `jq`. On parse failure, exit 0 (fail open).
+
+---
+
+## Standards in this library
+
+Read and apply all files listed here. `base/` applies to all code; `languages/` applies when writing that language.
+
+- `docs/ai/steering/base/code-review.md` — code review conventions: review groups, scope, conditional checks per language and domain.
+- `docs/ai/steering/base/logging.md` — logging conventions: levels, structured calls, PII rules, Zego common keys.
+- `docs/ai/steering/base/observability.md` — metrics and distributed tracing: three-signal coverage, OpenTelemetry instrumentation, metric naming, span attributes.
+- `docs/ai/steering/base/pull-requests.md` — pull request conventions: title format, body structure, not opening PRs unprompted.
+- `docs/ai/steering/base/testing.md` — testing conventions: integration-first, observable behaviour, naming, test isolation.
+- `docs/ai/steering/base/environment.md` — environment variable conventions (language-agnostic): single config entry point, GitOps-before-app sequencing, committed/gitignored config file layout, secrets-config provisioning workflow.
+- `docs/ai/steering/base/commit-workflow.md` — commit workflow conventions: never bypass pre-commit hooks, fix-and-retry on failure, preserve commit message on retry, framework-agnostic no-hook handling.
+- `docs/ai/steering/base/error-handling.md` — error handling conventions: custom domain exceptions, catch-specific patterns, boundary-only broad catches, and the prohibition on silent swallowing.
+- `docs/ai/steering/base/file-organisation.md` — file organisation conventions (language-agnostic): one responsibility per file, 50-300 line target, split at 400+, concept-based grouping.
+- `docs/ai/steering/base/resilience.md` — resilience conventions (language-agnostic): retry only transient failures, exponential backoff with jitter, maximum retry counts, explicit timeouts, idempotency keys.
+- `docs/ai/steering/base/spelling.md` — spelling conventions: UK English in all human-readable text; identifiers and API contracts exempt.
+
+- `docs/ai/steering/languages/python.md` — Python conventions: project structure, dependency injection, typing, functional core/imperative shell, pytest patterns.
+
+- `docs/ai/steering/domains/protobuf-converters.md` — protobuf converter conventions: never hand-roll conversions, nullability suffix rules, proto3 zero-value semantics, going upstream for missing converters.
+
+- `docs/ai/steering/domains/frontend-ticket-spec.md` — frontend ticket specification conventions: what must be resolved before an autonomous agent picks up a ticket in zego-web, customer-acquisition, checkout-mfe, my-zego, or zego-utils.
+
+---
+
+## Skills available in this repo
+
+- **`implement`** — You MUST use this when the user asks to implement a task spec or produce the artefact it describes.
+- **`review`** — You MUST use this when the user asks to review their code, run a code review, or verify a branch against Zego coding standards (with or without a task spec).
+- **`create-pr`** — You MUST use this when the user asks to open a pull request for a completed implementation.
+- **`ci-validation`** — You MUST use this when the user asks to run CI validation locally or verify that code passes CI checks before committing.
+- **`fix-pr-comments`** — You MUST use this when the user asks to address or fix unresolved review threads on a pull request.
+- **`fix-buildkite`** — You MUST use this when the user asks to diagnose, fix, or retry failed Buildkite CI builds.
+- **`write-design-doc`** — You MUST use this when the user asks to write a design document or task specs for a feature given a JIRA ticket or requirements file. This is the default design-doc flow.
+- **`write-design-doc-max`** — You MUST use this ONLY when the user explicitly asks for the "max" design-doc flow. It produces the same artefacts as `write-design-doc` but spends much more context running an incremental review of every design and task document. Not auto-routed for generic design-doc requests; the default `write-design-doc` handles those.
+- **`write-requirements`** — You MUST use this when the user asks to collect or document requirements from a product owner or PM.
+- **`write-acceptance-handoff`** — You MUST use this when the user asks to produce an acceptance handoff document for product sign-off.
+- **`write-standard`** — You MUST use this when the user asks to create a new standard, write a standards file, author coding conventions, or extend an existing standards file with new rules.
+- **`write-skill`** — You MUST use this when the user asks to create a new skill, write a skill file, or produce a SKILL.md for a workflow.
+- **`extend-claude-standards`** — You MUST use this when the user asks to deepen, update, or fill gaps in the repository context section of CLAUDE.local.md.

--- a/docs/ai/steering/base/README.md
+++ b/docs/ai/steering/base/README.md
@@ -1,0 +1,12 @@
+# Base Standards
+
+- [logging.md](logging.md) — logging conventions: levels, structured log calls, PII rules, and Zego common keys.
+- [observability.md](observability.md) — metrics and distributed tracing: three-signal coverage, OpenTelemetry instrumentation, metric naming, span attributes, and async trace linking.
+- [pull-requests.md](pull-requests.md) — PR title format, Background/Changes/Jira Ticket/s body structure, and gh pr create usage.
+- [testing.md](testing.md) — integration-first testing philosophy, mock boundaries, fixture hygiene, and coverage enforcement.
+- [environment.md](environment.md) — environment variable conventions (language-agnostic): single config entry point, GitOps-before-app sequencing, committed/gitignored config file layout, and secrets-config provisioning workflow.
+- [error-handling.md](error-handling.md) — error handling conventions: custom domain exceptions, catch-specific patterns, boundary-only broad catches, and the prohibition on silent swallowing.
+- [file-organisation.md](file-organisation.md) — file size and structural organisation: one responsibility per file, 50–300 line target, split at 400+, and concept-based grouping.
+- [resilience.md](resilience.md) — resilience conventions: retry only transient failures, exponential backoff with jitter, maximum retry counts, explicit timeouts, and idempotency keys.
+- [spelling.md](spelling.md) — UK English house style for all human-readable text: comments, docstrings, log messages, error messages; identifiers and API contracts exempt.
+- [commit-workflow.md](commit-workflow.md) — commit workflow conventions: pre-commit hooks run on every commit, fix-and-retry on failure, never bypass with --no-verify, graceful no-hook handling.

--- a/docs/ai/steering/base/code-review.md
+++ b/docs/ai/steering/base/code-review.md
@@ -1,0 +1,166 @@
+---
+version: "1.1"
+last_reviewed: 2026-06-02
+---
+
+# Code Review
+
+Instructions for reviewing a diff against Zego standards. Defines which checks run, how they are grouped, and what the output must look like.
+
+This document is what the `review` skill checks against. An agent running a review must work through every check mechanically against the diff. Writing a review file by hand without running the checks does not satisfy the workflow.
+
+---
+
+## Groups
+
+Checks are divided into eight groups, each run by a dedicated sub-agent in parallel. Groups E, F, and G are conditional — only spawn them if the relevant conditions are met.
+
+| Group | Name | Standard file(s) | Conditional? |
+|---|---|---|---|
+| A | Scope | (inline below) | Never |
+| B | Logging, Observability & Environment | `docs/ai/steering/base/logging.md`, `docs/ai/steering/base/observability.md`, `docs/ai/steering/base/environment.md` | Never |
+| C | Testing | `docs/ai/steering/base/testing.md` | Never |
+| D | Safety | (independent reasoning) | Never |
+| E | Task spec & design doc | ticket's task spec (and design doc, if present) | Skip if no task spec |
+| F | Python | `docs/ai/steering/languages/python.md` | Only if `.py` files in diff |
+| G | Protobuf Converters | `docs/ai/steering/domains/protobuf-converters.md` | Only if `.proto` or `converter` files in diff |
+| H | Error Handling, File Organisation, Resilience & Spelling | `docs/ai/steering/base/error-handling.md`, `docs/ai/steering/base/file-organisation.md`, `docs/ai/steering/base/resilience.md`, `docs/ai/steering/base/spelling.md` | Never |
+
+---
+
+## Group A — Scope
+
+These checks apply to every diff. They are hardcoded here and have no standard file.
+
+1. **No credentials in diff.** No passwords, API keys, tokens, or secrets appear in any added line. → blocker if found.
+2. **One logical change.** The diff represents a single coherent unit of work. Unrelated refactors mixed with feature work → major; suggest splitting.
+3. **Diff matches branch description.** Changes are consistent with what the branch name and commit messages describe. Unexplained scope creep → major.
+
+---
+
+## Group B — Logging, Observability & Environment
+
+Load and apply all rules from `docs/ai/steering/base/logging.md`, `docs/ai/steering/base/observability.md`, and `docs/ai/steering/base/environment.md`.
+
+Check every new or modified log call, metric instrument, span operation, and configuration/environment variable usage against the rules in those files. Apply all three files — logging, observability, and environment are distinct rule sets over cross-cutting infrastructure concerns.
+
+**Honour each file's Applicability section — scope by the surfaces present in the diff, not by the repo's stack.** `logging.md`, `observability.md`, and `environment.md` each separate a universal core from rules that act on a specific backend surface:
+
+- The **universal cores** — no logged credentials/PII, static messages with structured fields, sensible log levels, a single config entry point, documented variables — apply wherever the relevant code exists.
+- The **backend-surface rules** — OTel/Datadog metric & span instrumentation, and the GitOps/Helm/`secrets-config` provisioning workflow — act only on those surfaces. Apply them wherever that surface exists in the repo: if the instrumentation infra is present, new or modified code paths in the diff are expected to be instrumented, so flag under-instrumentation (e.g. a new endpoint with no metric or span) even when the diff does not edit existing instrumentation. Where the surface is absent from the repo entirely, there is nothing to check.
+
+Gate by surface presence, not by classifying the repo. Do **not** infer from a repo's language or framework that it *should* have server-side instrumentation or GitOps wiring, and do **not** raise a finding for the absence of a surface the repo does not have.
+
+---
+
+## Group C — Testing
+
+Load and apply all rules from `docs/ai/steering/base/testing.md`.
+
+Check every new or modified test file and test-adjacent change (fixtures, conftest, coverage config) against the rules in that file.
+
+---
+
+## Group D — Safety
+
+No standard file. The sub-agent reasons independently over the diff.
+
+For every new or modified function, class, method, or configuration block, generate candidate risk scenarios specific to the code patterns present, then investigate each. Assess whether the code:
+
+1. Introduces a security vulnerability (injection, insecure defaults, credential or token exposure, authentication or authorisation bypass)
+2. Risks data loss or corruption
+3. Logs, stores, or transmits PII through an unintended channel
+
+Every finding must be grounded in what the diff actually contains. Do not invent attack surfaces not present in the code.
+
+---
+
+## Group E — Task spec & design doc
+
+Only run if a task spec exists for the ticket (search `docs/tasks/` for a file whose frontmatter `ticket` field matches the branch ticket).
+
+If found: load the task spec and check whether the diff delivers what the goal, output spec, and acceptance criteria required. Also search `docs/design/` for a design doc whose `JIRA:` frontmatter field matches the ticket — if one is found, load it as supplementary context for the acceptance criteria check.
+
+If not found: skip this group entirely. Do not emit a finding for its absence.
+
+Skip this group when the diff for the current ticket contains only planning artefacts (paths matching the discovered task spec path, `docs/design/{TICKET}-*.md`, or `docs/tasks/{TICKET}-*.md`). The orchestrator records the skip in the review file's Validation-errors section with reason `pre-implementation` — specifically the exact string `Group E skipped: pre-implementation (diff contains only planning artefacts for {TICKET})`. Group E resumes as soon as the diff contains any other file.
+
+---
+
+## Group F — Python (conditional)
+
+Only run if the diff contains `.py` files.
+
+Load and apply all rules from `docs/ai/steering/languages/python.md`. Check every new or modified Python file.
+
+---
+
+## Group G — Protobuf Converters (conditional)
+
+Only run if the diff contains `.proto` files or files whose path includes `converter` or `converters`.
+
+Load and apply all rules from `docs/ai/steering/domains/protobuf-converters.md`. If the standard file does not exist, skip this group and record a validation error.
+
+---
+
+## Group H — Error Handling, File Organisation, Resilience & Spelling
+
+Load and apply all rules from `docs/ai/steering/base/error-handling.md`, `docs/ai/steering/base/file-organisation.md`, `docs/ai/steering/base/resilience.md`, and `docs/ai/steering/base/spelling.md`.
+
+Check every new or modified catch/exception block, error type definition, and error-handling flow against the error-handling rules. Check file sizes and directory structure against the file-organisation rules. Check retry logic, timeout configuration, backoff implementation, and idempotency patterns against the resilience rules. Check all human-readable text (comments, docstrings, log messages, error messages) against the spelling rules.
+
+---
+
+## Severity definitions
+
+- **blocker** — must be fixed before merge; merging with this present is wrong
+- **major** — violates a standard rule without documented exception; must be fixed
+- **minor** — violates a rule but is low-impact; should be fixed, may be deferred
+- **nit** — style preference not covered by a rule; non-blocking
+
+## Output format
+
+Each sub-agent returns two things:
+
+**1. Per-check block** — one line per item checked, tagged `[pass]`, `[advisory]`, `[warning]`, `[error]`, or `[blocker]`:
+
+```
+### Group {letter} — {name}
+[pass] {check description} — {one sentence: what was found}
+[advisory] {check description} — {one sentence: non-blocking observation}
+[warning] {check description} — {one sentence: issue that should be fixed}
+[error] {check description} — {one sentence: major issue that must be fixed}
+[blocker] {check description} — {one sentence: blocker that must be fixed before merge}
+```
+
+Tag-to-severity mapping (one-to-one — use exactly the tag that matches the severity):
+
+| Tag | Severity | Blocks verdict? |
+|-----|----------|-----------------|
+| `[pass]` | — | No |
+| `[advisory]` | nit | No |
+| `[warning]` | minor | No |
+| `[error]` | major | Yes (FAIL) |
+| `[blocker]` | blocker | Yes (FAIL) |
+
+Every check that ran must appear as a line. `[pass]` lines are required. A sub-agent that returns only failures is not providing an audit trail.
+
+In addition to the `PASS` and `FAIL` verdicts named by the orchestrator, the verdict surface includes `PRE-IMPLEMENTATION` — semantics: no implementation present yet; AC verification deferred; non-blocking. The findings-file status field carries the corresponding value `pre-implementation` with the same semantics as the verdict (no implementation present yet; AC verification deferred; non-blocking). These are emitted by the orchestrator's Stage 2b pre-implementation guard, which records the skip in the Validation-errors section with the exact reason string `Group E skipped: pre-implementation (diff contains only planning artefacts for {TICKET})` whenever the diff contains only planning artefacts (paths matching the discovered task spec path, `docs/design/{TICKET}-*.md`, or `docs/tasks/{TICKET}-*.md`).
+
+**2. YAML findings list** — structured entries for every `[warning]`, `[error]`, and `[blocker]`:
+
+```yaml
+findings:
+  - severity: blocker | major | minor | nit
+    file: {path}
+    line: {line number, range, or "n/a"}
+    rule: {relative path to standard file}#{anchor}
+    issue: {one sentence — what is wrong}
+    suggestion: {one sentence — what to do instead}
+```
+
+Return `findings: []` if nothing to report.
+
+## Exceptions
+
+A diff author may deviate from a rule with a documented reason in a commit message or inline comment. If the deviation is documented and justified, do not flag it — note the exception in the summary.

--- a/docs/ai/steering/base/commit-workflow.md
+++ b/docs/ai/steering/base/commit-workflow.md
@@ -1,0 +1,191 @@
+---
+version: 1.2
+last_reviewed: 2026-06-02
+---
+
+# Commit Workflow Standards
+
+Conventions for how Claude interacts with git commits and pre-commit hooks — the governing philosophy is: commit-time hooks are the repo's quality gates; run them on every commit, fix failures before retrying, never bypass them.
+
+Apply these rules whenever creating a git commit in any repository, regardless of stack.
+
+The rules are framework-agnostic. Hook frameworks vary by ecosystem — `pre-commit` (`.pre-commit-config.yaml`, common in Python), `husky` and `lint-staged` (JS/TypeScript), `lefthook` (Go and others), Gradle/Git hooks (Android), or raw executable `.git/hooks/pre-commit` — and Rules 7–8 already cover each plus the no-framework case. The hook *tools* in the examples below (`ruff`, `mypy`) are illustrative of one stack; read them as a stand-in for whatever the repo runs — `eslint`/`prettier`, `ktlint`/`detekt`, `swiftlint`, `scalafmt`, etc. The workflow (don't bypass, fix-and-retry, re-stage, don't amend) is identical across all of them.
+
+PR structure after committing is covered in [pull-requests.md](pull-requests.md).
+
+## Rules at a Glance
+
+1. **Never use `--no-verify`.** Never pass `--no-verify` to `git commit` unless the user explicitly asks for it — pre-commit hooks are the repo's chosen quality gates and bypassing them defeats their purpose, allowing lint violations, formatting drift, and type errors to land in the history.
+2. **Fix and retry on hook failure.** When a pre-commit hook fails, the commit did not happen — read the hook's error output, diagnose the root cause, fix the issue, and re-stage all files the hook touched (including any the hook auto-formatted). Re-stage is critical because the hook may have modified working-tree files without updating the index, and stale staged content will reproduce the same failure.
+3. **Preserve the commit message on retry.** Reuse the original commit message for every retry attempt — the intent has not changed, only the code needed fixing.
+4. **Never amend after a hook failure.** Always create a new commit attempt after fixing a hook failure — never use `--amend`, because the failed commit was never created and amending would modify the previous (unrelated) commit, risking data loss.
+5. **Retry budget with progress condition.** Make at most five commit attempts (the original plus four retries) for the same logical change — stop early if the same hook reports the same error on consecutive attempts (the fix is not converging), and stop unconditionally after five attempts, surfacing the failure to the user because the issue likely requires manual intervention or context Claude does not have.
+6. **Surface hook failures to the user.** Show the user the hook's error output and explain what was caught and what was fixed on each retry — silent fixes hide quality-gate activity and prevent the user from spotting systemic issues in their codebase.
+7. **Do not install, modify, or remove hooks.** Never run `pre-commit install` / `husky install` / `lefthook install`, edit `.pre-commit-config.yaml`, `.husky/` (e.g. `.husky/pre-commit`), or `lefthook.yml` / `.lefthook.yml`, or alter files in `.git/hooks/` — hook configuration is a repo-owner decision, and changing it without being asked modifies the project's quality gates.
+8. **Graceful handling when no hooks exist.** If a repo has no hook framework configuration (no `.pre-commit-config.yaml`, `.husky/`, `lefthook.yml` / `.lefthook.yml`, or executable `.git/hooks/pre-commit`), proceed with the commit normally — do not warn about missing hooks, suggest installing a framework, or treat the situation as degraded. If a framework config exists but hooks are not installed locally (e.g. `.husky/` present but `git commit` runs no hooks), surface this to the user rather than silently committing without coverage.
+
+## Never use `--no-verify`
+
+The prohibition is absolute unless the user explicitly opts in with a direct request. "The hook is slow", "I'll fix it later", and "it's just a formatting change" are not valid reasons — treat any temptation to skip as a signal to fix the underlying failure instead.
+
+```shell
+# good — commit runs hooks automatically
+git commit -m "AIDEV-51: Add commit workflow standard"
+
+# bad — bypasses the repo's quality gates
+git commit --no-verify -m "AIDEV-51: Add commit workflow standard"
+
+# good — user explicitly asked to skip
+# (user said "commit with --no-verify, the secret-scan hook is misconfigured")
+git commit --no-verify -m "AIDEV-51: Add commit workflow standard"
+```
+
+## Fix and retry on hook failure
+
+Re-staging is the critical step. Hooks often run formatters that modify files in the working tree without updating the index. After the hook (or Claude) fixes the issue, re-stage every file the hook touched — not just the files Claude edited — or the same failure recurs.
+
+```shell
+# good — hook fails, fix applied, all modified files re-staged, new commit created
+git commit -m "AIDEV-51: Add commit workflow standard"
+# pre-commit hook fails: "ruff found 2 fixable violations"
+# fix the violations (or the hook's auto-formatter already did)
+# re-stage ALL files the hook touched, not just the ones Claude edited
+git add docs/ai/steering/base/commit-workflow.md src/utils.py
+git commit -m "AIDEV-51: Add commit workflow standard"
+
+# bad — hook fails, bypass instead of fix
+git commit -m "AIDEV-51: Add commit workflow standard"
+# pre-commit hook fails: "ruff found 2 fixable violations"
+git commit --no-verify -m "AIDEV-51: Add commit workflow standard"
+```
+
+## Preserve the commit message on retry
+
+Reuse the exact original message — including multi-line bodies and trailers like `Co-Authored-By` — on every retry. Pass the message via a HEREDOC or variable to avoid retyping and accidental edits between attempts.
+
+```shell
+# good — same message on retry, passed via variable to avoid drift
+MSG="$(cat <<'EOF'
+AIDEV-51: Add commit workflow standard
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git commit -m "$MSG"
+# hook fails, fix applied, re-staged
+git commit -m "$MSG"
+
+# bad — message changed between attempts
+git commit -m "AIDEV-51: Add commit workflow standard"
+# hook fails, fix applied, re-staged
+git commit -m "AIDEV-51: Fix lint issues in commit workflow standard"
+```
+
+## Never amend after a hook failure
+
+A failed commit was never created — `--amend` after a hook failure modifies the previous (unrelated) commit, silently rewriting history and potentially destroying work.
+
+```shell
+# good — new commit attempt after hook failure
+git commit -m "AIDEV-51: Add commit workflow standard"
+# hook fails — no commit object was created
+# fix the issue, re-stage
+git commit -m "AIDEV-51: Add commit workflow standard"
+
+# bad — amend modifies the PREVIOUS commit, not the failed one
+git commit -m "AIDEV-51: Add commit workflow standard"
+# hook fails — no commit object was created
+# fix the issue, re-stage
+git commit --amend -m "AIDEV-51: Add commit workflow standard"
+# ↑ this rewrites the commit BEFORE the one you intended
+```
+
+## Retry budget with progress condition
+
+Two stopping rules:
+
+- **Hard cap:** five attempts (the original plus four retries) for the same logical change.
+- **Stall detection:** if the same hook reports the same error on two consecutive attempts, stop immediately — the fix is not converging.
+
+After exhausting the budget (or stalling), report the failure to the user with the full hook output. Do not attempt workarounds such as disabling the hook, modifying hook configuration, or restructuring the commit to avoid triggering the hook.
+
+Common unfixable cases: hooks that require authentication tokens, hooks that validate against a remote service, hooks with bugs that reject all input.
+
+```shell
+# good — different error each attempt, budget allows continued progress
+git commit -m "AIDEV-51: Add commit workflow standard"
+# hook fails: ruff — unused import → fix, re-stage
+git add src/main.py && git commit -m "AIDEV-51: Add commit workflow standard"
+# hook fails: mypy — type error exposed by import removal → fix, re-stage
+git add src/main.py && git commit -m "AIDEV-51: Add commit workflow standard"
+# succeeds on attempt 3
+
+# good — same error twice in a row, stop early (stall detected)
+git commit -m "AIDEV-51: Add commit workflow standard"
+# hook fails: secret-scan — token detected in config.py → redact, re-stage
+git add config.py && git commit -m "AIDEV-51: Add commit workflow standard"
+# hook fails: secret-scan — same token, same file → stop and surface to user
+
+# bad — keep retrying the same failure past the stall condition
+# (third attempt at the same secret-scan error)
+git add config.py && git commit -m "AIDEV-51: Add commit workflow standard"
+```
+
+## Surface hook failures to the user
+
+On every retry, report: which hook failed, the error it produced, the fix applied, and the retry outcome. Do not silently fix and re-commit.
+
+```text
+# good — surface the failure, the fix, and the outcome
+The ruff hook failed: "F401 `os` imported but unused in src/main.py:3".
+Removed the unused import on line 3 and re-staged src/main.py.
+Retrying commit… succeeded on attempt 2.
+
+# bad — silently fix and say nothing
+(hook fails, Claude fixes the import and re-commits without telling the user)
+```
+
+## Do not install, modify, or remove hooks
+
+Work with whatever hooks the repo already has. If no hooks are configured, do not add them. If hooks are misconfigured, report the issue to the user rather than fixing the configuration.
+
+Off-limits actions: `pre-commit install`, editing `.pre-commit-config.yaml` / `.husky/` / `.lefthook.yml`, writing to `.git/hooks/`.
+
+```shell
+# good — report the misconfiguration, let the user decide
+# "The pre-commit hooks are not installed locally.
+#  Run 'pre-commit install' if you'd like hooks to run on each commit."
+
+# bad — installing or modifying hook configuration
+pre-commit install
+echo "#!/bin/sh\nruff check ." > .git/hooks/pre-commit
+```
+
+## Graceful handling when no hooks exist
+
+Two distinct cases:
+
+- **No framework configured** (no `.pre-commit-config.yaml`, `.husky/`, `lefthook.yml` / `.lefthook.yml`, or executable `.git/hooks/pre-commit`): commit normally. Do not warn about missing hooks, suggest installing a framework, or treat the absence as degraded.
+- **Framework configured but not installed locally** (e.g. `.pre-commit-config.yaml` exists but `git commit` runs no hooks): surface this to the user so they can decide whether to install. Do not install the framework yourself (see Rule 7).
+
+## Red Flags — Stop and Reconsider
+
+If any of these thoughts cross your mind, stop — you are about to rationalise away a rule.
+
+- "The hook is slow and this is just a formatting change, so I'll pass `--no-verify` this once."
+- "The hook failure looks unrelated to my change, so it's safe to skip verification."
+- "The commit failed, so I'll `--amend` to keep my message instead of retyping it."
+- "I already fixed the issue, so amending the last commit is cleaner than making a new one."
+- "I'll temporarily disable the hook to get unblocked and re-enable it after."
+
+| Rationalisation | Rule it violates | Real-world consequence |
+|---|---|---|
+| "The hook is slow and this is just a formatting change, so I'll pass `--no-verify` this once." | Rule 1 — Never use `--no-verify` | Lint violations, formatting drift, or type errors bypass the quality gate and land in history, surfacing as CI failures or review churn later. |
+| "The hook failure looks unrelated to my change, so it's safe to skip verification." | Rule 1 — Never use `--no-verify` | A real defect the hook caught is committed unexamined; "unrelated" failures are frequently the hook correctly flagging the agent's own staged changes. |
+| "The commit failed, so I'll `--amend` to keep my message instead of retyping it." | Rule 4 — Never amend after a hook failure | The failed commit was never created, so `--amend` rewrites the previous, unrelated commit — silently destroying its content and corrupting history. |
+| "I already fixed the issue, so amending the last commit is cleaner than making a new one." | Rule 4 — Never amend after a hook failure | The "last commit" is not the failed attempt but the prior good commit; amending it mixes unrelated changes and risks data loss. |
+| "I'll temporarily disable the hook to get unblocked and re-enable it after." | Rule 1 — Never use `--no-verify` | The bypass becomes permanent in practice, the gate is defeated for that commit, and the change ships without the validation the repo owner mandated. |
+
+## See Also
+
+- [pull-requests.md](pull-requests.md) — PR structure conventions; sits downstream of the commit workflow.

--- a/docs/ai/steering/base/environment.md
+++ b/docs/ai/steering/base/environment.md
@@ -1,0 +1,206 @@
+---
+version: 1.2
+last_reviewed: 2026-06-02
+---
+
+# Environment Variable Standards
+
+Conventions for managing configuration — the governing philosophy is that configuration is infrastructure: every configuration value must be declared in a single config entry point, never scattered through ad-hoc reads, and never committed when it is a secret.
+
+## The universal principle
+
+These rules apply to **any** code that reads configuration, regardless of stack:
+
+1. **Single config entry point** — one module/file owns all configuration reads; business logic receives values by injection, never by reading the environment directly (Rule 1 below).
+2. **Sensible defaults where safe** (Rule 3 below).
+3. **Committed dev/CI config, gitignored personal overrides; never commit secrets** (Rule 4 below).
+4. **Document available variables** in a reference file kept in sync with the config entry point (Rule 5 below).
+
+## Applicability
+
+The **provisioning-workflow** rules — Rule 2 (GitOps before app code), Rule 6 (GitOps structure matches config), and Rule 7 (secrets through `secrets-config`) — act on one specific surface: configuration delivered through **Zego's Kubernetes pipeline** (ArgoCD, the `Zegocover/gitops-<repo>` Helm charts, and AWS Secrets Manager via the `secrets-config` Terraform repo). Apply them wherever that surface exists — i.e. the repo is deployed through that pipeline.
+
+Where the surface is absent — the code is not deployed through the k8s GitOps pipeline — these three rules have nothing to act on. Apply the universal config-hygiene rules (1, 3, 4, 5) and use whatever configuration-delivery and secret-storage mechanism the platform provides in their place.
+
+**Gate by the surface, not by the repo's language or framework.** Do not raise findings for missing GitOps/Helm/`secrets-config` wiring in a repo that does not deploy that way. (Runtimes that commonly lack this surface include mobile apps, browser frontends, BI/declarative models, and libraries — but these are illustrations, not the test. The test is whether the repo deploys through the k8s GitOps pipeline.)
+
+## Rules at a Glance
+
+1. **Single config entry point.** All environment variable reads must go through one module or file that centralises configuration — never scatter direct environment-variable reads through business logic, because scattered reads are invisible to the type system, bypass validation, and cannot be discovered by reading one file.
+2. **GitOps before app code for required vars.** When a new environment variable has no default value, the GitOps PR (`Zegocover/gitops-<repo-name>`) must be merged and synced before the application code PR merges — otherwise ArgoCD deploys a container that crashes immediately because the required variable is missing.
+3. **Sensible defaults where possible.** Give configuration fields a default value when a safe, non-secret default exists — this reduces the number of hard deployment dependencies and lets the service start in local development without a complete GitOps mirror.
+4. **Committed development/CI config, gitignored personal overrides.** Maintain committed configuration files for local development and CI, plus a gitignored file for personal overrides — the personal override file must never be committed because it is the file most likely to accumulate secrets.
+5. **Document available variables.** Maintain a reference file (`.env.example`, a doc comment block, or equivalent) listing every variable the config reads, with placeholder values and comments — without it, a new developer or Claude must reverse-engineer the config module to know what to set.
+6. **GitOps structure matches config structure.** Environment variables in the Helm chart (`blueprint.apps.<service>.envVars`) must correspond one-to-one with fields in the config entry point — orphaned GitOps vars waste memory and create confusion; missing GitOps vars cause startup crashes.
+7. **Provision secrets through secrets-config.** New secrets must be added to the `Zegocover/secrets-config` Terraform repo and applied before the consuming application code merges — if the secret does not exist in AWS Secrets Manager when the pod starts, the service will fail to access required secrets at runtime.
+
+## Single config entry point
+
+Every service must have one module or file that owns all configuration reads. Business logic receives config values via injection — it never reads from the environment directly. This makes every environment dependency discoverable in a single place, enables startup-time validation, and ensures the type system knows what each value is.
+
+In Python, this is a Pydantic `BaseSettings` class. In Scala, this is Typesafe Config / PureConfig with a case class. See language-specific standards for implementation details.
+
+The config entry point should be instantiated or loaded once at startup and injected into components that need it. Do not re-read the environment per request — each re-read bypasses any caching or validation the config layer provides.
+
+```
+# good — one config module, injected into consumers
+[config entry point]
+  port = 8080           (from env PORT, default 8080)
+  log_level = "INFO"    (from env LOG_LEVEL, default "INFO")
+  dynamo_region = ...   (from env DYNAMO__REGION)
+  dynamo_table = ...    (from env DYNAMO__TABLE_NAME)
+
+app = build_app(config)
+
+# bad — env reads scattered in business logic
+def get_score(customer_id):
+    table_name = read_env("DYNAMO_TABLE_NAME")  # untyped, unvalidated, invisible
+    ...
+```
+
+## GitOps before app code for required vars
+
+When a config field has no default value, the service will crash at startup if the variable is missing from the environment. ArgoCD auto-syncs the GitOps repo, so the deployment sequence is: Buildkite builds the image, the gitops-buildkite-plugin updates the image tag, ArgoCD deploys. If the GitOps repo does not yet define the variable, the new container starts, config validation fails, and the container crash-loops.
+
+The correct sequence for a required variable:
+
+1. Add the field to the config entry point in the application repo (PR open, not merged).
+2. Open a PR in `Zegocover/gitops-<repo-name>` adding the variable to `values.yaml` (or `values/<env>.yaml` for per-environment overrides).
+3. Merge and confirm the GitOps PR has synced (ArgoCD shows the new config on the running pods, even though the app code does not yet read it — extra env vars are harmless).
+4. Merge the application code PR.
+
+For variables with a sensible default, the ordering is less critical — the service will start with the default and pick up the GitOps value on the next deploy. Even so, having the GitOps PR ready before or alongside the app PR is good practice.
+
+```yaml
+# gitops-score-per-product/values.yaml — add the variable here first
+blueprint:
+  apps:
+    score-per-product:
+      envVars:
+        NEW_FEATURE_ENABLED: "false"   # safe default; app PR can merge independently
+
+# gitops-score-per-product/values/production.yaml — per-env override
+blueprint:
+  apps:
+    score-per-product:
+      envVars:
+        NEW_FEATURE_ENABLED: "true"
+```
+
+## Sensible defaults where possible
+
+A field with a default can be omitted from the environment without crashing the service. This is valuable in three contexts: local development (fewer variables to configure), CI (lighter CI config), and resilience (a missing GitOps value degrades gracefully instead of crash-looping).
+
+Not every field can have a default. Database hostnames, API keys, and service URLs are environment-specific by nature. The rule is: if a value is safe to assume in the absence of explicit configuration, provide it.
+
+```
+# good — safe defaults where they make sense; no default where they don't
+dynamo_region  = "eu-west-1"    # safe default for Zego
+dynamo_table   = <required>     # no safe default — must come from env
+read_capacity  = 5              # reasonable starting point
+
+# bad — no defaults anywhere; every variable must be provisioned even for local dev
+dynamo_region  = <required>
+dynamo_table   = <required>
+read_capacity  = <required>
+```
+
+## Committed development/CI config, gitignored personal overrides
+
+The config files serve distinct audiences:
+
+- **Development config** (committed) — contains the full set of variables needed to run the service locally (pointing at local databases, mock endpoints, safe test values). In Python this is `.env.development`; in Scala this is an `application.conf` or `local.conf` with safe defaults.
+- **CI config** (committed) — contains the minimal set needed for CI smoke tests (may point at ephemeral resources or stubs). In Python this is `.env.ci`; in Scala this may be a dedicated `ci.conf` or CI-specific env var injection.
+- **Personal overrides** (gitignored, never committed) — developers use this for personal tweaks (a different database port, a debug flag). In Python this is `.env`; in Scala this might be `local-overrides.conf`. Values here take precedence over committed config.
+
+The personal override file must never contain values in the repository. It is the file most likely to accumulate real credentials during development, and committing it — even once — exposes secrets in git history permanently.
+
+```gitignore
+# .gitignore — personal override files are always ignored
+.env
+local-overrides.conf
+```
+
+```shell
+# .env.development (Python) — committed, safe local values
+DYNAMO__REGION=eu-west-1
+DYNAMO__TABLE_NAME=local-scores
+PM__BASE_URL=http://localhost:8081
+LOG_LEVEL=DEBUG
+```
+
+```shell
+# .env.ci (Python) — committed, minimal for CI
+DYNAMO__REGION=eu-west-1
+DYNAMO__TABLE_NAME=ci-scores
+LOG_LEVEL=WARNING
+```
+
+## Provisioning a new secret
+
+Secrets are provisioned through the `Zegocover/secrets-config` Terraform repo — adding a field to the config entry point is not enough. If the secret does not exist in AWS Secrets Manager when the pod starts, the service will fail to access required secrets at runtime. The correct sequence mirrors the GitOps rule:
+
+1. Add the secret field to the config entry point in the application repo (PR open, not merged).
+2. Open a PR in `Zegocover/secrets-config` adding the secret to the relevant `env/<environment>.tfvars.json` files, listing your service as an `allowed_reader` with its `{namespace, service}` pair.
+3. Merge the `Zegocover/secrets-config` PR; Buildkite runs `terraform apply`, creating the secret (empty) and its KMS key in AWS.
+4. Coordinate with systems engineering to set the actual secret value in AWS Secrets Manager.
+5. Merge the application code PR.
+
+Each secret is scoped to specific services via `allowed_readers`. If your service needs to read a secret it is not currently listed for, the `Zegocover/secrets-config` entry must be updated to grant access — the pod's IRSA role is matched against the declared `{namespace, service}` pairs and access is denied without a match.
+
+## Document available variables
+
+Maintain a reference file listing every variable the config reads, with placeholder values that indicate the expected format and a comment explaining the purpose. Without it, onboarding a new developer or enabling Claude to configure the service requires reading the entire config module and tracing each field's environment variable name.
+
+In Python, this is a `.env.example` file. In Scala, the `application.conf` with `${?ENV_VAR}` placeholders serves this role natively. Whatever the format, keep it in sync with the config entry point — when a field is added or removed, update the reference file in the same PR.
+
+```shell
+# .env.example — committed, documents every variable
+# Application
+LOG_LEVEL=INFO                          # DEBUG, INFO, WARNING, ERROR
+PORT=8080                               # HTTP server port
+
+# DynamoDB
+DYNAMO__REGION=eu-west-1                # AWS region
+DYNAMO__TABLE_NAME=                     # required — no default
+
+# Policy Management client
+PM__BASE_URL=                           # required — no default
+PM__TIMEOUT_SECONDS=30                  # request timeout in seconds
+```
+
+## GitOps structure matches config structure
+
+The Helm chart in `Zegocover/gitops-<repo-name>` defines environment variables under `blueprint.apps.<service-name>.envVars` in `values.yaml`, with per-environment overrides in `values/staging.yaml`, `values/production.yaml`, and `values/integrations.yaml`. Every field in the config entry point that does not have a safe default must have a corresponding entry in GitOps. Conversely, every variable defined in GitOps should correspond to a field the application actually reads — orphaned variables create confusion about what the service depends on.
+
+When reviewing a PR that adds or removes a config field, check the corresponding GitOps repo for the matching change. If the field is required (no default), the GitOps PR must merge first (see "GitOps before app code for required vars").
+
+```yaml
+# gitops-score-per-product/values.yaml — base values shared across environments
+blueprint:
+  apps:
+    score-per-product:
+      envVars:
+        LOG_LEVEL: "INFO"
+        DYNAMO__REGION: "eu-west-1"
+        DYNAMO__TABLE_NAME: "scores"
+        PM__BASE_URL: "http://policy-management.internal"
+        PM__TIMEOUT_SECONDS: "30"
+```
+
+```yaml
+# gitops-score-per-product/values/production.yaml — production overrides only
+blueprint:
+  apps:
+    score-per-product:
+      envVars:
+        LOG_LEVEL: "WARNING"
+        DYNAMO__TABLE_NAME: "scores-production"
+```
+
+## See Also
+
+- [../languages/python.md](../languages/python.md) — Python conventions including Pydantic BaseSettings config, dependency injection, and composition root patterns.
+- [logging.md](logging.md) — logging conventions; the config entry point's `log_level` field is the standard way to control log verbosity per environment.
+- [testing.md](testing.md) — testing conventions; test configuration should load committed development/CI config files.
+- [Zegocover/secrets-config](https://github.com/Zegocover/secrets-config) — Terraform repo that provisions AWS Secrets Manager secrets; add entries here before consuming new secrets in application code.

--- a/docs/ai/steering/base/error-handling.md
+++ b/docs/ai/steering/base/error-handling.md
@@ -1,0 +1,156 @@
+---
+version: 1.2
+last_reviewed: 2026-06-02
+---
+
+# Error Handling Standards
+
+Error handling conventions — the governing philosophy is: distinguish failures specifically; reserve broad/catch-all handling for application boundaries where it logs and wraps — never silently swallow. Apply these rules to any codebase when writing or modifying error-handling logic. Log-level selection for error scenarios is covered in [logging.md](logging.md); testing failure paths is covered in [testing.md](testing.md).
+
+## Applicability across error idioms
+
+The rules and examples below are written in **exception** vocabulary (raise / catch / exception hierarchy), which maps directly to Python, Kotlin/Java, and TypeScript. The underlying principles are idiom-independent — translate them to the language's native error model:
+
+- **Exception-based** (Python, Kotlin, Java, TypeScript, Scala's `try`/`catch`) — apply the rules as written.
+- **Typed-result idioms** (Rust/Swift `Result`/`Option`, Scala `Either`/`Try`, Go's `(value, error)` returns): "custom domain exceptions" → distinct error types/variants in the result; "catch specific" → match the specific error case, not a catch-all `_`; "broad catch at boundaries only" → propagate errors up via the result type and convert to a response only at the boundary; "never silently swallow" → never discard an error value (`_ = err`, ignoring `Result`, empty `catch`).
+- **Declarative models** (LookML) — no imperative error handling; not applicable.
+
+Wherever the text says "exception", read "error" for typed-result idioms; the four rules hold in both worlds.
+
+## Rules at a Glance
+
+1. **Custom domain exceptions.** Define exception types that describe what went wrong in domain terms rather than raising generic exceptions — domain-specific types give callers enough context to decide how to handle the failure without inspecting message strings.
+2. **Catch specific exceptions.** Catch the narrowest exception type that matches the expected failure — broad catches hide bugs by intercepting errors the author did not anticipate and silently treating them as expected.
+3. **Broad catches only at application boundaries.** Reserve `catch Exception` (or the language equivalent) for top-level entry points — API handlers, background-task runners, CLI commands — where the only correct action is to log the error with full context, return a safe response, and prevent the process from crashing.
+4. **Never silently swallow exceptions.** Every catch block must either re-raise, wrap-and-raise, or log at WARNING or above with enough context to diagnose the original failure — a silent catch is worse than no catch because it converts a visible crash into an invisible data-corruption or logic-skip bug. Log-and-continue (without re-raising) is only acceptable when the caller explicitly tolerates degraded behaviour — e.g. a cache miss falling back to a direct lookup — never as a general-purpose error suppression pattern.
+
+## Custom domain exceptions
+
+Generic exception types force callers to parse message strings to distinguish one failure from another. A domain exception type carries the failure's meaning in its name — callers can catch it specifically, monitoring can alert on it by type, and test assertions are precise.
+
+Define a small hierarchy rooted in a single base exception for the service or bounded context. Each leaf type maps to one failure reason. Carry structured context (IDs, amounts, states) as fields on the exception rather than interpolating them into the message string, so downstream handlers can access the data programmatically.
+
+```
+# good — caller can catch the specific failure and access context fields
+class PolicyNotFoundError extends ServiceBaseError:
+    policy_id: string
+
+raise PolicyNotFoundError(policy_id="POL-123")
+
+# bad — caller must parse a string to know what went wrong
+raise Exception("Policy POL-123 not found")
+```
+
+```
+# good — structured hierarchy, each leaf has a clear domain meaning
+class PaymentError extends ServiceBaseError
+class PaymentDeclinedError extends PaymentError:
+    reason_code: string
+class PaymentTimeoutError extends PaymentError:
+    gateway: string
+    elapsed_ms: int
+
+# bad — flat generic exceptions distinguished only by message
+raise Exception("payment declined")
+raise Exception("payment timed out")
+```
+
+## Catch specific exceptions
+
+A catch block that matches a broad type intercepts every exception that inherits from it — including bugs the author never considered. When a key-lookup error from a typo is caught by a `catch Exception` intended for network failures, the typo becomes invisible and the system proceeds with wrong data.
+
+Catch the narrowest type that matches the failure you expect. If two distinct failures need different handling, write two catch blocks.
+
+```
+# good — each failure type gets the handler it needs
+try:
+    response = gateway.charge(amount)
+catch PaymentDeclinedError as err:
+    log.warning("Payment declined.", {"reason": err.reason_code})
+    return decline_response(err.reason_code)
+catch PaymentTimeoutError as err:
+    log.warning("Payment gateway timeout.", {"gateway": err.gateway})
+    schedule_retry(charge_id)
+
+# bad — broad catch treats declines and timeouts identically, hides unexpected errors
+try:
+    response = gateway.charge(amount)
+catch Exception as err:
+    log.warning("Payment failed.", {"error": str(err)})
+    return generic_failure_response()
+```
+
+## Broad catches only at application boundaries
+
+Application boundaries are the outermost execution points: HTTP request handlers, message-queue consumers, background-task entry points, CLI commands. At these points, an unhandled exception would crash the process or return an opaque 500 to the caller. A broad catch here is a safety net — it logs the unexpected error with full diagnostic context and returns a safe, generic response.
+
+Anywhere below the boundary, a broad catch is harmful: it intercepts errors that should propagate to a handler that knows how to deal with them. The boundary catch should log at ERROR with the exception type, message, and stack trace, then reference [logging.md](logging.md) for level guidance and structured-logging conventions.
+
+```
+# good — boundary handler catches everything, logs with full context, returns safe response
+function handle_request(request):
+    try:
+        return process(request)
+    catch Exception as err:
+        log.error("Unhandled error in request handler.", {"error_type": type(err), "error": str(err), "trace": stacktrace(err)})
+        return error_response(status=500, body="Internal server error")
+
+# bad — broad catch buried inside domain logic, hiding bugs from the boundary
+function calculate_premium(policy):
+    try:
+        rate = fetch_rate(policy.product)
+        return rate * policy.value
+    catch Exception:
+        return DEFAULT_PREMIUM
+```
+
+## Never silently swallow exceptions
+
+A silent catch — one that catches an exception and does nothing, or catches and continues without logging — is the most dangerous error-handling pattern. It converts a visible failure into invisible data corruption or skipped logic. The system reports success while operating on wrong assumptions.
+
+Every catch block must do at least one of: re-raise the exception, wrap it in a domain exception and raise that, or log at WARNING or above with enough context (exception type, message, relevant IDs) for someone to diagnose the original failure from logs alone. "Enough context" means the log entry answers: what operation failed, why, and which entities were involved.
+
+```
+# good — catch, log, re-raise
+try:
+    send_notification(customer_id, message)
+catch NotificationError as err:
+    log.error("Failed to send notification.", {"customer.id": customer_id, "error_type": type(err), "error": str(err)})
+    raise
+
+# good — catch, log at WARNING, continue with degraded behaviour (only when the caller explicitly tolerates the degradation)
+try:
+    cached_rate = cache.get(rate_key)
+catch CacheUnavailableError as err:
+    log.warning("Cache unavailable, falling back to direct lookup.", {"rate_key": rate_key, "error": str(err)})
+    cached_rate = None
+
+# bad — silent swallow; notification silently never sent, caller assumes success
+try:
+    send_notification(customer_id, message)
+catch NotificationError:
+    do nothing
+```
+
+## Red Flags — Stop and Reconsider
+
+If any of these thoughts cross your mind, stop — you are about to rationalise away a rule.
+
+- "I'm not sure exactly which exception this raises, so I'll catch `Exception` to be safe."
+- "Catching broadly here makes the code more robust against anything going wrong."
+- "This error is non-critical, so I'll just swallow it and let the flow continue."
+- "I'll add an empty catch for now and come back to handle it properly later."
+- "I'll log it at DEBUG and move on so the happy path isn't interrupted."
+
+| Rationalisation | Rule it violates | Real-world consequence |
+|---|---|---|
+| "I'm not sure exactly which exception this raises, so I'll catch `Exception` to be safe." | Rule 2 — Catch specific exceptions | The broad catch also intercepts bugs the author never anticipated — a typo or programming error is treated as an expected failure and the system proceeds on wrong data. |
+| "Catching broadly here makes the code more robust against anything going wrong." | Rule 2 — Catch specific exceptions | "Robust" becomes "silently wrong": unexpected errors are masked rather than propagated to a handler that knows how to deal with them. |
+| "This error is non-critical, so I'll just swallow it and let the flow continue." | Rule 4 — Never silently swallow exceptions | A visible failure becomes an invisible logic-skip or data-corruption bug; the system reports success while operating on wrong assumptions. |
+| "I'll add an empty catch for now and come back to handle it properly later." | Rule 4 — Never silently swallow exceptions | The empty catch ships and is never revisited, permanently hiding the failure from logs and monitoring. |
+| "I'll log it at DEBUG and move on so the happy path isn't interrupted." | Rule 4 — Never silently swallow exceptions | A DEBUG line in production is effectively silent; the failure never appears at WARNING or above, so no one can diagnose it from logs. |
+
+## See Also
+
+- [logging.md](logging.md) — log-level selection for error scenarios and structured-logging conventions for context fields.
+- [testing.md](testing.md) — testing failure paths explicitly (Rule 8) to verify error handling works as intended.

--- a/docs/ai/steering/base/file-organisation.md
+++ b/docs/ai/steering/base/file-organisation.md
@@ -1,0 +1,84 @@
+---
+version: 1.1
+last_reviewed: 2026-06-02
+---
+
+# File Organisation Standards
+
+File size and structural organisation conventions for all codebases — a file should have one clear responsibility; when it grows past its language's comfortable reading size, it likely has more than one. Apply these rules whenever creating, modifying, or splitting files in any codebase. Language-specific module systems, import conventions, and re-export patterns are covered in the relevant language standards file.
+
+## On the line-count targets
+
+The numeric targets below (50–300 line working range, split at 400, ceiling at 500) are **signals calibrated to concise languages** such as Python or TypeScript. They are not a universal gate. The primary test is always **one responsibility** (Rule 1 — "describe it in one sentence without 'and'"), not the raw line count.
+
+Scale the numbers to the language's natural verbosity and idioms:
+
+- **Verbose / boilerplate-heavy languages** (Scala, Kotlin, Java, Swift) legitimately run longer per responsibility — a single cohesive Scala case-class hierarchy or a Swift view controller may exceed 300 lines while still owning one concept. For these languages the primary test stays the responsibility check (Rule 1), not the raw count, and the concrete 500-line ceiling (Rule 4) does not apply directly: defer the verbose-language ceiling to the relevant per-language standard, which sets its own figure where one is defined (only `languages/python.md` exists today). Until such a standard exists for a given language, lean on the responsibility test — a file that owns more than one concept is signalling a missing split regardless of length.
+- **Framework-shaped files** (iOS view controllers, Android Activities/Fragments, SwiftUI views, LookML `view`/`model` files) follow their framework's conventions; the responsibility test applies, the exact numbers do not.
+- **Generated code, data tables, and declarative artefacts** (protobuf, LookML, schema/migration files) are exempt, as noted in Rules 2 and 4.
+
+Where a language standard defines its own size guidance, it takes precedence over the numbers here.
+
+## Rules at a Glance
+
+1. **One responsibility per file.** Each file should own a single concept or responsibility — grouping unrelated concerns in one file makes it harder to navigate, review, and test because readers must mentally filter irrelevant code to find what they need.
+2. **Target 50–300 lines per file.** Aim for files in the 50–300 line range as the standard working size — files in this range are small enough to read in one sitting and large enough to hold a complete, cohesive unit of functionality.
+3. **Split at 400+ lines.** Actively split any file that exceeds 400 lines — a file this long almost certainly contains more than one responsibility, and splitting it restores navigability and keeps diffs focused.
+4. **No 500+ line files.** Do not let logic-bearing files exceed 500 lines — this ceiling reinforces the split-at-400 guidance and prevents incremental growth from producing monolithic files. The 500-line figure is the concise-language baseline; verbose languages set their own (higher) ceiling in the relevant per-language standard, and where one is defined it takes precedence. Generated code, data tables, and other mechanical artefacts are exempt.
+5. **Organise by concept.** Group files by the concept or responsibility they represent, not by technical layer or file type — concept-based organisation keeps related code together so that a change to one feature touches as few directories as possible.
+
+## One responsibility per file
+
+A file that owns a single concept is easier to name, easier to find, and produces smaller diffs when changed. When a file accumulates helpers, constants, and secondary logic around its primary purpose, it becomes a grab-bag that only the original author can navigate confidently.
+
+The test for whether a file has one responsibility: can you describe what it does in one sentence without using "and"? If the description requires "and", the file likely has a natural split point.
+
+```
+# good — each file owns one concept
+# pricing — calculates premium from risk factors
+# risk_factors — loads and validates risk factor definitions
+
+# bad — two unrelated concepts in one file
+# pricing_and_risk_factors — calculates premium AND loads risk factor definitions
+```
+
+## Target 50–300 lines per file
+
+Files shorter than 50 lines may indicate over-splitting — a file with a single function and no rationale for isolation is often better inlined into its caller. Files in the 50–300 range are the productive middle ground: long enough to hold a meaningful unit of work, short enough to review without scrolling fatigue.
+
+This is a signal, not an absolute gate. Generated code, data tables, protocol buffer definitions, and similar artefacts may legitimately exceed 300 lines because their content is mechanical or tabular rather than logic-bearing. The question to ask is: does this file contain more than one responsibility? If it is long but cohesive, it is fine.
+
+## Split at 400+ lines
+
+When a file crosses 400 lines, treat it as a prompt to refactor. Look for natural seams: a group of related functions that could move to their own file, a class that has grown a secondary concern, or a set of constants that would be clearer in a dedicated file.
+
+Splitting is not always a net win — splitting a 410-line file into two 205-line files that constantly import each other creates coupling without improving clarity. Split along responsibility boundaries, not arbitrary line counts.
+
+## No 500+ line files
+
+The 500-line ceiling exists to prevent the common pattern where a file grows gradually from 400 to 600 to 800 lines because each individual addition seems small. A hard upper limit forces the split conversation to happen before the file becomes genuinely difficult to work with.
+
+As with the 300-line target, generated code, data tables, and other mechanical artefacts are valid exceptions — the ceiling applies to logic-bearing code where human readability matters.
+
+## Organise by concept
+
+Concept-based organisation means that all code related to, say, pricing lives in one place, rather than scattering pricing logic across `models/`, `services/`, `utils/`, and `helpers/` directories. When a developer needs to understand or change pricing, they open one directory (or a small cluster of files) rather than searching the full tree.
+
+This rule does not prescribe specific directory structures — it states a principle that applies to any project layout. A flat structure with well-named files, a feature-folder layout, or a domain-driven package hierarchy can all satisfy concept-based organisation.
+
+```
+# good — related files grouped by concept
+# quotes/calculator
+# quotes/validation
+# quotes/repository
+
+# bad — same code scattered by technical layer
+# models/quote
+# services/quote_calculator
+# utils/quote_validation
+```
+
+## See Also
+
+- [testing.md](testing.md) — testing conventions, including test file organisation and naming.
+- Language-specific standards (e.g. [python.md](../languages/python.md)) — framework-imposed directory structures (Django's `models.py`/`views.py`, etc.) may override Rule 5; the relevant language standard documents these exceptions.

--- a/docs/ai/steering/base/logging.md
+++ b/docs/ai/steering/base/logging.md
@@ -1,0 +1,140 @@
+---
+version: 1.3
+last_reviewed: 2026-06-02
+---
+
+# Logging Standards
+
+Logging conventions — what to log, at what level, and how to structure log calls so that someone who knows the domain but not this codebase can diagnose problems from the output. Log formatting, serialisation, and output routing are enforced by the Zego standard logging library and are not covered here.
+
+## Applicability
+
+The rules below divide into a **universal core** that applies to any code that logs — regardless of stack or runtime — and **Zego-service specifics** that assume a backend service emitting to Zego's shared production logging infrastructure (Datadog).
+
+**Universal core — applies everywhere** (backend, mobile, frontend, libraries):
+
+- **Never log credentials** at any level (Rule 1) — passwords, tokens, API keys.
+- **Never log PII into broadly-retained or collected telemetry** (Rule 1) — the "INFO and above" threshold below is the backend-service expression of this; on other runtimes apply the same principle to whatever log tier is collected/retained.
+- **Static message + structured context fields**, no interpolation (Rule 2).
+- **Meaningful log levels** (Rule 5) and **log intent and outcome** (Rule 6).
+
+**Zego-service specifics — backend services on the shared logging infrastructure:**
+
+- The **"INFO and above is collected by production infrastructure"** retention model (Rule 1) — mobile/frontend logs go to crash-reporting/analytics/browser consoles with different retention, so map the PII principle to that tier instead.
+- **Zego common keys** and the **key inventory** (Rules 3, 4) — these exist for cross-service Datadog queryability. They apply where the runtime emits to the shared store; on mobile/frontend, adopt the equivalent shared-attribute convention for that platform's telemetry, or treat as not applicable.
+
+Apply the universal core wherever code logs. Apply the service specifics where the code emits to the shared production logging infrastructure; where it logs to a different tier (mobile crash/analytics, browser console, etc.), map the same PII and structure principles to that tier. Gate by where the logs actually go, not by the repo's language or framework.
+
+## Rules at a Glance
+
+1. **No PII or credentials at INFO and above.** Never log names, addresses, or identifiers at INFO or higher — our logging setup is not designed to store PII. Never log passwords, tokens, or API keys at any level — credential exposure is equally damaging regardless of log retention. DEBUG is exempt for PII (not credentials): PII may appear at DEBUG level, which is disabled by default in production and should not be enabled there without a specific investigation reason.
+2. **Structured logging.** Use a static string as the log message and put all variable data in structured context fields (in Python, the `extra` dict; see language-specific standards for equivalents) — no interpolation, format strings, or string concatenation in the message argument — so log lines are grep- and query-stable.
+3. **Zego common keys.** Use the shared key names (e.g. `customer.id`, `policy.id`, `quote.id`) in context fields so logs are queryable across services without per-service field mapping.
+4. **Document new keys.** Any new context key introduced in a PR must be documented wherever the project maintains its key inventory before the PR merges — keeping the key inventory current enables PII audits and makes cross-service query consistency maintainable. DEBUG-only diagnostic keys are exempt: they are PII-explicit by design and inventorying them dilutes the audit signal.
+5. **Meaningful log levels.** Choose the level that reflects the system's actual state: DEBUG for detailed diagnostics, INFO for normal operations and state changes, WARNING for recoverable problems, ERROR for unrecoverable failures where the system has given up.
+6. **Log intent and outcome.** Log when the system is about to perform a significant action and again when it completes — logging the outcome at INFO or higher so it is visible in production — because without both intent and outcome it is impossible to distinguish "never attempted" from "attempted and failed silently".
+
+## No PII or credentials at INFO and above
+
+INFO and above is collected by our production logging infrastructure and accessible to a broad set of tooling and staff — PII at these levels creates a data-handling obligation we cannot meet with current tooling. DEBUG is a local development and investigation tool; production deployments run at INFO by default so DEBUG output is not collected in normal operations. Do not enable DEBUG in production without a specific investigation reason.
+
+The PII restriction covers names, addresses, dates of birth, email addresses, phone numbers, and any identifier that could be linked to a natural person (e.g. driving licence number, vehicle registration). Policy IDs and quote IDs are acceptable — they are internal references, not PII.
+
+Credentials — passwords, tokens, and API keys — must never appear in logs at any level. Unlike PII, there is no safe retention window: a leaked credential is immediately actionable by an attacker regardless of how briefly the log is stored.
+
+```
+# good
+log.info("Quote generated.", {"quote.id": quote_id, "customer.id": customer_id})
+
+# bad — customer name and email appear at INFO level
+log.info("Quote generated for <name> (<email>).")
+```
+
+```
+# good — PII at DEBUG is permitted
+log.debug("Validating address.", {"address": raw_address_input, "customer.id": customer_id})
+```
+
+## Structured logging
+
+Logging pipelines index on the message string. When the message changes per call — because it contains a policy ID, a count, or any runtime value — the pipeline cannot group related events and search becomes unreliable. A static message paired with structured context fields keeps the message stable and puts the variable data where it can be filtered and aggregated.
+
+```
+# good
+log.info("Policy renewed.", {"policy.id": policy_id, "term_months": term_months})
+
+# bad — string interpolation embeds variable data in the message
+log.info("Policy <policy_id> renewed for <term_months> months.")
+
+# bad — format arguments have the same effect
+log.info("Policy %s renewed for %d months.", policy_id, term_months)
+
+# bad — concatenation is equivalent
+log.info("Policy " + policy_id + " renewed.")
+```
+
+## Zego common keys
+
+Using a shared key vocabulary across services means a Datadog query for `customer.id:12345` returns results from every service that touched that customer, without needing to know each service's local field names. New services should adopt the common keys from the outset rather than introducing synonyms (`customerId`, `cust_id`, etc.) that fragment cross-service queries.
+
+Representative common keys: `customer.id`, `policy.id`, `quote.id`, `product.id`, `claim.id`. The authoritative list is maintained in the project's key inventory (typically the service's logging configuration or a dedicated reference document).
+
+```
+# good — uses the shared key name
+log.info("Quote rated.", {"quote.id": quote_id, "product.id": product_id})
+
+# bad — local synonym that won't match cross-service queries
+log.info("Quote rated.", {"quoteId": quote_id, "productId": product_id})
+```
+
+## Document new keys
+
+The common key vocabulary only works if it stays current. When a new context key is introduced — whether it is a new common key or a service-local key — documenting it in the same PR keeps the inventory accurate and gives reviewers a chance to spot synonyms before they are committed.
+
+If the project has no key inventory yet, creating one is part of the PR.
+
+DEBUG-only diagnostic keys do not need to be documented in the key inventory. They are PII-explicit by design (only used locally or in targeted investigations, not in normal production output), and including them would dilute the inventory's value as a PII-audit surface.
+
+## Meaningful log levels
+
+The level tells the reader how much to care. Using the wrong level — logging recoverable warnings as ERROR, or logging normal state changes as DEBUG — trains readers to ignore the signals and defeats alerting.
+
+| Level | Use when |
+|-------|----------|
+| `DEBUG` | Detailed diagnostics useful during development or investigation — not wanted in normal production output. |
+| `INFO` | The system is doing what it should: a request completed, a record was written, a job finished. |
+| `WARNING` | Something unexpected happened but the system recovered or degraded gracefully — worth knowing, not yet broken. |
+| `ERROR` | The system has given up on an operation; manual intervention or an alert response may be needed. |
+
+```
+# good
+log.info("Payment processed.", {"policy.id": policy_id, "amount_pence": amount})
+log.warning("Payment gateway timeout; retrying.", {"attempt": attempt, "policy.id": policy_id})
+log.error("Payment failed after max retries.", {"policy.id": policy_id, "attempts": max_attempts})
+
+# bad — ERROR for a condition the system handled
+log.error("Retrying payment.", {"attempt": attempt})
+```
+
+## Log intent and outcome
+
+Logging only the outcome makes it impossible to distinguish "never attempted" from "attempted and failed silently". Logging intent and outcome together gives a complete picture of what the system tried to do and what happened, which is the minimum needed to reconstruct an incident.
+
+Log the intent at DEBUG if the action is frequent and low-stakes; log it at INFO if it represents a meaningful state change. Always log the outcome — success or failure — at INFO or higher so it is visible in production.
+
+```
+# good
+log.debug("Sending renewal notice.", {"policy.id": policy_id})
+# ... attempt to send renewal notice ...
+log.info("Renewal notice sent.", {"policy.id": policy_id})
+# ... on failure ...
+log.error("Failed to send renewal notice.", {"policy.id": policy_id, "error_type": error_type})
+
+# bad — outcome only; no way to tell if the send was attempted
+# ... attempt to send renewal notice ...
+# ... on failure: do nothing (silent failure) ...
+```
+
+## See Also
+
+- [observability.md](observability.md) — metrics and distributed tracing conventions, including span attributes and the shared key vocabulary.

--- a/docs/ai/steering/base/observability.md
+++ b/docs/ai/steering/base/observability.md
@@ -1,0 +1,154 @@
+---
+version: 1.2
+last_reviewed: 2026-06-02
+---
+
+# Observability Standards
+
+Conventions for metrics and distributed tracing — observability exists so that when something goes wrong, someone who knows the domain but not the code can understand what happened, why, and how everything fits together; the same intent as logging, extended to all three signals (metrics: is there a problem? traces: where? logs: what?). Logging conventions, including log formatting and routing enforced by the Zego standard logging library, are not covered here. Logging rules belong in logging.md.
+
+## The universal principle
+
+One rule applies to **every** runtime, regardless of stack: instrument the code so that an incident is diagnosable from telemetry alone, across the three signals appropriate to that runtime — is there a problem (metrics), where (traces/spans), and what happened (logs/events). Use shared business identifiers (e.g. `policy.id`, `quote.id`, `customer.id`) consistently across whatever signals the platform emits, and never put PII in indexed telemetry. How those signals are produced and where they are sent is platform-specific.
+
+## Applicability
+
+The concrete rules below act on one specific surface: **server-side metric and distributed-trace instrumentation emitted through OpenTelemetry to Datadog** (the surface present in HTTP/gRPC services, async consumers and producers, and scheduled jobs running in the cluster). Apply them wherever that surface exists in the code.
+
+Where the surface is absent — the code emits no server-side metrics or traces, or runs on a platform with its own telemetry model — these rules have nothing to act on. Apply only the universal principle above and stop.
+
+**Gate by the surface, not by the repo's language or framework.** Do not infer from a repo's stack that it *should* adopt OTel/Datadog server instrumentation, and do not raise findings for its absence. (Runtimes that commonly lack this surface include mobile apps, browser frontends, BI/declarative models, and libraries — but these are illustrations, not the test. The test is whether the instrumentation surface is present.)
+
+## Rules at a Glance
+
+1. **Three-signal coverage.** Instrument all three signals — metrics, traces, and logs — because each answers a distinct diagnostic question; omitting one leaves a blind spot that forces guesswork during an incident.
+2. **OpenTelemetry as the instrumentation library.** Use OpenTelemetry for all metrics and tracing instrumentation — it is vendor-agnostic, prevents lock-in, and targets Datadog as the current backend for both metrics and APM.
+3. **Framework instrumentors before custom code.** Use framework instrumentors (HTTP server middleware, HTTP client instrumentors, gRPC interceptors) before writing custom spans or metrics — they cover the common cases without maintenance burden (e.g., FastAPI middleware in Python, Spring Boot auto-configuration in Java, otelgin/otelhttp in Go).
+4. **Register instrumentors explicitly at startup.** Register all instrumentors in service startup code rather than relying on auto-discovery — auto-discovery is non-deterministic and can behave inconsistently across package managers and build tools (e.g., uv in Python, Gradle shadow-jar in Java).
+5. **Outside-in instrumentation strategy.** Instrument service boundaries first (HTTP/gRPC servers and clients, async consumers and producers), then add internal spans only when boundary data is insufficient to diagnose a specific problem — starting inside out produces noise without covering the gaps that actually matter.
+6. **Counter, Histogram, UpDownCounter.** Choose the metric instrument that matches the measurement: Counter for cumulative counts (throughput, error rates), Histogram for latency distributions, UpDownCounter for current state (queue depth, active sessions) — using the wrong instrument produces misleading aggregations in Datadog.
+7. **OTel semantic conventions for metric naming.** Name metrics using lowercase dot-delimited namespaces with snake_case within components; prefix Zego-specific metrics with `zego.{service}` where `{service}` is the canonical service name (hyphens are permitted where the service name itself contains them); include explicit client/server direction (e.g. `http.client.request.duration` vs `http.server.request.duration`); omit unit suffixes from the name — they belong in metadata.
+8. **Standard instrument suffixes.** Use `.limit` for a known total, `.usage` for amount used, `.utilization` for a fraction (0.0–1.0), `.time` for passage of time, `.io` for bidirectional data flow — consistent suffixes make metric families queryable without per-metric documentation.
+9. **UCUM units in metadata.** Express units using UCUM: `s` for seconds, `By` for bytes, `1` for dimensionless ratios, `{thing}` for item counts — record them as instrument metadata, not in the metric name.
+10. **Low cardinality on metric attributes.** Never use UUIDs, unbounded identifiers, or user-supplied values as metric attribute values — high cardinality explodes the metric series count in Datadog; reserve high-cardinality identifiers for trace attributes.
+11. **Auto-instrumentation for spans first.** Use auto-instrumentation (HTTP, database, AWS SDK) before adding manual spans — manual spans are for significant gaps that auto-instrumentation cannot cover.
+12. **Correct span kind when instrumenting manually.** Set span kind to SERVER for incoming requests, CLIENT for outgoing calls, and INTERNAL for local computation — the kind determines how Datadog APM renders the call graph.
+13. **Business identifiers on span attributes.** Attach business identifiers (policy.id, quote.id, customer.id) to span attributes using the same key names as logs — this makes traces and logs joinable in Datadog without field-name mapping.
+14. **No PII on span attributes.** Never include PII (names, addresses, dates of birth, email addresses, phone numbers, vehicle registrations, driving licence numbers) in span attributes — span data is retained and indexed in Datadog under the same data-handling obligations as logs at INFO.
+15. **No span events.** Do not use span events — they are being deprecated in OpenTelemetry; record point-in-time details as log lines with span and trace ID metadata instead.
+16. **Span links for async processing.** When consuming a message (Kinesis, SQS), start a new root span and attach the producer's trace context as a span link — async processing is a causal relationship, not a synchronous parent-child, and a child span would distort latency metrics for the producer.
+
+## Three-signal coverage
+
+Metrics answer "is there a problem?" — they are cheap to collect and power alerting. Traces answer "where?" — they show which service and code path is slow or failing. Logs answer "what?" — they carry the event detail needed to understand root cause. All three are required because each covers a gap the others cannot fill: metrics without traces tell you something is wrong but not where; traces without logs tell you where but not what happened; logs without metrics cannot trigger alerts.
+
+## OpenTelemetry as the instrumentation library
+
+OpenTelemetry is the CNCF-standard instrumentation framework. Instrumenting against the OTel API means the backend (currently Datadog for both metrics and APM) can be changed by reconfiguring the exporter without touching instrumentation code. Instrumenting directly against a vendor SDK creates a migration cost proportional to the size of the codebase.
+
+## Framework instrumentors before custom code
+
+Framework instrumentors for HTTP servers, HTTP clients, and gRPC cover the most common instrumentation points (request duration, error rates, downstream call latency) without requiring manual span management. Writing custom spans for cases already covered by an instrumentor duplicates work and drifts out of sync with framework updates. In Python, these are the FastAPI, HTTPX, and gRPC instrumentors; in Java, Spring Boot auto-configuration and OkHttp interceptors; in Go, otelgin/otelhttp and otelgrpc. See language-specific standards for implementation details.
+
+## Register instrumentors explicitly at startup
+
+Auto-discovery mechanisms (e.g., `opentelemetry-instrument` in Python, the Java agent in Java) work by scanning installed packages or classpath entries at process start. Depending on the package manager or build tool, the scan can produce different results across runs or fail silently (e.g., uv in Python can resolve packages non-deterministically; fat-jar packaging in Java can shade out instrumentors). Explicit registration in the service startup code is deterministic and reviewable.
+
+## Outside-in instrumentation strategy
+
+Boundaries are where failures actually appear to users: a slow downstream call, a rejected request, a dropped message. Starting at the boundary guarantees coverage of the highest-value diagnostic surface. Adding internal spans is a targeted decision driven by a specific gap — "the boundary shows the call is slow but we cannot tell which internal step is responsible" — not a default.
+
+## Counter, Histogram, UpDownCounter
+
+Using a Counter for queue depth produces a number that only ever increases and cannot represent the current state. Using a Histogram for a dimensionless count produces meaningless percentile distributions. Each instrument has an aggregation model that only makes sense for the measurement it is designed for.
+
+| Instrument | Use for |
+|---|---|
+| `Counter` | Counts that only go up: requests handled, errors raised, records written. |
+| `Histogram` | Values you want to aggregate as distributions: request duration, payload size. |
+| `UpDownCounter` | Values that go up and down: active connections, queue depth, in-flight jobs. |
+
+## OTel semantic conventions for metric naming
+
+Consistent naming makes metrics queryable across services without per-service documentation. The OTel semantic conventions define the namespace structure; the `zego.{service}` prefix scopes Zego-specific metrics so they do not collide with upstream OTel conventions as they are added. Explicit direction (`client` vs `server`) distinguishes a call you made from a call made to you, which have different SLO owners.
+
+```
+# good
+histogram "http.server.request.duration"
+    unit: "s"
+    description: "Duration of HTTP requests handled by this server."
+
+histogram "zego.quote-service.rating.duration"
+    unit: "s"
+    description: "Duration of quote rating operations."
+
+# bad — unit in the name, no direction, PascalCase namespace
+histogram "RequestDurationMs"
+
+# bad — no service prefix on a Zego-specific metric
+histogram "rating.duration"
+```
+
+## Low cardinality on metric attributes
+
+Datadog indexes every unique combination of attribute values as a separate metric series. A single metric with a UUID attribute produces as many series as there are UUIDs — this exhausts metric quotas, degrades query performance, and incurs cost proportional to throughput. Attributes on metrics must come from a bounded set: HTTP method, status code, environment, service name, region.
+
+High-cardinality identifiers (policy IDs, quote IDs, customer IDs) belong on trace and log data, where they are stored as indexed fields rather than as dimension keys in a time-series database.
+
+```
+# good — bounded attribute values
+http_requests.add(1, {"method": request.method, "status_code": response.status_code})
+
+# bad — UUID creates unbounded cardinality
+http_requests.add(1, {"method": request.method, "request_id": request_id})
+```
+
+## Business identifiers on span attributes
+
+Joining traces to logs requires shared key names. Using `policy.id` in both a span attribute and a log context field (e.g. Python's `extra` dict) means a Datadog APM trace can pivot directly to the related log lines without a separate mapping step. Use the same key vocabulary defined in logging.md.
+
+```
+# good — shared key names, no PII
+span.set_attributes({
+    "policy.id": policy_id,
+    "quote.id": quote_id,
+    "customer.id": customer_id,
+})
+
+# bad — PII in span attributes
+span.set_attributes({
+    "customer.email": customer.email,
+    "customer.name": customer.full_name,
+})
+
+# bad — local synonyms that won't join to log queries
+span.set_attributes({
+    "policyId": policy_id,
+    "quoteRef": quote_id,
+})
+```
+
+## No span events
+
+OpenTelemetry is deprecating span events in favour of log records with span context (trace ID and span ID as metadata fields). Span events written today will require migration. Log records with span context are already the standard in our logging setup and integrate naturally with Datadog Log Management.
+
+## Span links for async processing
+
+When a Kinesis or SQS consumer handles a message, the processing happens in a separate process, often minutes or hours after the producer emitted the event. Making the consumer span a child of the producer span would inflate the producer's measured duration to include all downstream processing time, distorting latency metrics and SLO calculations. A span link preserves the causal relationship — "this processing was triggered by that event" — without affecting either trace's duration metrics.
+
+```
+# good — new root span with a link to the producer context
+producer_context = propagator.extract(message.attributes)
+link = create_link(producer_context)
+span = tracer.start_span("process_message", kind: CONSUMER, links: [link])
+handle(message)
+
+# bad — consumer is a child of the producer, inflating producer latency
+producer_context = propagator.extract(message.attributes)
+span = tracer.start_span("process_message", kind: CONSUMER, parent: producer_context)
+handle(message)
+```
+
+## See Also
+
+- [logging.md](logging.md) — logging conventions: levels, structured log calls, PII rules, and Zego common keys.

--- a/docs/ai/steering/base/pull-requests.md
+++ b/docs/ai/steering/base/pull-requests.md
@@ -1,0 +1,120 @@
+---
+version: 1.0
+last_reviewed: 2026-05-07
+---
+
+# Pull Request Standards
+
+Conventions for structuring pull requests — the governing principle is that a PR exists to reduce reviewer cognitive load: Background front-loads context, Changes maps the diff, and Jira Ticket/s closes the automation loop. Apply these rules whenever opening or updating a pull request in any repository. Nothing in the PR content or authoring cycle (title, body, structure, sectioning) is mechanically enforced — the rules below describe how to author a PR, not how to gate one. Phase handoff between `write-design-doc` → `implement` → `review` is the exception: it IS mechanically enforced (rule 10).
+
+## Rules at a Glance
+
+1. **Title format.** Begin the title with the Jira ticket number followed by a colon, use imperative mood, and keep it at or under 70 characters — the title is a one-line contract that tells reviewers what merged.
+2. **Background answers why.** Write Background as the motivating problem, constraint, or context; never restate the diff — reviewers can read the diff, they cannot read your mind. A ticket link alone is not sufficient; include at least one sentence describing why the change exists even when a ticket is present.
+3. **Changes is bulleted and verb-first.** List one bullet per meaningful change, opening each with an imperative verb — this maps the diff without burying the structure in prose.
+4. **Jira Ticket/s as full URL.** Link each ticket as a full `https://zegons.atlassian.net/browse/TICKET` URL, one bullet per ticket — partial references break automation.
+5. **Do not hard-wrap prose.** Leave Background and any prose content as flowing text; let GitHub's renderer wrap it — manual line breaks fragment copy-paste and diff readability.
+6. **Do not open a PR unprompted.** Only create a pull request when the user explicitly asks — opening one prematurely forces review of incomplete work.
+7. **Use HEREDOC for gh pr create.** Pass the PR body via a HEREDOC when using `gh pr create --body`, copying content from `.github/PULL_REQUEST_TEMPLATE.md` — the CLI does not auto-populate the repo's pull request template.
+8. **PR body must match the template.** When `.github/PULL_REQUEST_TEMPLATE.md` is present, the PR body must reproduce every section heading from the template in the template's order — no sections added, none removed. When no template is present, use the default three-section fallback (Background, Changes, Jira Ticket/s). In either case, do not add extra top-level sections such as `## Test Plan` or `## Notes` — additional sections fragment the reviewer's reading path.
+9. **Apply AI review triggers only on merge-ready branches.** Invoke review labels or workflows only when the branch is in a state you would merge today — every triggered run costs credits and asks a reviewer to read the output.
+10. **Phase handoff is gated by the prior-phase PR.** The `implement` and `review` skills VERIFY at Stage 0 that the prior phase (design for `implement`; implementation for `review`) has an open or merged PR, and HALT if it does not. The gate is verification-only — it NEVER creates or opens a PR (consistent with rule 6). The documented per-invocation exception is `--no-handoff-gate`, intended for spikes and other legitimately design-doc-less work; the override is not a transient-`gh`-failure retry mechanism.
+
+## Title format
+
+The title serves two audiences: the reviewer scanning a PR list and the git log reader months later. A ticket prefix makes the title searchable and links it to the backlog without opening the body. Imperative mood ("Add", "Fix", "Remove") matches git convention and states what the merge accomplishes, not what it is doing.
+
+The 70-character limit is a practical ceiling — most PR list views truncate beyond this and a title that fits in one line is faster to scan.
+
+```
+# good
+AIDEV-16: Add pull-request standards file to base library
+
+# bad — missing ticket, passive voice, over limit
+Adding a new standards file for pull requests to the base standards library folder
+```
+
+## Background answers why
+
+Reviewers arrive without the context you accumulated while writing the code. The diff shows them *what* changed; Background must tell them *why* the change exists at all. A Background that restates the diff ("This PR adds an index to the users table") leaves reviewers to infer the motivation themselves. A Background that answers why ("Queries against users were timing out under load; adding an index on email drops p99 latency to under 50 ms") lets them evaluate the approach immediately.
+
+Keep Background as one or two sentences of flowing prose. If the motivation is a Jira ticket, a sentence that summarises the problem is still required — a ticket link alone is not Background.
+
+```
+# good
+Background: The CI pipeline was re-running all integration tests on every push,
+causing 20-minute wait times for trivial changes. This splits the test suite so
+unit tests run on every push and integration tests run only on merge to main.
+
+# bad — restatement of the diff
+Background: This PR splits the test suite into unit and integration test jobs.
+```
+
+## Changes is bulleted and verb-first
+
+The Changes section maps the diff to intent. Reviewers use it to orient themselves before opening files — a bulleted list with one item per meaningful change lets them build a mental model of scope in seconds. Prose narration ("I updated the handler and also changed the model and then fixed the test") buries structure.
+
+Verb-first bullets ("Add", "Extract", "Remove", "Fix") make the nature of each change immediately clear without reading the full bullet.
+
+```
+# good
+Changes:
+- Add `split-tests.yml` CI workflow for unit/integration separation
+- Remove integration test step from `ci.yml`
+- Update `Makefile` targets to match new workflow names
+
+# bad — prose, no verbs, opaque scope
+Changes:
+The CI workflow was changed along with the Makefile and the old integration
+step was removed as part of this work.
+```
+
+## Jira Ticket/s as full URL
+
+Full URLs ensure that GitHub, Slack, and any webhook integrations can resolve the link without knowing the Jira base URL. Partial references (`AIDEV-16`, `#16`, bare ticket numbers) are readable to humans but break automated linkage in most CI and notification pipelines.
+
+Use the heading `Jira Ticket/s` exactly — this matches the template header that automation may key on.
+
+```
+# good
+Jira Ticket/s:
+- https://zegons.atlassian.net/browse/AIDEV-16
+
+# bad — partial reference
+Jira Ticket/s: AIDEV-16
+```
+
+## Use HEREDOC for gh pr create
+
+GitHub populates the PR body from the repository's `PULL_REQUEST_TEMPLATE.md` only when the PR is opened through the web UI. When using `gh pr create`, the `--body` flag requires the full body text — the template is not injected automatically.
+
+Read the template from `.github/PULL_REQUEST_TEMPLATE.md` and paste its structure into the HEREDOC, filling in the placeholders. Pass the body via a shell HEREDOC to preserve newlines and avoid quoting issues:
+
+```bash
+# good — template structure copied from .github/PULL_REQUEST_TEMPLATE.md
+gh pr create --title "AIDEV-16: Add pull-request standards file" --body "$(cat <<'EOF'
+## Background
+
+The base standards library had no file covering pull request structure, leaving
+teams to reinvent the template independently.
+
+## Changes
+
+* Add `docs/ai/steering/base/pull-requests.md`
+* Update `docs/ai/steering/base/README.md` with new entry
+
+## Jira Ticket/s
+
+* https://zegons.atlassian.net/browse/AIDEV-16
+EOF
+)"
+
+# bad — template not injected, body empty or malformed
+gh pr create --title "AIDEV-16: Add pull-request standards file"
+```
+
+## Apply AI review triggers only on merge-ready branches
+
+AI review labels and workflow triggers (such as a `claude-review` label or a `/review` comment) invoke an automated reviewer that costs API credits and produces output that a human reviewer is then expected to read. Triggering a review on a draft, a work-in-progress branch, or a branch that will need significant rework wastes both budget and reviewer attention.
+
+Only apply review triggers when the branch is in a state you would merge today if the review came back clean.

--- a/docs/ai/steering/base/resilience.md
+++ b/docs/ai/steering/base/resilience.md
@@ -1,0 +1,169 @@
+---
+version: 1.0
+last_reviewed: 2026-05-12
+---
+
+# Resilience Standards
+
+Conventions for retry logic, backoff, timeouts, and idempotency across inter-service communication — the governing philosophy is: fail fast on deterministic errors; retry only transient failures with bounded backoff, jitter, and timeouts. Apply these rules to any service that makes calls to external dependencies (HTTP, gRPC, message queues), regardless of language. Circuit breaker selection and configuration are implementation-specific and not covered here. Observability of retries and timeouts is covered in observability.md.
+
+## Rules at a Glance
+
+1. **Retry only transient failures.** Retry HTTP 429, 502, 503, and 504 and gRPC UNAVAILABLE, DEADLINE_EXCEEDED, and RESOURCE_EXHAUSTED — never retry other 4xx HTTP codes or deterministic gRPC errors (INVALID_ARGUMENT, NOT_FOUND, PERMISSION_DENIED, ALREADY_EXISTS) because they will fail identically on every attempt, wasting time and load.
+2. **Exponential backoff with jitter.** Use exponential backoff with full jitter (randomised delay between 0 and the exponential cap) on every retry — fixed-interval or exponential-without-jitter retries cause thundering herds when many clients back off in lockstep after a shared dependency recovers.
+3. **Maximum retry count.** Set a maximum retry count (typically 3 to 5 attempts including the original request) on every retryable call — unbounded retries turn a transient failure into a sustained load spike that prevents the dependency from recovering.
+4. **Explicit timeouts on all external calls.** Set an explicit timeout on every outbound HTTP request, gRPC call, and database query — a missing timeout means a hung dependency silently blocks the caller indefinitely, exhausting connection pools and cascading the failure upstream.
+5. **Idempotency keys for retry safety.** Attach a unique idempotency key (or deduplication identifier) to any mutating operation that may be retried — without one, a retried write can create duplicate records or apply an effect twice, because the caller cannot distinguish "request failed before processing" from "request succeeded but the response was lost".
+
+## Retry only transient failures
+
+A transient failure is one where the same request, sent again after a short delay, has a reasonable chance of succeeding — the server was temporarily overloaded, a network blip occurred, or a rate limit was hit. A deterministic failure — bad input, missing resource, insufficient permissions — will produce the same error on every attempt. Retrying deterministic failures wastes the caller's time and adds unnecessary load to a dependency that is correctly rejecting the request.
+
+The distinction matters most during incidents: if a downstream service is returning 400 for a schema change, retrying floods it with duplicate bad requests and obscures the real error in logs. Fail fast on deterministic errors so the caller can surface the real problem immediately.
+
+```
+# good — retries only transient status codes
+TRANSIENT_HTTP_CODES = {429, 502, 503, 504}
+
+function call_with_retry(request, max_attempts=3):
+    for attempt in 1..max_attempts:
+        response = http_client.send(request, timeout=5s)
+        if response.status not in TRANSIENT_HTTP_CODES:
+            return response
+        if attempt < max_attempts:
+            sleep(backoff_with_jitter(attempt))
+    raise MaxRetriesExceeded(attempts=max_attempts)
+
+# bad — retries all non-200 responses, including deterministic errors
+function call_with_retry(request, max_attempts=3):
+    for attempt in 1..max_attempts:
+        response = http_client.send(request, timeout=5s)
+        if response.status != 200:
+            sleep(1s)
+            continue
+        return response
+```
+
+For gRPC, the same principle applies: retry UNAVAILABLE (server not accepting requests), DEADLINE_EXCEEDED (upstream timed out), and RESOURCE_EXHAUSTED (rate-limited or quota exceeded). Do not retry INVALID_ARGUMENT, NOT_FOUND, PERMISSION_DENIED, ALREADY_EXISTS, UNIMPLEMENTED, or any other status that indicates a permanent condition.
+
+For message queues, retry semantics are typically managed by the broker (NACK/redelivery, dead-letter queues) rather than application-level retry loops. The principles still apply — only retry transient failures, set a maximum delivery count, and use idempotency keys on the consumer side — but the implementation mechanism differs. Queue-specific retry configuration (redelivery policies, DLQ routing) is outside the scope of this standard.
+
+## Exponential backoff with jitter
+
+Exponential backoff increases the delay between retries — typically doubling each time (e.g. 1s, 2s, 4s). This gives the failing dependency progressively more time to recover. However, if many clients all use the same deterministic delay schedule, they will retry in sync, creating periodic load spikes (thundering herd) that can prevent recovery.
+
+Full jitter solves this by randomising the delay between 0 and the exponential cap on each attempt. This spreads retries evenly across the backoff window, reducing the peak retry load at any given moment.
+
+```
+# good — exponential backoff with full jitter
+function backoff_with_jitter(attempt, base_delay=1s, max_delay=30s):
+    exponential_cap = min(base_delay * 2^(attempt - 1), max_delay)
+    return random_between(0, exponential_cap)
+
+# bad — fixed interval; all clients retry at the same time
+function backoff(attempt):
+    return 1s
+
+# bad — exponential without jitter; clients still synchronise
+function backoff(attempt):
+    return min(1s * 2^(attempt - 1), 30s)
+```
+
+## Maximum retry count
+
+Every retry loop must have a hard upper bound. Without one, a dependency that returns a retryable error indefinitely (e.g. a 503 during a prolonged outage) causes the caller to loop until its own timeout or resource limit is hit — by which point it has sent dozens of requests that only add load to the struggling dependency.
+
+A typical maximum is 3 to 5 total attempts (including the original request). The right number depends on the use case: a user-facing API call should fail quickly (2-3 attempts); a background job that can tolerate latency might use more (up to 5). The maximum must always be explicit in code, never implicit via an unbounded loop.
+
+```
+# good — explicit maximum, clear termination
+function send_with_retry(request, max_attempts=3):
+    for attempt in 1..max_attempts:
+        response = http_client.send(request, timeout=5s)
+        if response.status not in TRANSIENT_HTTP_CODES:
+            return response
+        if attempt < max_attempts:
+            sleep(backoff_with_jitter(attempt))
+    raise MaxRetriesExceeded(attempts=max_attempts)
+
+# bad — no upper bound; loops until something else kills the process
+function send_with_retry(request):
+    while true:
+        response = http_client.send(request)
+        if is_retryable(response):
+            sleep(backoff_with_jitter(attempt))
+            continue
+        return response
+```
+
+## Explicit timeouts on all external calls
+
+A timeout defines the maximum time the caller will wait for a response. Without one, the default is often "wait forever" — which means a single hung connection can block a thread, exhaust a connection pool, and cascade the failure to every upstream caller.
+
+Set timeouts at the point of the call, not only at the infrastructure level (e.g. load balancer timeout). Infrastructure timeouts are a safety net, not a substitute — they are typically set higher than the application needs and may not exist for all call types (database queries, gRPC streams, message publish calls).
+
+Most HTTP and gRPC clients distinguish a connect timeout (time to establish a connection — catches unreachable hosts) from a read/response timeout (time to receive data after connecting — catches hung requests mid-flight). Set both explicitly; they serve different purposes and have different safe defaults. A low connect timeout (1 to 3 seconds) fails fast when a host is down, while the read timeout should match the expected response latency of the dependency.
+
+Choose timeout values based on the expected latency of the dependency under normal load, plus a reasonable margin. A call that normally completes in 200ms should not have a 60s timeout — that is effectively no timeout at all for the purpose of cascading-failure prevention.
+
+```
+# good — explicit timeout on every external call
+response = http_client.get("https://api.provider.com/rates",
+    timeout=5s)
+
+grpc_response = grpc_client.get_quote(request,
+    timeout=3s)
+
+rows = db.execute("SELECT ...",
+    timeout=2s)
+
+# bad — no timeout; caller blocks until the dependency responds or the connection dies
+response = http_client.get("https://api.provider.com/rates")
+
+# bad — timeout so high it provides no protection against cascading failure
+response = http_client.get("https://api.provider.com/rates",
+    timeout=300s)
+```
+
+## Idempotency keys for retry safety
+
+When a mutating request (POST, PUT, or a gRPC method that creates or modifies state) is retried, the caller does not know whether the original request was processed before the failure occurred. If the server processed the request but the response was lost (network timeout, connection reset), a retry without an idempotency key will apply the effect twice — creating a duplicate record, charging a payment twice, or sending a notification again.
+
+An idempotency key is a unique identifier for the operation, generated by the caller and sent with every attempt. The server uses it to detect duplicate requests: if it has already processed a request with that key, it returns the stored result instead of re-executing the operation. This makes retries safe regardless of where in the request lifecycle the failure occurred.
+
+Generate the key once per logical operation, not per attempt. Typically this is a UUID or a deterministic hash of the operation's inputs. Pass it as a header (e.g. `Idempotency-Key`) or a field in the request body, depending on the API's convention.
+
+```
+# good — idempotency key generated once, sent on every attempt
+function create_payment_with_retry(payment, max_attempts=3):
+    idempotency_key = generate_uuid()
+    for attempt in 1..max_attempts:
+        response = http_client.post("/payments",
+            body=payment,
+            headers={"Idempotency-Key": idempotency_key},
+            timeout=5s)
+        if response.status not in TRANSIENT_HTTP_CODES:
+            return response
+        if attempt < max_attempts:
+            sleep(backoff_with_jitter(attempt))
+    raise MaxRetriesExceeded(attempts=max_attempts)
+
+# bad — no idempotency key; retry may create duplicate payment
+function create_payment_with_retry(payment, max_attempts=3):
+    for attempt in 1..max_attempts:
+        response = http_client.post("/payments",
+            body=payment,
+            timeout=5s)
+        if response.status not in TRANSIENT_HTTP_CODES:
+            return response
+        if attempt < max_attempts:
+            sleep(backoff_with_jitter(attempt))
+    raise MaxRetriesExceeded(attempts=max_attempts)
+```
+
+For event-driven systems, the deduplication key serves the same purpose: a unique identifier attached to each message that allows the consumer to detect and skip duplicates. Generate the key at the producer and include it in the message payload.
+
+## See Also
+
+- [observability.md](observability.md) — metrics and tracing conventions for instrumenting retries, timeouts, and failure rates.
+- [logging.md](logging.md) — logging conventions for recording retry attempts, timeout events, and failure outcomes.

--- a/docs/ai/steering/base/spelling.md
+++ b/docs/ai/steering/base/spelling.md
@@ -1,0 +1,63 @@
+---
+version: 1.0
+last_reviewed: 2026-05-12
+---
+
+# Spelling Standards
+
+UK English is Zego's house style for all human-readable text in the codebase — comments, docstrings, log messages, error messages, and any other prose that developers or users read. Apply these rules to any codebase, always. Spell-checking tooling, if configured, enforces its own dictionary and is not covered here.
+
+## Rules at a Glance
+
+1. **UK English for human-readable text.** Use UK English spelling in all comments, docstrings, log messages, error messages, and documentation strings — consistency across the codebase reduces cognitive load for reviewers and keeps prose style uniform.
+2. **Identifiers and API contracts are exempt.** Do not change the spelling of variable names, function names, class names, enum values, or external API field names to match UK English — renaming these would break contracts, callers, and tooling that depends on the existing names.
+3. **Common US/UK differences.** Prefer the UK spelling when a word has a well-known US/UK variant — applying the wrong variant is the most frequent source of inconsistency and the easiest to prevent with a short reference list.
+
+## UK English for human-readable text
+
+All text that a human reads in the codebase — inline comments, block comments, docstrings, log message strings, error message strings, and in-code documentation — must use UK English spelling. This applies regardless of the programming language. Standalone documentation files (READMEs, ADRs, design docs) should also follow UK English; user-facing UI strings are a product concern and outside the scope of this standard.
+
+```
+# good
+# Initialise the colour map before authorising the request
+
+# bad — US spellings
+# Initialize the color map before authorizing the request
+```
+
+```
+# good
+log.info("Organisation catalogue synchronised.", {"org.id": org_id})
+
+# bad — US spellings in the log message
+log.info("Organization catalog synchronized.", {"org.id": org_id})
+```
+
+## Identifiers and API contracts are exempt
+
+Code identifiers — variable names, function names, class names, enum values, constants, and module names — are not required to use UK English. Renaming an identifier changes its contract: every caller, every import, every serialised field, and every test assertion that references it would also need to change. The same applies to field names in external API contracts, configuration keys defined by third-party systems, and protocol buffer field names.
+
+When writing a new identifier with no existing contract, use UK English unless it would be inconsistent with the surrounding codebase convention — consistency with neighbouring code takes precedence over the house style for identifiers specifically.
+
+```
+# good — UK English in the comment, existing US-convention identifier left alone
+color_hex = "#FF5733"  # Colour value for the warning banner
+
+# bad — renaming an existing identifier to match UK spelling
+colour_hex = "#FF5733"  # renamed from color_hex for UK English consistency
+```
+
+## Common US/UK differences
+
+The most frequent variants that appear in codebases. When in doubt, check a UK English dictionary.
+
+| US spelling | UK spelling | Example context |
+|-------------|-------------|-----------------|
+| -ize | -ise | initialise, authorise, serialise, synchronise, organisation |
+| -or | -our | colour, behaviour, favour, neighbour |
+| -og | -ogue | catalogue, dialogue, analogue |
+| -er | -re | centre, metre (unit of length) |
+| -ense | -ence | licence (noun), defence |
+| -ll | -l | fulfil/fulfilment, instalment, enrol/enrolment |
+
+Note: some `-ize` spellings are correct in UK English when the suffix derives from Greek `-izo` (e.g. "capsize" is not "capsise"). When genuinely uncertain, check a UK dictionary rather than applying `-ise` mechanically.

--- a/docs/ai/steering/base/testing.md
+++ b/docs/ai/steering/base/testing.md
@@ -1,0 +1,210 @@
+---
+version: 1.2
+last_reviewed: 2026-05-11
+---
+
+# Testing Standards
+
+Testing conventions for verifying observable behaviour — the governing philosophy is integration-first: test from the outside in through real components, and write unit tests only where integration tests cannot reach. Apply these rules to any codebase when writing or modifying tests. Language-specific tooling (test runners, coverage plugins, parametrize decorators) is not covered here — see the relevant language standards file. Constructor injection and composition root patterns that enable dependency substitution in tests are covered in the language-specific standards files (e.g. `languages/python.md`).
+
+## Rules at a Glance
+
+1. **Integration tests as default.** Prefer integration tests that exercise real components end-to-end over unit tests — they catch wiring bugs, validate real behaviour, and are harder to make pass with a broken implementation.
+2. **Unit tests for unreachable paths.** Write unit tests only for logic that integration tests cannot cost-effectively reach: deep error branches, pure algorithmic logic, and combinatorial edge cases.
+3. **Mock only at the external boundary.** Replace only third-party HTTP clients, databases, and external services you do not own — never mock your own code, including via test-only subclasses that override concrete production methods, because mocking internal calls only tests that you wrote the mock correctly.
+4. **Build real domain objects in fixtures.** Construct genuine domain objects in test fixtures rather than stubs or magic-value dicts — tests that use real objects catch contract breakage; tests that use stub objects hide it.
+5. **Fresh fixtures per test.** Fixtures must return a new object on every call — shared mutable state between tests causes order-dependent failures that are hard to diagnose.
+6. **No copy-pasted setup.** Extract repeated setup into fixtures and repeated input/output pairs into table-driven tests — duplication means a future change breaks many tests for one logical reason.
+7. **Fix or delete brittle tests.** When a test fails intermittently, fix the root cause or delete the test — never add retries, because a flaky test in CI masks real failures and trains the team to ignore red.
+8. **Test failure paths explicitly.** Write at least one test per failure path — happy-path-only test suites pass on broken code that returns a wrong result rather than raising.
+9. **Extract pure logic from framework glue.** Pull business logic out of framework handlers into pure functions or classes so it can be tested without spinning up the framework.
+10. **Coverage enforced at config level only.** Target high coverage and enforce the threshold in CI config — never add inline coverage exclusions, because they permanently hide untested code from the metric.
+11. **Never add test-only paths to production code.** When a test fails, fix the test or fix the production bug — never add environment checks, test-fixture hooks, or conditional branches to production code to make a test pass. If production code needs to change to become testable, extract logic (Rule 9); don't add `if testing` / `if ENV == "test"` gates.
+
+## Integration tests as default
+
+An integration test assembles real components — real service classes, real repositories against a real or in-process database, real serialisers — and calls through the full stack. The trade-off is slower execution and more setup; the benefit is that a passing test suite is strong evidence the system works, not just that its individual pieces behave as their author assumed.
+
+Unit tests have their place: pure algorithmic logic with many input combinations is best tested in isolation, and some error branches (network timeout, upstream 500) are impractical to trigger through a real stack. The rule is not "never unit test" — it is "start with integration, drop to unit only when integration cannot reach".
+
+```
+# good — exercises the real service, real repository, real domain logic
+test "policy activation records event":
+    repo = PolicyRepository(db_session)
+    service = PolicyService(repo=repo, events=event_bus)
+    service.activate(policy_id="POL-1")
+    assert event_bus.last_emitted.type == "policy.activated"
+
+# bad — tests the service in isolation at the cost of hiding wiring bugs
+test "policy activation records event":
+    mock_repo.get.returns = FakePolicy()
+    service = PolicyService(repo=mock_repo, events=mock_events)
+    service.activate(policy_id="POL-1")
+    assert mock_events.emit.was_called_once
+```
+
+## Mock only at the external boundary
+
+The external boundary is anything you do not own: a third-party REST API, a managed database, an external message broker, a payment provider SDK. Everything inside your service boundary — your own classes, your own repositories, your own domain logic — should run real.
+
+Mocking internal code couples the test to implementation details. When you refactor, the mock breaks even if the behaviour is unchanged. Worse, a mock that is set up incorrectly will make a test pass on code that is wrong.
+
+This also applies to test-only subclasses. Creating a subclass of a concrete production class that overrides methods and testing the subclass instead of the real class is mocking-by-inheritance — it has the same problem: the test validates the override, not the production behaviour. Test the real class or don't test it. This does not apply to concrete implementations of abstract base classes, interfaces, or protocols — those are legitimate dependency substitutions, not mocks.
+
+```
+# good — only the external HTTP client is replaced
+test "quote fetches rate from provider":
+    fake_http.get("/rates").returns = { "rate": 0.05 }
+    service = QuoteService(http=fake_http)
+    quote = service.get_quote(vehicle_id="V-1")
+    assert quote.rate == 0.05
+
+# bad — mocking own repository hides whether the service and repo integrate correctly
+test "quote fetches rate from provider":
+    mock_quote_repo.find.returns = FakeQuote(rate=0.05)
+    ...
+```
+
+## Build real domain objects in fixtures
+
+A fixture that returns a real `Policy(id="POL-1", status="pending")` will break if the `Policy` constructor changes — which is the right behaviour. A fixture that returns a plain map/dict `{"id": "POL-1", "status": "pending"}` or a mock object will silently pass even if the domain object's contract has been broken.
+
+Build fixtures using the same constructors and factory methods production code uses. If a domain object is expensive to construct, that is a signal the object has too many required dependencies — address the design, not the test.
+
+```
+# good — uses the real constructor; breaks loudly if the contract changes
+function make_policy(overrides):
+    defaults = { id: "POL-1", status: "pending", product: "van" }
+    return Policy(merge(defaults, overrides))
+
+# bad — a plain map/dict will not catch constructor or type changes
+function make_policy():
+    return { id: "POL-1", status: "pending", product: "van" }
+```
+
+## Fresh fixtures per test
+
+A fixture that returns the same object across tests creates shared mutable state. Test A mutates the object; Test B assumes it is clean; Test B fails only when run after Test A.
+
+Fixtures must construct and return a new instance on every invocation. In most test frameworks this is the default behaviour for function-scoped fixtures — do not widen the scope unless you have a measured performance reason and the object is provably immutable.
+
+```
+# good — new Policy instance on every test call
+fixture active_policy():
+    return Policy(id="POL-1", status="active")
+
+# bad — file-level singleton is shared across all tests in the file
+ACTIVE_POLICY = Policy(id="POL-1", status="active")   # created once, reused everywhere
+```
+
+## No copy-pasted setup
+
+When two tests share the same setup code, extract it into a fixture. When two tests differ only in their inputs and expected outputs, merge them into a table-driven (parametrised) test. Duplicated setup is maintenance debt: a domain change requires updating every copy.
+
+The rule applies to assertion helpers too — if three tests assert the same multi-field condition, extract an assertion helper rather than repeating the condition inline.
+
+```
+# good — table-driven; one place to add cases, one place to update assertions
+cases = [
+    { product: "van",  expected_rate: 0.10 },
+    { product: "taxi", expected_rate: 0.25 },
+    { product: "bike", expected_rate: 0.05 },
+]
+for each case in cases:
+    test "base rate for {case.product}":
+        policy = make_policy(product=case.product)
+        assert calculate_rate(policy) == case.expected_rate
+
+# bad — three copies of identical setup that diverge over time
+test "van rate":
+    policy = Policy(id="P1", status="active", product="van")
+    assert calculate_rate(policy) == 0.10
+
+test "taxi rate":
+    policy = Policy(id="P1", status="active", product="taxi")
+    assert calculate_rate(policy) == 0.25
+```
+
+## Fix or delete brittle tests
+
+A test that sometimes passes and sometimes fails provides negative value: it trains the team to ignore CI red, delays detection of real regressions, and wastes time on retries. The only acceptable responses are to fix the root cause (a timing dependency, a race condition, a non-deterministic ordering) or to delete the test.
+
+Common causes of flakiness: relying on wall-clock time instead of injecting a clock, relying on dictionary/set ordering, using real sleeps instead of advancing a test clock, and shared state left over from a previous test.
+
+## Test failure paths explicitly
+
+A test suite that only exercises the happy path will pass on an implementation that raises no exceptions but returns wrong results on error inputs. For every logical failure case — invalid input, missing resource, upstream error — write at least one test that asserts the correct error response, exception type, or fallback behaviour.
+
+```
+# good — failure path is a first-class test case
+test "activate raises when policy not found":
+    assert_throws PolicyNotFoundError:
+        service.activate(policy_id="NONEXISTENT")
+
+# bad — only the success path is tested; broken error handling goes undetected
+test "activate success":
+    service.activate(policy_id="POL-1")
+    assert ...
+```
+
+## Extract pure logic from framework glue
+
+Framework entry points (HTTP handlers, event consumers, CLI commands) mix dispatch logic — parsing requests, routing errors, returning responses — with business logic. Business logic buried in a handler can only be tested by spinning up the full framework.
+
+Pull the business logic into a plain function or class that takes typed arguments and returns a typed result. Test that directly. Test the handler only for the thin layer it owns: correct parsing, correct status codes, correct error mapping.
+
+```
+# good — pure function tested directly, no framework required
+function calculate_premium(base_rate, risk_score):
+    return base_rate * (1 + risk_score / 100)
+
+test "calculate premium applies risk multiplier":
+    assert calculate_premium(base_rate=0.10, risk_score=50) == 0.15
+
+# bad — business logic lives inside the handler; test must go through HTTP
+function quote_handler(request):
+    base_rate = parse_float(request.body["base_rate"])
+    risk_score = parse_int(request.body["risk_score"])
+    return json_response({ premium: base_rate * (1 + risk_score / 100) })
+```
+
+## Coverage enforced at config level only
+
+Inline exclusions (`# pragma: no cover`, `// istanbul ignore next`, and equivalents) permanently remove lines from the coverage metric without any record of why. Over time they accumulate and the coverage number stops reflecting reality.
+
+Set the coverage threshold in CI configuration. When a line genuinely should not be covered — a defensive branch that can only be reached by hardware failure, a type-narrowing assertion — omit it at the config level with a comment explaining why, rather than scattering exclusions through the source.
+
+## Never add test-only paths to production code
+
+Test-only branches in production code (environment variable checks, fixture-registration hooks, environment-gated behaviour) create invisible coupling between the test suite and the deployment artifact. They are never exercised in production, so they rot silently, and they make the production code harder to reason about.
+
+When a test is hard to write, the correct responses are:
+
+- **Fix the test** if the test is wrong — incorrect setup, bad assertion, or testing the wrong thing
+- **Fix the production code** if there is a genuine bug
+- **Extract logic** (Rule 9) if the code is untestable due to framework coupling
+- **Rethink the test approach** — the integration-first philosophy (Rule 1) exists precisely to avoid needing production-side test accommodations
+
+If none of these fit, the test may not be worth writing.
+
+## Red Flags — Stop and Reconsider
+
+If any of these thoughts cross your mind, stop — you are about to rationalise away a rule.
+
+- "I'll just mock the repository so I don't have to stand up a real database for this test."
+- "A unit test with mocks is faster and will catch the same bug, so I'll skip the integration test."
+- "I'll subclass the production class in the test and override the slow method — it's still testing the real class."
+- "Setting up the real collaborators is too much boilerplate; a mock keeps the test focused."
+- "This logic is simple enough that an isolated unit test is clearly sufficient here."
+
+| Rationalisation | Rule it violates | Real-world consequence |
+|-----------------|------------------|------------------------|
+| "I'll just mock the repository so I don't have to stand up a real database for this test." | Rule 3 — Mock only at the external boundary | The test asserts the mock was called, not that the service and repository integrate — a broken query or schema mismatch passes CI and surfaces only in production. |
+| "A unit test with mocks is faster and will catch the same bug, so I'll skip the integration test." | Rule 1 — Integration tests as default | Wiring bugs between real components go untested; the suite is green on a system that does not actually work end-to-end. |
+| "I'll subclass the production class in the test and override the slow method — it's still testing the real class." | Rule 3 — Mock only at the external boundary | The test validates the override, not the production method, so a regression in the real method ships undetected. |
+| "Setting up the real collaborators is too much boilerplate; a mock keeps the test focused." | Rule 1 — Integration tests as default; Rule 3 — Mock only at the external boundary | The test couples to current implementation detail and passes on incorrectly wired code, defeating the reason the test was written. |
+| "This logic is simple enough that an isolated unit test is clearly sufficient here." | Rule 1 — Integration tests as default | "Simple" logic with a real wiring bug (wrong field mapped, wrong dependency injected) passes in isolation and fails only against live data. |
+
+## See Also
+
+- [languages/python.md](../languages/python.md) — constructor injection and composition root patterns that enable dependency substitution in tests.

--- a/docs/ai/steering/domains/README.md
+++ b/docs/ai/steering/domains/README.md
@@ -1,0 +1,4 @@
+# Domain Standards
+
+- [protobuf-converters.md](protobuf-converters.md) — protobuf converter conventions: never hand-roll conversions, nullability suffix rules, proto3 zero-value semantics, and going upstream for missing converters.
+- [frontend-ticket-spec.md](frontend-ticket-spec.md) — frontend ticket specification conventions: what must be resolved before an autonomous agent picks up a ticket in zego-web, customer-acquisition, checkout-mfe, my-zego, or zego-utils.

--- a/docs/ai/steering/domains/frontend-ticket-spec.md
+++ b/docs/ai/steering/domains/frontend-ticket-spec.md
@@ -1,0 +1,127 @@
+---
+version: 1.0
+last_reviewed: 2026-05-18
+---
+
+# Frontend Ticket Specification Standards
+
+Conventions for writing frontend Jira tickets that an autonomous AI agent can implement end-to-end without human steering during development. The governing philosophy is: every ambiguity that is not resolved before the agent starts is a context switch waiting to happen — resolve it upfront. Apply these rules when writing or refining any frontend ticket in `zego-web` (onboarding-web), `customer-acquisition` (acquisition-web), `checkout-mfe`, `my-zego`, or `zego-utils`, before the ticket moves to In Progress. Ticket authoring conventions that apply to all teams are not covered here.
+
+## Rules at a Glance
+
+1. **Figma node ID before In Progress.** Every ticket that touches UI must reference the exact Figma node ID(s) before the agent starts — a vague Figma link is not sufficient; the agent cannot resolve design ambiguity mid-implementation without stalling.
+2. **Scope boundary is surgical.** State explicitly what this ticket covers and what it does not, including things the agent might reasonably add but must not — routing changes, adjacent screens, API integration if not in scope — because agents are thorough by default.
+3. **Data contract fully specified.** Every field the UI must render must have a source path, type, and null-handling rule — agents must not guess data shapes, invent fallbacks, or default to hardcoded values when session data is absent.
+4. **Acceptance criteria are binary.** Each criterion must pass or fail without human judgment — "looks good" and "matches design" are not valid criteria; "matches Figma node 6554-63136 at breakpoints 375px and 1280px" is.
+5. **Existing components named explicitly.** When the ticket requires reusing or extending an existing component, name it by its exact import path — agents waste cycles discovering the component tree if this is omitted.
+6. **No open questions at start.** Any open question in the ticket description must be resolved and the answer recorded in the ticket before the agent picks it up — an unresolved question is a guaranteed mid-implementation stall.
+7. **One screen or one component per ticket.** Tickets that span multiple screens or introduce multiple independent components must be split — a ticket the agent cannot complete in a single uninterrupted session will produce a stalled or oversized PR.
+8. **Test requirement is explicit.** State exactly which behaviours require test coverage and at which level (unit / component / e2e:mock) — "add tests" is not sufficient; the agent needs to know what to test, not just that tests are expected.
+
+## Figma node ID before In Progress
+
+A Figma link to the file root gives the agent the entire file to navigate, which is expensive and imprecise. A node ID (`?node-id=6554-63136`) pins the agent to the exact frame — spacing, token usage, responsive behaviour, and component hierarchy are all unambiguous. Without it, the agent must infer design intent from context, which produces inconsistency.
+
+```markdown
+# good
+**Figma:** https://www.figma.com/design/I2sehqDcrR3XrKaBj2LHxe/...?node-id=6554-63136
+
+# bad — agent must navigate the entire file to find the relevant frame
+**Figma:** https://www.figma.com/design/I2sehqDcrR3XrKaBj2LHxe/Renewals
+```
+
+## Scope boundary is surgical
+
+An agent that is not given an explicit boundary will implement everything that seems related. This is not a bug — it is the agent doing its job correctly given incomplete information. The out-of-scope list is the mechanism for communicating the boundary, not a formality. Be specific about adjacent concerns an agent is likely to reach for: routing wires itself up naturally from a new screen, API calls seem necessary once a data shape exists, adjacent components look incomplete without the new one.
+
+```markdown
+# good
+**In scope:** Add the review section above the existing `<Section>` for card details.
+**Out of scope:** Changes to the Stripe form, submit logic, routing, or any screen other than `payment-single-screen.svelte`.
+
+# bad — no boundary stated; agent may refactor adjacent code, add a route, or extend the API call
+**What:** Implement the review premium section.
+```
+
+## Data contract fully specified
+
+The frontend often renders data that comes from a session envelope or API response. An agent that is not told the exact source path will either hardcode a value, render nothing, or write a best-guess accessor that breaks at runtime. Hardcoded display values are a silent bug: the component passes visual review but fails the moment real data differs from the placeholder. Specify the path, the TypeScript type, and what to do when the value is absent.
+
+```markdown
+# good
+| Field          | Path                                              | Type              | Null handling                               |
+| -------------- | ------------------------------------------------- | ----------------- | ------------------------------------------- |
+| Annual premium | `envelope.data.quotes?.[0]?.price?.annual?.total` | `Money`           | Omit section if absent; do not default to 0 |
+| Start date     | `envelope.data.cover?.startDate`                  | `string` (ISO date) | Omit row if absent                        |
+
+# bad — agent must guess the shape or may default to a hardcoded fallback
+Display the annual premium and start date from the session data.
+```
+
+## Acceptance criteria are binary
+
+Criteria that require judgment introduce a review cycle. The reviewer has to decide whether the criterion is met; if they decide it is not, the agent gets a `CHANGES_REQUESTED` and another round begins. Criteria that are objectively checkable close that loop before it opens.
+
+```markdown
+# good
+- [ ] Section is absent (not an error state) when `cover` or `quotes` is null or empty
+- [ ] Annual premium rendered using `formatCurrencyLabel` — not a raw number
+- [ ] Layout matches Figma node 6554-63136 at 375px and 1280px viewport widths
+
+# bad — requires human judgment to evaluate
+- [ ] Section looks correct
+- [ ] Premium is displayed properly
+```
+
+## Existing components named explicitly
+
+The component tree in these repos is large. An agent asked to "use the existing summary card" will search, find multiple candidates, and either pick the wrong one or ask a clarifying question mid-task. Name the component by its import path — the agent can then open the file, read its interface, and use it correctly on the first attempt.
+
+```markdown
+# good
+Reuse `src/components/policy/PolicySummaryCard.svelte` for the summary block.
+Extend `src/components/shared/FormField/FormField.svelte` — do not create a new wrapper.
+
+# bad — agent must guess which component is intended
+Use the existing summary card component.
+Add a form field using the shared component.
+```
+
+## No open questions at start
+
+An open question in a ticket is a mid-implementation interrupt waiting to happen. When the agent hits it, work stops: the agent either blocks (best case) or makes an assumption that requires a rework cycle to correct (common case). Every question in the description must have a recorded answer before the ticket moves to In Progress — not "to be confirmed", not "ask design".
+
+```markdown
+# good
+**Q: Should the section be shown for monthly policies as well?**
+**A: Yes — show for all payment frequencies. Confirmed with design 2026-05-14.**
+
+# bad — agent must either block or guess
+**Open question:** Should this section be shown for monthly policies too?
+```
+
+## One screen or one component per ticket
+
+Tickets that span two screens or introduce two independent components create PRs that reviewers cannot meaningfully approve in a single pass. The reviewer has to context-switch between concerns, which increases the chance of missed issues and extends the review cycle. Split the ticket — the overhead of an extra ticket is lower than the overhead of a bloated PR.
+
+If two tickets have a dependency (component B needs component A to exist), express it in the `Depends on:` field of the task spec, not by combining them into one ticket.
+
+## Test requirement is explicit
+
+"Add tests" tells the agent nothing about what to verify, at which layer, or what coverage is considered complete. An agent left to decide this autonomously will either under-test (only the happy path) or over-test (snapshot tests for every state). State the behaviours to cover and the level at which to cover them.
+
+```markdown
+# good
+- Unit: `formatPremiumSection` returns `null` when `quotes` is empty or absent
+- Component: section renders with correct label and formatted value when data is present
+- Component: section is absent (not hidden, not zero) when `quotes[0].price` is null
+- e2e:mock: full payment screen renders without the section when the session fixture has no quotes
+
+# bad — agent decides scope and level
+Add tests for the premium section.
+```
+
+## See Also
+
+- [../base/pull-requests.md](../base/pull-requests.md) — PR conventions that apply once the agent has implemented the ticket.
+- [../base/testing.md](../base/testing.md) — testing principles that inform the test requirement field.

--- a/docs/ai/steering/domains/protobuf-converters.md
+++ b/docs/ai/steering/domains/protobuf-converters.md
@@ -1,0 +1,167 @@
+---
+version: 1.0
+last_reviewed: 2026-05-11
+---
+
+# Protobuf Converter Standards
+
+Conventions for converting between Python types and Zego protobuf message types — the governing philosophy is never hand-roll a conversion; always use `zego.protobuf.converters`, and if a converter is missing, add it to the `zego-protobuf` package rather than writing inline conversion code. Apply these rules whenever writing or modifying code that constructs, reads, or converts any `zego.protobuf.*` or `google.protobuf.*` message type. Python language conventions are owned by `docs/ai/steering/languages/python.md`.
+
+## Rules at a Glance
+
+1. **No hand-rolled conversions.** Always use `zego.protobuf.converters` for any proto type in the reference table below — hand-rolled implementations consistently get sign-matched nanos wrong (corrupting `FixedDecimal`), treat epoch as a real date rather than "absent" (corrupting `Timestamp` and `Date`), and silently apply the wrong rounding mode (corrupting `Money`).
+2. **Nullability suffix.** Use `from_X` / `to_X` when the value is guaranteed non-`None`; use `from_X_optional` / `to_X_optional` when the value or its proto "unset" sentinel may represent absence — the `_optional` variants translate the proto3 zero-value sentinel to `None` automatically so callers never need to know the sentinel.
+3. **Proto3 zero-values mean absent.** `Timestamp(seconds=0)`, `Date(year=0, month=0, day=0)`, an empty `Url.url`, and any `*_UNSPECIFIED = 0` enum member all signal "not set" in proto3; use `_optional` variants to handle this transparently — passing these sentinels through non-optional converters returns incorrect results.
+4. **`MoneyConverter.to_integer` for minor-unit APIs only.** Use it only for Stripe-style APIs that expect amounts in the smallest currency unit; it truncates with `ROUND_DOWN` and the round-trip is intentionally lossy — there is no `from_integer`.
+5. **`EnumConverter` as a module-level constant.** Construct `EnumConverter` once at module level and reuse it — instantiation introspects `DESCRIPTOR.values` to strip prefixes and is wasteful per-call.
+6. **UUID direct construction.** There is no `UUIDConverter`; construct `zego.protobuf.UUID` directly as `UUID(uuid=str(my_python_uuid))` — the proto contract requires lowercase, hyphenated form and `str(uuid.UUID(...))` already produces it.
+7. **Go upstream for missing converters.** If a proto type has no converter in `zego.protobuf.converters`, add one to the `zego-protobuf` package rather than hand-rolling in service code — putting the converter in the package ensures correctness invariants are shared and tested once.
+
+## Converter Reference Table
+
+| Proto type | Python type | Converter |
+|---|---|---|
+| `zego.protobuf.FixedDecimal` | `decimal.Decimal` | `FixedDecimalConverter` |
+| `zego.protobuf.Money` | `(Decimal, currency_code)` or minor-unit `int` | `MoneyConverter` |
+| `google.protobuf.Timestamp` | `datetime.datetime` | `TimestampConverter` |
+| `zego.protobuf.Date` | `datetime.date` | `DateConverter` |
+| `zego.protobuf.Url` | `str` | `UrlConverter` |
+| Any proto enum | A native Python `Enum` | `EnumConverter` |
+| `zego.protobuf.UUID` | `str` | None — construct directly (see Rule 6) |
+
+All converters import from `zego.protobuf.converters`.
+
+## No hand-rolled conversions
+
+`FixedDecimal` stores an amount as `sint64 units` and `sfixed32 nanos`, and `units` and `nanos` must have matching signs (or one must be zero). A hand-rolled implementation that sets `nanos` from the fractional part of an absolute value will produce incorrect results for negative amounts: `-1.75` must be `units=-1, nanos=-750_000_000`, not `units=-1, nanos=750_000_000`. `FixedDecimalConverter` enforces this invariant.
+
+`Timestamp` and `Date` use proto3 defaults (seconds=0, all-zero date fields) to represent "not set". A hand-rolled `to_datetime` that does not account for this will return the Unix epoch rather than `None`, corrupting any downstream code that treats `None` as absent.
+
+`MoneyConverter` truncates with `ROUND_DOWN` for minor-unit conversion; a reimplementation that uses `ROUND_HALF_UP` or `ROUND_HALF_EVEN` will produce values one unit too high, leading to overcharging.
+
+```python
+from decimal import Decimal
+from zego.protobuf.converters import FixedDecimalConverter
+
+# good
+fd = FixedDecimalConverter.from_decimal(Decimal("-1.75"))
+# → FixedDecimal(units=-1, nanos=-750_000_000) — signs matched
+
+# bad — hand-rolled; sign of nanos is wrong for negative amounts
+fd = FixedDecimal(units=-1, nanos=750_000_000)  # invalid; to_decimal raises ValueError
+```
+
+## Nullability suffix
+
+Every converter ships two pairs of methods. Use the right pair for the nullability of your input:
+
+- `from_X(value)` — value is non-`None`; raises `TypeError` or `ValueError` on `None` or the proto zero-value.
+- `from_X_optional(value)` — value may be `None`; returns the proto zero-value sentinel when given `None`.
+- `to_X(proto)` — proto field is non-`None` and not a zero-value sentinel; returns the Python type.
+- `to_X_optional(proto)` — proto field may be `None` or the zero-value sentinel; returns `None` in those cases.
+
+```python
+from datetime import date
+from zego.protobuf.converters import DateConverter
+
+# good — optional variant when the date may be absent
+proto_date = DateConverter.from_date_optional(None)   # → Date(year=0, month=0, day=0)
+python_date = DateConverter.to_date_optional(proto_date)  # → None
+
+# bad — non-optional variant when the value may be None
+proto_date = DateConverter.from_date(None)            # raises TypeError
+```
+
+## Proto3 zero-values mean absent
+
+Proto3 cannot distinguish between a field that was never set and a field explicitly set to its zero value. Zego's convention is that the zero value always means "not set":
+
+- `Timestamp(seconds=0, nanos=0)` → absent datetime
+- `Date(year=0, month=0, day=0)` → absent date
+- `Url(url="")` → absent URL
+- Any `*_UNSPECIFIED = 0` enum member → absent enum value
+
+Use `_optional` converter variants to get `None` for these cases automatically. Use the non-optional variants only when you have verified the field was explicitly set to a meaningful value.
+
+```python
+from zego.protobuf.converters import TimestampConverter
+
+# good — optional variant handles the epoch-as-absent convention
+dt = TimestampConverter.to_datetime_optional(ts_field)  # None if ts_field is epoch
+
+# bad — non-optional variant; returns epoch datetime when field was never set
+dt = TimestampConverter.to_datetime(ts_field)           # returns 1970-01-01T00:00:00Z
+```
+
+## `MoneyConverter.to_integer` for minor-unit APIs only
+
+`to_integer` multiplies a `Money` amount by a unit multiplier and truncates with `ROUND_DOWN`. This is intentional: when a calculated amount cannot be represented exactly (e.g. £10.999), charging the customer one minor unit less is preferable to charging one too many. The round-trip is lossy by design.
+
+Use `to_integer` only when the downstream API (e.g. Stripe) requires amounts in the smallest currency unit. Do not use it for display, persistence, or arithmetic.
+
+There is no `from_integer`. If you need one, add it to the `zego-protobuf` package with explicit rounding semantics documented.
+
+```python
+from zego.protobuf.converters import MoneyConverter
+
+# good — Stripe charge in pence
+amount_pence, currency = MoneyConverter.to_integer(money)         # default multiplier=100
+amount_yen, _ = MoneyConverter.to_integer(jpy_money, multiplier=1)  # zero-decimal currency
+
+# bad — using to_integer for a stored amount; loses sub-pence precision permanently
+stored_amount = MoneyConverter.to_integer(money)[0]
+```
+
+## `EnumConverter` as a module-level constant
+
+`EnumConverter` introspects the proto enum's `DESCRIPTOR.values` on construction to determine the longest common prefix to strip. This introspection is not free — done per-call inside a handler or service method it adds unnecessary work on every invocation. Construct once at module level.
+
+The Python `Enum` does not need an `UNSPECIFIED` member. The converter maps the proto's zero-value `_UNSPECIFIED` member to `None` automatically.
+
+```python
+from enum import Enum
+from zego.protobuf.accounts.v1.phonenumber_pb2 import PhoneNumber
+from zego.protobuf.converters import EnumConverter
+
+class PhoneNumberLabel(Enum):
+    MOBILE = "mobile"
+    HOME = "home"
+
+# good — constructed once at module level
+PHONE_LABEL = EnumConverter(PhoneNumberLabel, PhoneNumber.PhoneNumberLabel)
+
+PHONE_LABEL.to_enum(PhoneNumber.PHONE_NUMBER_LABEL_MOBILE)          # PhoneNumberLabel.MOBILE
+PHONE_LABEL.to_enum(PhoneNumber.PHONE_NUMBER_LABEL_UNSPECIFIED)     # None
+PHONE_LABEL.from_enum_optional(None)                                # PHONE_NUMBER_LABEL_UNSPECIFIED
+
+# bad — reconstructed inside a function; pays introspection cost per call
+def convert_label(proto_label: int) -> PhoneNumberLabel | None:
+    converter = EnumConverter(PhoneNumberLabel, PhoneNumber.PhoneNumberLabel)
+    return converter.to_enum(proto_label)
+```
+
+## UUID direct construction
+
+`zego.protobuf.UUID` is `{ string uuid = 1; }` — a thin wrapper around a string. No converter is needed. Construct it directly using `str(my_python_uuid)`, which always produces lowercase, hyphenated form (e.g. `3403768f-898a-4dd4-854a-b1f1e63a0fc2`). Do not uppercase it; the proto contract requires lowercase.
+
+```python
+import uuid
+from zego.protobuf.uuid_pb2 import UUID
+
+# good
+proto_uuid = UUID(uuid=str(my_python_uuid))         # lowercase, hyphenated
+python_uuid = uuid.UUID(proto_uuid.uuid)
+
+# bad — uppercase form violates the proto contract
+proto_uuid = UUID(uuid=str(my_python_uuid).upper())
+```
+
+## Go upstream for missing converters
+
+If a proto type in `zego.protobuf.*` or `google.protobuf.*` has no converter in `zego.protobuf.converters`, the correct response is to add one to the `zego-protobuf` package — not to write inline conversion logic in service code. Service-local conversions embed correctness invariants in a place where they cannot be tested centrally, are not shared, and are invisible to other teams working with the same type.
+
+Before adding a converter, check whether one already exists in the package. If the converter you need does not exist, add it to the `zego-protobuf` package with tests, then import and use it.
+
+## See Also
+
+- [../languages/python.md](../languages/python.md) — Python conventions: project structure, dependency injection, typing, and functional core/imperative shell.

--- a/docs/ai/steering/languages/README.md
+++ b/docs/ai/steering/languages/README.md
@@ -1,0 +1,3 @@
+# Languages Standards
+
+- [python.md](python.md) — structural and architectural conventions for Python: functional core/imperative shell, composition root, type annotations, Pydantic vs dataclass, protocols, async I/O, docstring style, and testing tooling (pytest, pytest-asyncio, coverage enforcement).

--- a/docs/ai/steering/languages/python.md
+++ b/docs/ai/steering/languages/python.md
@@ -1,0 +1,678 @@
+---
+version: 1.3
+last_reviewed: 2026-05-11
+---
+
+# Python Standards
+
+Structural and architectural conventions for Python — how business logic is organised, dependencies are wired, types are annotated, and interfaces are expressed; the governing philosophy is functional core, imperative shell: pure functions for business logic, I/O at the edges. Apply these rules to any Python file you write or modify. Formatting, import ordering, and type checking are enforced mechanically by ruff and mypy and are not covered here; testing tooling (pytest, pytest-asyncio, coverage.py) is language-specific and is covered here. Logging conventions are owned by `docs/ai/steering/base/logging.md`; observability and tracing conventions are owned by `docs/ai/steering/base/observability.md`; testing principles and structure are owned by `docs/ai/steering/base/testing.md`.
+
+## Rules at a Glance
+
+1. **Functional core, imperative shell.** Keep business logic in pure functions with no I/O; push all network, database, and filesystem calls to the outermost layer — pure functions are trivially testable and isolate the parts of the system that are expensive to exercise.
+2. **Composition root.** Wire the full object graph once at startup via constructor arguments; never use service locators, module-level singletons, DI frameworks, or mid-request dependency lookups — the dependency graph must be greppable and startup-only. Exception: request-scoped state (current user, trace context, DB transactions) may use framework-provided request scopes, context managers, or `contextvars` (e.g. FastAPI `Depends`, `contextvars`) where startup injection cannot apply.
+3. **Modules over all-static classes.** Put free functions in modules, not in classes made entirely of `@staticmethod` methods — an all-static class is a module with unnecessary syntax.
+4. **Type annotations everywhere.** Annotate every parameter and return value, including `-> None`; avoid `Any`; never silence mypy except in the two cases the **Imports at the top** rule explicitly permits (optional-extras deferred imports and documented circular imports with no structural fix) — in those cases `# type: ignore` is allowed but must include an inline comment explaining why; in all other cases silencing mypy hides contract violations until runtime.
+5. **Docstrings for public interfaces.** Write docstrings for all public modules, classes, and functions using Google style; say *why* the interface exists, not *what* the code does — intent and invariants that cannot be inferred from code survive refactors; docs that restate the code become noise.
+6. **TODO with Jira reference.** Format every TODO as `# TODO(ABC-1234):` — untracked TODOs rot.
+7. **Imports at the top.** Place all imports at module level; never inside functions or blocks — inline imports make module dependencies invisible to static analysis and usually signal a circular import to fix structurally. Permitted exceptions: `if TYPE_CHECKING:` blocks; optional-extras deferred imports where the library may not be installed (guard with `ImportError` and an inline comment); documented circular imports with no structural fix (requires an inline comment with a Jira ticket).
+8. **PEP 8 naming.** Use `snake_case` for variables, functions, and methods; `PascalCase` for classes; `UPPER_SNAKE_CASE` for constants — consistent naming is the baseline contract for Python readability across the codebase.
+9. **Protocols sparingly.** Introduce a `Protocol` only when two or more concrete implementations already exist; implementations inherit the protocol explicitly (not just structurally) and overrides are marked `@override` — speculative interfaces add complexity without value. Import `override` from `typing` (Python 3.12+) or `typing_extensions` (backport for earlier versions).
+10. **Pydantic for domain data and boundaries.** Pydantic is Zego's standard for anything that represents domain data, crosses a service boundary, or is constructed from external input — it validates on construction, catching malformed input at the boundary before it propagates into business logic; use `@dataclass(frozen=True)` only for small internal value types with no validation or serialisation needs.
+11. **`Any` requires an inline comment.** When `Any` is genuinely the right annotation, add an inline comment at the annotation explaining why — not in a docstring, at the annotation itself.
+12. **Async for I/O.** Use `async`/`await` for all I/O operations; keep pure computational functions synchronous — mixing sync and async in the same function blurs the functional core/imperative shell boundary and can block the event loop.
+13. **No magic strings or numbers.** Replace raw string and numeric literals that carry domain meaning with `Enum` values (for shared, API, or persisted values), `Literal` types (for type-checker-only constraints), or module-level constants — named values make intent explicit and prevent silent drift when a value changes. Use `StrEnum` (Python 3.11+) for string enums; on Python 3.10 and below use `str, Enum` instead.
+14. **pytest and pytest-asyncio.** Use pytest as the test framework; use pytest-asyncio for all async test functions — mixing sync and async test helpers produces unpredictable event loop state.
+15. **tests/unit/ and tests/integration/ layout.** Place tests in `tests/unit/` for cases that genuinely cannot be expressed as integration tests, and `tests/integration/` for everything else — keeping the directories separate makes it trivial to run each suite independently in CI.
+16. **AsyncMock for async dependencies.** Use `AsyncMock` (from `unittest.mock`) when substituting async external dependencies in unit tests — a plain `Mock` does not await correctly and produces silent failures. Exception: never use `AsyncMock` for AWS SDK clients — use LocalStack instead; see **No boto3 mocks**.
+17. **Factory fixtures for variations.** When tests need variations on a domain object, return a builder callable from the fixture rather than a fixed instance — callers override only the fields relevant to their assertion, keeping setup concise and the fixture reusable.
+18. **95% coverage via pyproject.toml.** Enforce coverage with `fail_under = 95` in `pyproject.toml`; run diff-cover against `origin/main` so new code is held to a strict bar without blocking progress on existing debt.
+19. **No inline coverage exclusions.** Never use `# pragma: no cover` inline — omit files at the config level in `[tool.coverage.run] omit` in `pyproject.toml`, and only for pure startup wiring (entrypoints, signal handlers) after extracting all testable logic.
+20. **No time.sleep() in async tests.** Use `asyncio.sleep()` or mock time rather than `time.sleep()` in async tests — `time.sleep()` blocks the event loop and makes async tests unreliable.
+21. **LocalStack for AWS integration tests.** Use LocalStack for all AWS service integration tests (DynamoDB, Kinesis, S3) — inject real SDK clients pointed at its endpoint so tests exercise real API calls and parameter validation; pin to `localstack/localstack:4.14`, as versions after 4.14 introduced a mandatory account system that breaks unauthenticated local use.
+22. **No boto3 mocks.** Never patch boto3 clients directly — hand-rolled mocks couple tests to call signatures rather than observable behaviour and hide real API rejection. Use `AsyncMock` only at a `Protocol` boundary where call dispatch (not data fidelity) is under test; never as a substitute for LocalStack when real read/write behaviour matters.
+23. **Pydantic BaseSettings as config entry point.** All environment variables must be read through a single Pydantic `BaseSettings` class — never call `os.getenv()` or `os.environ[]` outside that class; instantiate once in the composition root and inject via DI — this implements the single config entry point required by `docs/ai/steering/base/environment.md`.
+24. **Nested config groups with `env_nested_delimiter`.** Group related settings into nested `BaseModel` classes and use `env_nested_delimiter="__"` — flat config classes with dozens of fields become unreadable and make it impossible to tell which settings belong together.
+25. **`secrets_dir` for filesystem-mounted secrets.** Set `secrets_dir` in `SettingsConfigDict` to the mount path (`/mnt/<service-name>`) so Pydantic reads secret files natively — secrets provisioned via `secrets-config` are mounted at this path by the Blueprint infrastructure.
+26. **Env file loading with `SettingsConfigDict`.** Declare `env_file=(".env.development", ".env")` so Pydantic loads committed development values as the base and gitignored personal overrides on top — this implements the committed/gitignored config file layout from `docs/ai/steering/base/environment.md`.
+27. **pytest-dotenv for test configuration.** Configure `pytest-dotenv` with `env_files = ".env.development"` in `pyproject.toml` so tests load the same safe defaults as local development.
+
+## Functional core, imperative shell
+
+Business logic that is entangled with I/O can only be tested through the I/O layer — slow, flaky, and expensive to set up. Separating pure computation from side effects means the core can be unit-tested with no mocks, and I/O paths can be integration-tested at the boundary.
+
+```python
+# good — pure core, I/O at the edge
+def calculate_premium(base_rate: Decimal, risk_score: float) -> Decimal:
+    return base_rate * Decimal(str(risk_score))
+
+async def update_policy_premium(
+    policy_id: str,
+    repo: PolicyRepository,
+    rate_service: RateService,
+) -> None:
+    base_rate = await rate_service.fetch_base_rate(policy_id)
+    risk_score = await repo.get_risk_score(policy_id)
+    premium = calculate_premium(base_rate, risk_score)
+    await repo.save_premium(policy_id, premium)
+
+# bad — business logic and I/O in the same function
+async def update_policy_premium(policy_id: str) -> None:
+    base_rate = await db.fetch("SELECT rate FROM rates WHERE policy_id = %s", policy_id)
+    risk_score = await db.fetch("SELECT score FROM risk WHERE policy_id = %s", policy_id)
+    premium = base_rate * risk_score  # logic buried inside I/O
+    await db.execute("UPDATE policies SET premium = %s WHERE id = %s", premium, policy_id)
+```
+
+## Composition root
+
+When dependencies are constructed mid-request or via service locators, the dependency graph is invisible to static analysis and tests. Wiring everything once at startup makes dependencies explicit, testable, and easy to trace.
+
+Request-scoped state (the current user, trace context, DB transactions) is the main exception: framework-provided request scopes, context managers, or `contextvars` are fine because they cannot be resolved at startup.
+
+```python
+# main.py — composition root, wired once at startup
+def build_app() -> App:
+    settings = load_settings()
+    db = Database(dsn=settings.database_url)
+    rate_client = RateServiceClient(base_url=settings.rate_service_url)
+    policy_repo = PolicyRepository(db=db)
+    pricing_service = PricingService(repo=policy_repo, rate_client=rate_client)
+    return App(pricing_service=pricing_service)
+
+# bad — dependency constructed inside the function that uses it
+async def handle_request(policy_id: str) -> Response:
+    db = Database(dsn=os.environ["DATABASE_URL"])  # constructed mid-request
+    repo = PolicyRepository(db=db)
+    ...
+
+# good — request-scoped state via FastAPI Depends (permitted exception)
+async def get_current_user(token: str = Header(...)) -> User:
+    return decode_token(token)
+
+async def handle_request(user: User = Depends(get_current_user)) -> Response:
+    ...
+```
+
+## Modules over all-static classes
+
+A class with only `@staticmethod` methods provides no benefit over a module of free functions — it adds a namespace that imports can already provide, forces callers to write `ClassName.method()` for no reason, and obscures that there is no shared state.
+
+```python
+# good
+# pricing.py
+def calculate_base_rate(vehicle_class: str) -> Decimal: ...
+def apply_ncd_discount(rate: Decimal, ncd_years: int) -> Decimal: ...
+
+# bad — all-static class masquerading as a module
+class PricingUtils:
+    @staticmethod
+    def calculate_base_rate(vehicle_class: str) -> Decimal: ...
+    @staticmethod
+    def apply_ncd_discount(rate: Decimal, ncd_years: int) -> Decimal: ...
+```
+
+## Type annotations everywhere
+
+Untyped code hides contract violations until runtime. Full annotations let mypy catch mismatches at development time, make function signatures self-documenting, and remove the need to read implementations to understand what a function accepts or returns.
+
+`# type: ignore` is permitted only in the two cases the **Imports at the top** rule explicitly allows: optional-extras deferred imports (where the library may not be installed) and documented circular imports with no structural fix. In both cases the suppress comment must be accompanied by an inline explanation of why it is needed. Silencing mypy in any other situation masks real type errors.
+
+```python
+# good
+def apply_discount(price: Decimal, discount_rate: float) -> Decimal:
+    return price * Decimal(str(1 - discount_rate))
+
+# bad — no annotations; caller must read the body to know the types
+def apply_discount(price, discount_rate):
+    return price * (1 - discount_rate)
+```
+
+## Docstrings for public interfaces
+
+A docstring that restates the code ("adds two numbers") adds no value. A docstring that explains *why* an interface exists — its invariants, when to use it, what it is responsible for — is load-bearing documentation that survives refactors.
+
+Use Google style. Omit sections that add no information.
+
+```python
+# good
+def calculate_risk_score(policy: Policy, claims: list[Claim]) -> float:
+    """Compute the underwriting risk score for a policy.
+
+    Combines claims frequency, severity, and policy age into a single
+    normalised score in [0.0, 1.0]. Higher scores indicate greater risk.
+    Does not consider external bureau data — callers should enrich the
+    policy before calling this function if bureau data is available.
+
+    Args:
+        policy: The policy under assessment.
+        claims: All historical claims associated with the policy.
+
+    Returns:
+        Risk score in [0.0, 1.0].
+    """
+
+# bad — restates the code, adds no information
+def calculate_risk_score(policy: Policy, claims: list[Claim]) -> float:
+    """Calculate risk score from policy and claims."""
+```
+
+## Imports at the top
+
+Inline imports hide a module's dependencies from static analysis tools and IDEs, making it impossible to build a complete import graph or detect cycles without running the code. They also make it harder to review what a module depends on at a glance.
+
+Three exceptions are permitted, each requiring an inline comment:
+
+1. `if TYPE_CHECKING:` blocks — standard pattern; no comment needed.
+2. Optional-extras deferred imports where the library may not be installed — guard with `ImportError` and note what the optional dependency enables.
+3. Documented circular imports with no structural fix — note the Jira ticket tracking the structural resolution.
+
+```python
+# good — all imports at module level
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from myapp.models import Policy  # type-checking only; no runtime cost
+
+# good — optional extras guarded at import time (not deferred inside a function)
+try:
+    import orjson as json  # optional: faster JSON; falls back to stdlib
+except ImportError:
+    import json  # type: ignore[no-redef]
+
+# bad — import hidden inside a function body
+def calculate_premium(policy_id: str) -> Decimal:
+    import httpx  # makes the dependency invisible to static analysis
+    ...
+
+# bad — circular import deferred with no tracking ticket
+def get_service():
+    from myapp.services import PolicyService  # circular import workaround
+    return PolicyService()
+
+# good — circular import deferred, ticket noted (last resort)
+def get_service():
+    from myapp.services import PolicyService  # circular import; tracked in SYSENG-4321
+    return PolicyService()
+```
+
+## Protocols sparingly
+
+Introducing a `Protocol` before there are two concrete implementations is speculative design — it adds an interface that has never been exercised against a real second implementation and may not fit when one appears. Wait until the second implementation exists, then extract the protocol.
+
+When you do introduce a protocol, inherit it explicitly and mark every override with `@override` so that type checkers can enforce the contract.
+
+```python
+# good — protocol introduced for two concrete implementations
+from typing import Protocol
+from typing_extensions import override
+
+class RateClient(Protocol):
+    async def fetch_base_rate(self, policy_id: str) -> Decimal: ...
+
+class HttpRateClient(RateClient):
+    @override
+    async def fetch_base_rate(self, policy_id: str) -> Decimal:
+        ...
+
+class StubRateClient(RateClient):
+    @override
+    async def fetch_base_rate(self, policy_id: str) -> Decimal:
+        return Decimal("1.00")
+
+# bad — protocol introduced for a single implementation
+class RateClient(Protocol):
+    async def fetch_base_rate(self, policy_id: str) -> Decimal: ...
+
+class HttpRateClient:  # only implementation; structural conformance is untested
+    async def fetch_base_rate(self, policy_id: str) -> Decimal:
+        ...
+```
+
+## Pydantic for domain data and boundaries
+
+Pydantic is Zego's standard for domain data and service boundaries. It validates on construction and serialises cleanly to JSON, catching malformed input at the point of ingestion rather than deep in business logic. Reserve `@dataclass` for small internal value types that carry no validation or serialisation logic.
+
+```python
+# good — Pydantic for a domain model built from external input
+from pydantic import BaseModel, field_validator
+
+class PolicyQuoteRequest(BaseModel):
+    policy_id: str
+    vehicle_class: str
+    inception_date: date
+
+    @field_validator("vehicle_class")
+    @classmethod
+    def must_be_known_class(cls, v: str) -> str:
+        if v not in KNOWN_VEHICLE_CLASSES:
+            raise ValueError(f"Unknown vehicle class: {v}")
+        return v
+
+# good — dataclass for a small internal value type
+from dataclasses import dataclass
+from decimal import Decimal
+
+@dataclass(frozen=True)
+class PremiumBreakdown:
+    base: Decimal
+    discount: Decimal
+    total: Decimal
+```
+
+## `Any` requires an inline comment
+
+`Any` disables type checking at the point of use. It is occasionally the right answer — when integrating with untyped third-party libraries or when a type is genuinely dynamic — but the reason must be stated at the annotation so that reviewers can evaluate whether `Any` is justified or an annotation that should be tightened.
+
+```python
+# good — reason stated at the annotation
+raw_payload: Any  # boto3 response dict; no stub available for this client
+parsed = PayloadModel.model_validate(raw_payload)
+
+# bad — Any with no explanation
+raw_payload: Any
+```
+
+## Async for I/O
+
+A synchronous blocking call inside an async function blocks the entire event loop for the duration of the call, eliminating the benefit of async concurrency. Keeping I/O operations async and computational functions synchronous preserves the functional core/imperative shell boundary and keeps the event loop unblocked.
+
+```python
+# good
+async def fetch_policy(policy_id: str, client: AsyncHttpClient) -> Policy:
+    response = await client.get(f"/policies/{policy_id}")
+    return Policy.model_validate(response.json())
+
+def score_policy(policy: Policy, rules: list[Rule]) -> float:
+    # pure computation — synchronous
+    return sum(rule.score(policy) for rule in rules) / len(rules)
+
+# bad — blocking I/O inside an async function
+async def fetch_policy(policy_id: str) -> Policy:
+    response = requests.get(f"/policies/{policy_id}")  # blocks the event loop
+    return Policy.model_validate(response.json())
+```
+
+## No magic strings or numbers
+
+A raw literal like `"motor"` or `0.15` scattered through the codebase has no stable identity: it can be misspelled silently, duplicated inconsistently, and changed in one place while other callsites are missed. Named values give a single point of truth and let the type checker enforce valid inputs.
+
+Choose the right representation for the situation:
+
+- **`Enum`** — when the value is shared across modules, appears in API payloads or persisted data, or must be enforced at runtime.
+- **`Literal`** — when the constraint is type-checker-only and the value does not cross a boundary (no serialisation, no database storage).
+- **Module-level constant** — when the value is a single numeric or string scalar used in one module with no cross-boundary sharing.
+
+```python
+# good — Enum for a value that appears in API payloads and is persisted
+from enum import StrEnum
+
+class VehicleClass(StrEnum):
+    MOTOR = "motor"
+    COMMERCIAL = "commercial"
+    FLEET = "fleet"
+
+def calculate_base_rate(vehicle_class: VehicleClass) -> Decimal: ...
+
+# good — Literal for a type-checker-only constraint (no serialisation needed)
+from typing import Literal
+
+def set_log_level(level: Literal["DEBUG", "INFO", "WARNING", "ERROR"]) -> None: ...
+
+# good — module-level constant for a single scalar with local scope
+MAX_RETRY_ATTEMPTS: int = 3
+BASE_DISCOUNT_RATE: Decimal = Decimal("0.05")
+
+# bad — magic strings scattered at call sites; misspelling is a silent bug
+def calculate_base_rate(vehicle_class: str) -> Decimal:
+    if vehicle_class == "moter":  # silent typo; no type checker catches this
+        ...
+
+# bad — magic number with no name; meaning is opaque
+premium = base_rate * 0.15  # what does 0.15 represent?
+```
+
+## pytest and pytest-asyncio
+
+pytest is the standard test runner across Python services. pytest-asyncio provides the event loop fixtures and `@pytest.mark.asyncio` decorator that async test functions require. Without it, async tests either fail to run or run synchronously and never actually exercise the awaited paths.
+
+Mark the asyncio mode in `pyproject.toml` to avoid decorating every async test individually:
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+```
+
+```python
+# good — async test with pytest-asyncio (asyncio_mode = "auto")
+async def test_fetch_policy_returns_model(client: AsyncMock) -> None:
+    client.get.return_value = {"id": "p1", "status": "active"}
+    result = await fetch_policy("p1", client)
+    assert result.id == "p1"
+
+# bad — sync wrapper around an async call; never awaits the coroutine
+def test_fetch_policy_returns_model(client: Mock) -> None:
+    result = fetch_policy("p1", client)  # returns a coroutine, not a Policy
+    assert result.id == "p1"
+```
+
+## tests/unit/ and tests/integration/ layout
+
+Unit tests are the exception, not the default. A test belongs in `tests/unit/` only when it tests a pure function or a piece of logic that genuinely has no external dependencies — a calculation, a transformation, a validation rule. Everything else goes in `tests/integration/`, which in practice means most tests.
+
+Keeping the directories separate allows CI to run fast unit checks on every commit and defer integration runs to PR builds or nightly pipelines without any configuration changes to the test files themselves.
+
+```
+# good — directory layout
+tests/
+  unit/
+    test_premium_calculator.py   # pure calculation logic; no I/O
+    test_risk_score.py           # pure scoring function
+  integration/
+    test_policy_repository.py    # exercises the DB layer
+    test_rate_service_client.py  # exercises the HTTP client
+    test_pricing_service.py      # exercises the assembled service
+```
+
+## AsyncMock for async dependencies
+
+When an async function is substituted with a plain `Mock`, calling it returns the mock object directly rather than a coroutine. Any `await` on that result raises a `TypeError` at runtime — or, worse, is silently swallowed depending on the test setup, giving a passing test that never actually ran the awaited code path.
+
+`AsyncMock` returns a coroutine from every call, so `await dependency.method()` works as expected in the function under test.
+
+```python
+from unittest.mock import AsyncMock
+
+# good — AsyncMock for an async dependency
+async def test_update_policy_premium(policy_repo: AsyncMock, rate_service: AsyncMock) -> None:
+    rate_service.fetch_base_rate.return_value = Decimal("100.00")
+    policy_repo.get_risk_score.return_value = 1.2
+    await update_policy_premium("p1", policy_repo, rate_service)
+    policy_repo.save_premium.assert_awaited_once_with("p1", Decimal("120.00"))
+
+# bad — plain Mock for an async dependency; await raises TypeError
+async def test_update_policy_premium(policy_repo: Mock, rate_service: Mock) -> None:
+    rate_service.fetch_base_rate.return_value = Decimal("100.00")  # not a coroutine
+    await update_policy_premium("p1", policy_repo, rate_service)   # TypeError on await
+```
+
+## Factory fixtures for variations
+
+A fixture that returns a fixed domain object forces tests that need a slightly different shape to either duplicate the construction inline or build their own fixture. A factory fixture — one that returns a callable — lets callers pass only the fields relevant to their case and keeps all default values in one place.
+
+```python
+import pytest
+
+# good — factory fixture; callers override only what they care about
+@pytest.fixture
+def make_policy() -> Callable[..., Policy]:
+    def _make(**overrides: Any) -> Policy:
+        defaults = Policy(
+            id="p1",
+            vehicle_class=VehicleClass.MOTOR,
+            inception_date=date(2026, 1, 1),
+            status="active",
+        )
+        return defaults.model_copy(update=overrides)
+    return _make
+
+def test_commercial_vehicle_rate(make_policy: Callable[..., Policy]) -> None:
+    policy = make_policy(vehicle_class=VehicleClass.COMMERCIAL)
+    assert calculate_base_rate(policy) > Decimal("0")
+
+# bad — duplicated construction in every test that needs a variant
+def test_commercial_vehicle_rate() -> None:
+    policy = Policy(
+        id="p1",
+        vehicle_class=VehicleClass.COMMERCIAL,
+        inception_date=date(2026, 1, 1),
+        status="active",
+    )
+    assert calculate_base_rate(policy) > Decimal("0")
+```
+
+## 95% coverage via pyproject.toml
+
+A hard coverage floor prevents debt from accumulating silently. `fail_under = 95` in `pyproject.toml` applies to the whole codebase; diff-cover tightens the bar on newly written code so a PR cannot introduce untested lines even when the overall project is below 95%.
+
+```toml
+# pyproject.toml
+[tool.coverage.run]
+source = ["src"]
+omit = [
+    "src/myapp/main.py",       # entrypoint wiring only; no testable logic
+]
+
+[tool.coverage.report]
+fail_under = 95
+```
+
+Run diff-cover in CI after the standard coverage report:
+
+```bash
+# good — CI step; fails if new lines in the PR are below threshold
+coverage run -m pytest
+coverage xml
+diff-cover coverage.xml --compare-branch=origin/main --fail-under=95
+```
+
+## No inline coverage exclusions
+
+`# pragma: no cover` at the line or block level is invisible in code review and tends to spread — once one file uses it, the pattern repeats. Centralising omissions in `pyproject.toml` makes the full list of excluded files visible in one place and forces a deliberate decision about each one.
+
+The only files that belong in the omit list are pure startup wiring: entrypoints that call `uvicorn.run()`, signal handler registrations, `if __name__ == "__main__"` blocks. Any logic inside those files should be extracted into a testable function before the file is omitted.
+
+```python
+# bad — inline exclusion; invisible to reviewers scanning pyproject.toml
+def _register_signal_handlers() -> None:  # pragma: no cover
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+```
+
+```toml
+# good — omit at the config level, after extracting all testable logic
+[tool.coverage.run]
+omit = [
+    "src/myapp/main.py",  # entrypoint only: uvicorn.run() call and signal registration
+]
+```
+
+## No time.sleep() in async tests
+
+`time.sleep()` is a blocking call. Inside an async test it suspends the OS thread, blocking the event loop for the full duration. This can cause other coroutines to time out, makes the test suite slower than necessary, and may mask race conditions that only appear with real async scheduling.
+
+Use `asyncio.sleep()` to yield control back to the event loop, or mock the time source entirely when the test is checking timing logic.
+
+```python
+# good — yield to the event loop; other coroutines can run
+async def test_retry_backs_off() -> None:
+    with patch("myapp.client.asyncio.sleep") as mock_sleep:
+        await client.fetch_with_retry("p1")
+    mock_sleep.assert_awaited_once_with(1.0)
+
+# bad — blocks the event loop for one second
+async def test_retry_backs_off() -> None:
+    await client.fetch_with_retry("p1")
+    time.sleep(1)  # blocks the event loop
+    assert client.call_count == 2
+```
+
+## LocalStack for AWS integration tests
+
+LocalStack runs a local AWS emulator that accepts real boto3 API calls, validates parameters, and persists data in memory — a test that passes against LocalStack gives meaningful evidence that the production AWS interaction will work. Inject boto3/aioboto3 clients with `endpoint_url="http://localhost:4566"` so the same client code runs in tests and production.
+
+```python
+import boto3
+import pytest
+
+# good — real boto3 client pointed at LocalStack; exercises real API calls and validation
+@pytest.fixture
+def s3_client():
+    return boto3.client(
+        "s3",
+        endpoint_url="http://localhost:4566",
+        region_name="eu-west-1",
+        aws_access_key_id="test",      # dummy credentials — valid for LocalStack only; never use outside test fixtures
+        aws_secret_access_key="test",  # dummy credentials — valid for LocalStack only; never use outside test fixtures
+    )
+
+async def test_policy_saved_to_s3(s3_client) -> None:
+    s3_client.create_bucket(
+        Bucket="policies",
+        CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+    )
+    repo = S3PolicyRepository(bucket="policies", client=s3_client)
+    await repo.save(Policy(id="p1", status="active"))
+    obj = s3_client.get_object(Bucket="policies", Key="p1.json")
+    assert json.loads(obj["Body"].read())["status"] == "active"
+```
+
+```yaml
+# docker-compose.yml — pin to 4.14; versions after 4.14 require mandatory account registration
+services:
+  localstack:
+    image: localstack/localstack:4.14
+    ports:
+      - "4566:4566"
+```
+
+## No boto3 mocks
+
+A hand-rolled boto3 mock patches the call site (`client.put_object`, `client.put_item`) and asserts on exact arguments. If the implementation switches from `put_object` to `upload_file` the test breaks even though the behaviour is unchanged — and it accepts parameters the real AWS API would reject, so tests pass on code that would fail in production.
+
+`AsyncMock` is appropriate only at a `Protocol` boundary: when the component under test depends on an abstraction (a publisher protocol, an event emitter) and the test is verifying call dispatch, not that data was actually written to AWS. Do not use `AsyncMock` to stand in for a real DynamoDB table, S3 bucket, or Kinesis stream.
+
+```python
+# good — AsyncMock at a Protocol boundary; tests that the right event is dispatched
+async def test_event_published_on_save(mock_publisher: AsyncMock) -> None:
+    service = PolicyService(publisher=mock_publisher)
+    await service.save(Policy(id="p1", status="active"))
+    mock_publisher.publish.assert_awaited_once_with(PolicySavedEvent(policy_id="p1"))
+
+# bad — hand-rolled mock; couples test to put_object call signature
+def test_policy_saved_to_s3(mock_s3_client: Mock) -> None:
+    repo = S3PolicyRepository(client=mock_s3_client)
+    repo.save(Policy(id="p1", status="active"))
+    mock_s3_client.put_object.assert_called_once_with(
+        Bucket="policies", Key="p1.json", Body=ANY  # breaks if impl switches to upload_file
+    )
+```
+
+## Pydantic BaseSettings as config entry point
+
+`docs/ai/steering/base/environment.md` requires a single config entry point for all environment variable reads. In Python, this is a Pydantic `BaseSettings` class. All environment variables must be read through this class — never call `os.getenv()` or `os.environ[]` outside it, because scattered reads are invisible to the type system, bypass validation, and cannot be discovered by reading one file.
+
+The config model should be instantiated once in the composition root and injected into components that need it. Do not instantiate `BaseSettings` per-request — each instantiation re-reads the environment and re-validates.
+
+```python
+# good — single config model, instantiated once
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Configuration(BaseSettings):
+    model_config = SettingsConfigDict(env_nested_delimiter="__")
+
+    port: int = 8080
+    log_level: str = "INFO"
+    dynamo: DynamoConfiguration
+    pm: PMConfiguration
+
+config = Configuration()  # once, in the composition root
+
+# bad — os.getenv scattered in business logic
+def get_score(customer_id: str) -> float:
+    table_name = os.getenv("DYNAMO_TABLE_NAME")  # untyped, unvalidated, invisible
+    ...
+```
+
+```python
+# bad — re-instantiating BaseSettings per request
+def handle_request(request):
+    config = Configuration()  # re-reads env and re-validates on every call
+    ...
+```
+
+## Nested config groups with `env_nested_delimiter`
+
+A flat config class with thirty fields forces the reader to scan every field to find the one they need. Grouping related fields into nested `BaseModel` classes creates a table of contents: `dynamo.*` for DynamoDB settings, `pm.*` for policy management, `kafka.*` for event streaming.
+
+The `env_nested_delimiter="__"` setting maps `DYNAMO__TABLE_NAME` to `Configuration.dynamo.table_name`. Use double underscores consistently in env files and GitOps values.
+
+```python
+# good — grouped by concern
+class DynamoConfiguration(BaseModel):
+    region: str = "eu-west-1"
+    table_name: str
+
+class PMConfiguration(BaseModel):
+    base_url: str
+    timeout_seconds: int = 30
+
+class Configuration(BaseSettings):
+    model_config = SettingsConfigDict(env_nested_delimiter="__")
+
+    dynamo: DynamoConfiguration
+    pm: PMConfiguration
+    log_level: str = "INFO"
+
+# bad — flat; unreadable at scale and no logical grouping
+class Configuration(BaseSettings):
+    dynamo_region: str
+    dynamo_table_name: str
+    pm_base_url: str
+    pm_timeout_seconds: int
+    log_level: str
+```
+
+## `secrets_dir` for filesystem-mounted secrets
+
+Secrets provisioned via `secrets-config` are mounted at `/mnt/<service-name>` by the Blueprint infrastructure. Pydantic `BaseSettings` supports reading these natively via `secrets_dir`. Set it to the mount path and Pydantic will read files whose names match field names.
+
+```python
+# good — secrets read from mounted filesystem
+class Configuration(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_nested_delimiter="__",
+        secrets_dir="/mnt/score-per-product",
+    )
+
+    db_password: str          # read from /mnt/score-per-product/db_password
+    api_key: str              # read from /mnt/score-per-product/api_key
+    port: int = 8080          # read from env var, not a secret
+
+# bad — secrets passed as environment variables
+class Configuration(BaseSettings):
+    db_password: str          # DB_PASSWORD in the env; visible in pod spec and process listing
+```
+
+## Env file loading with `SettingsConfigDict`
+
+`docs/ai/steering/base/environment.md` requires committed development/CI config files plus a gitignored personal override. In Python, configure Pydantic to load `.env.development` as the base and `.env` as the override — later entries in the tuple take precedence:
+
+```python
+class Configuration(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_nested_delimiter="__",
+        env_file=(".env.development", ".env"),  # .env overrides .env.development
+    )
+```
+
+This is not the only valid approach. Some services (e.g. zego-credit) handle env file switching at the docker-compose level and use `zego.core.configuration.load` rather than `BaseSettings` directly — that works just as well provided the env file layout and gitignore rules from `docs/ai/steering/base/environment.md` are followed.
+
+## pytest-dotenv for test configuration
+
+Configure `pytest-dotenv` to load `.env.development` for tests so that test runs pick up the same safe defaults as local development without requiring manual env setup:
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+env_files = ".env.development"
+```
+
+## See Also
+
+- [../base/logging.md](../base/logging.md) — logging conventions: levels, structured log calls, PII rules, and Zego common keys.
+- [../base/observability.md](../base/observability.md) — metrics and distributed tracing conventions.
+- [../base/testing.md](../base/testing.md) — testing principles and structure: test types, naming, assertion style, and what belongs in each layer.
+- [../base/environment.md](../base/environment.md) — language-agnostic environment variable conventions: single config entry point, GitOps sequencing, secrets-config provisioning.


### PR DESCRIPTION
## Background

Rolls the Zego AI Standards library into this repo (a reusable Terraform module exposing AWS VPC metadata) for the M2 AI-loop mandate — part of the `orchestration` domain rollout (SYSENG-3093).

## Changes

- Fan in Zego AI Standards **v1.1.0**; `.github/` insert-only (PR template added).
- `ci-test-command: terraform fmt -check -recursive`; `terraform-safety` hook (upstreaming: Zegocover/zego-ai-standards#193).
- Curated `CLAUDE.local.md` (reusable TF module; environment.md out-of-scope).

**Note:** this repo's default branch is `master`, so this PR targets `master`.

## Testing

- settings.json valid JSON; hooks executable + bash -n clean; all steering refs resolve.

## Jira Ticket/s

- https://zegons.atlassian.net/browse/SYSENG-3093